### PR TITLE
feat: Dev setup improvements, update assets

### DIFF
--- a/.claude/commands/add-new-provider.md
+++ b/.claude/commands/add-new-provider.md
@@ -1,0 +1,21 @@
+Add a new AI provider "$ARGUMENTS" to the OpenUsage TUI dashboard.
+
+Read and follow the full skill specification in docs/skills/add-new-provider.md.
+
+Follow all phases in order:
+
+1. **Phase 0 — Quiz**: Ask me all 10 questions from the skill doc before writing any code. If I provided the provider name as "$ARGUMENTS", use that as the starting point but still confirm the details. Research the provider's API docs yourself if I don't know an answer.
+
+2. **Phase 1 — Research**: Study the provider's API documentation. Summarize findings before coding.
+
+3. **Phase 2 — Create provider package**: Implement the provider in `internal/providers/<id>/` following the patterns and conventions documented in the skill.
+
+4. **Phase 3 — Dashboard widget**: Configure a beautiful dashboard tile with appropriate gauges, compact rows, and color role.
+
+5. **Phase 4 — Register**: Add to `registry.go`, `detect.go`, and `example_settings.json`.
+
+6. **Phase 5 — Tests**: Write at least 3 tests (success, auth-required, rate-limited) using `httptest.NewServer`.
+
+7. **Phase 6 — Verify**: Run `go build`, `go test`, and `make vet`.
+
+Complete the full checklist at the end of the skill doc before finishing.

--- a/.claude/commands/design-feature.md
+++ b/.claude/commands/design-feature.md
@@ -1,0 +1,15 @@
+Design a new feature "$ARGUMENTS" for the OpenUsage TUI dashboard.
+
+Read and follow the full skill specification in docs/skills/design-feature/SKILL.md.
+
+Follow all phases in order:
+
+1. **Phase 0 — Quiz**: Ask me all 8 questions from the skill doc before doing any design work. If I provided the feature name as "$ARGUMENTS", use that as the starting point but still confirm details. Research the codebase yourself if I don't know an answer.
+
+2. **Phase 1 — Explore**: Read the subsystem map in docs/skills/design-feature/references/subsystem-map.md, then read the primary files for every affected subsystem. Read any overlapping design docs in docs/. Summarize what you learned that affects the design.
+
+3. **Phase 2 — Design**: Write the design doc to docs/<FEATURE_NAME>_DESIGN.md following the template in docs/skills/design-feature/references/design-template.md. Keep it simple — no unnecessary abstractions.
+
+4. **Phase 3 — Tasks**: Break the design into concrete, ordered implementation tasks with specific files and tests. Append to the design doc.
+
+Complete the full checklist at the end of the skill doc before finishing.

--- a/.claude/commands/dev-workflow-improvements.md
+++ b/.claude/commands/dev-workflow-improvements.md
@@ -1,0 +1,15 @@
+Audit and improve the development workflow for OpenUsage.
+
+Read and follow the full skill specification in docs/skills/dev-workflow-improvements/SKILL.md.
+
+This skill ensures the development flow is complete, consistent, and propagated to all AI tools.
+
+Follow all phases:
+
+1. **Phase 0 — Audit**: Run `make sync-tools`, check for drift. Validate all skills are registered in skills-table.md, have Claude commands, OpenCode stubs. Check for broken references.
+
+2. **Phase 1 — Fix**: Fix any issues found: sync drift, missing registrations, broken references, CLAUDE.md mismatches.
+
+3. **Phase 2 — Improve**: If improvements requested, quiz the user about what needs changing. Add/update skills, onboard new tools, fix workflow gaps. Run sync after each change.
+
+4. **Phase 3 — Verify**: Run sync (should be clean), build, test, show git diff for review.

--- a/.claude/commands/develop-feature.md
+++ b/.claude/commands/develop-feature.md
@@ -1,0 +1,23 @@
+Develop the feature "$ARGUMENTS" end-to-end — from design to pull request.
+
+Read and follow the full skill specification in docs/skills/develop-feature/SKILL.md.
+
+This skill orchestrates the full development lifecycle:
+
+1. **Phase 0 — Intake**: Check for existing design doc. Ask: full lifecycle or specific phase?
+
+2. **Phase 1 — Design** (`/design-feature`): Design the feature, produce design doc with tasks.
+
+3. **Phase 2 — Review** (`/review-design`): Validate design against codebase, fix discrepancies.
+
+4. **Phase 3 — Implement** (`/implement-feature`): Execute tasks with tests, parallel where possible.
+
+5. **Phase 4 — Validate** (`/validate-feature`): Build, test, design compliance, code quality checks.
+
+6. **Phase 5 — Iterate** (`/iterate-feature`): Fix issues from validation (loops until clean or user decides).
+
+7. **Phase 6 — Finalize** (`/finalize-feature`): Create branch, commit, open PR.
+
+8. **Phase 7 — Summary**: Report full lifecycle results.
+
+Each phase pauses for user confirmation before proceeding to the next.

--- a/.claude/commands/finalize-feature.md
+++ b/.claude/commands/finalize-feature.md
@@ -1,0 +1,15 @@
+Finalize the feature "$ARGUMENTS" — create branch, commit, and open PR.
+
+Read and follow the full skill specification in docs/skills/finalize-feature/SKILL.md.
+
+Follow all phases in order:
+
+1. **Phase 0 — Pre-flight Checks**: Verify build, vet, tests pass. Scan for secrets and debug code. Block if issues found.
+
+2. **Phase 1 — Branch**: Create feature branch with proper naming convention. Confirm with user.
+
+3. **Phase 2 — Commit**: Stage specific files, draft conventional commit message, present for approval, commit.
+
+4. **Phase 3 — Push & PR**: Push to remote, draft PR with summary/changes/test plan from design doc, create via `gh pr create`.
+
+5. **Phase 4 — Final Checklist**: Report branch, commit, PR URL, and next steps.

--- a/.claude/commands/finalize-feature.md
+++ b/.claude/commands/finalize-feature.md
@@ -2,14 +2,10 @@ Finalize the feature "$ARGUMENTS" — create branch, commit, and open PR.
 
 Read and follow the full skill specification in docs/skills/finalize-feature/SKILL.md.
 
-Follow all phases in order:
+Follow all phases:
 
-1. **Phase 0 — Pre-flight Checks**: Verify build, vet, tests pass. Scan for secrets and debug code. Block if issues found.
-
-2. **Phase 1 — Branch**: Create feature branch with proper naming convention. Confirm with user.
-
-3. **Phase 2 — Commit**: Stage specific files, draft conventional commit message, present for approval, commit.
-
-4. **Phase 3 — Push & PR**: Push to remote, draft PR with summary/changes/test plan from design doc, create via `gh pr create`.
-
-5. **Phase 4 — Final Checklist**: Report branch, commit, PR URL, and next steps.
+1. **Phase 0 — Pre-flight**: Build, vet, tests pass. Check for secrets.
+2. **Phase 1 — Branch**: Create feature branch.
+3. **Phase 2 — Commit**: Draft message, show to user, stage specific files, commit.
+4. **Phase 3 — PR**: Push and create PR via `gh pr create`.
+5. **Phase 4 — Checklist**: Report branch, commit, PR URL.

--- a/.claude/commands/implement-feature.md
+++ b/.claude/commands/implement-feature.md
@@ -1,0 +1,21 @@
+Implement the feature "$ARGUMENTS" from its design doc.
+
+Read and follow the full skill specification in docs/skills/implement-feature/SKILL.md.
+
+Follow all phases in order:
+
+1. **Phase 0 — Load Design**: Find the design doc for "$ARGUMENTS" in `docs/`. Extract the problem statement, affected subsystems, and implementation tasks. Confirm with me which tasks to implement.
+
+2. **Phase 1 — Codebase Analysis**: Read the subsystem map in docs/skills/design-feature/references/subsystem-map.md. Read every file listed in the implementation tasks. Note current state and any conflicts with the design.
+
+3. **Phase 1.5 — Pre-Implementation Quiz**: Surface ambiguities between the design doc and the actual codebase. Present questions about unclear integration points, multiple valid approaches, or missing details. Update the design doc with my answers.
+
+4. **Phase 2 — Execution Plan**: Present the ordered task plan with approaches, risks, and parallelization analysis (which tasks can run concurrently). Wait for my approval before coding.
+
+5. **Phase 3 — Implement**: Execute tasks in dependency order. Use parallel agents for independent task groups when there are 3+ tasks that don't depend on each other. For each task: write code, write tests, run diagnostics, run package tests. After each parallel group, run integration verification. Fix issues before moving on. Flag any design deviations.
+
+6. **Phase 4 — Integration Check**: After all tasks, run `make build`, test changed packages with `-race`, and lint/vet.
+
+7. **Phase 5 — Summary**: Report all changes, tests added, design doc updates, and any notes.
+
+Use the per-task checklist in docs/skills/implement-feature/references/execution-checklist.md for every task.

--- a/.claude/commands/implement-feature.md
+++ b/.claude/commands/implement-feature.md
@@ -4,18 +4,10 @@ Read and follow the full skill specification in docs/skills/implement-feature/SK
 
 Follow all phases in order:
 
-1. **Phase 0 — Load Design**: Find the design doc for "$ARGUMENTS" in `docs/`. Extract the problem statement, affected subsystems, and implementation tasks. Confirm with me which tasks to implement.
-
-2. **Phase 1 — Codebase Analysis**: Read the subsystem map in docs/skills/design-feature/references/subsystem-map.md. Read every file listed in the implementation tasks. Note current state and any conflicts with the design.
-
-3. **Phase 1.5 — Pre-Implementation Quiz**: Surface ambiguities between the design doc and the actual codebase. Present questions about unclear integration points, multiple valid approaches, or missing details. Update the design doc with my answers.
-
-4. **Phase 2 — Execution Plan**: Present the ordered task plan with approaches, risks, and parallelization analysis (which tasks can run concurrently). Wait for my approval before coding.
-
-5. **Phase 3 — Implement**: Execute tasks in dependency order. Use parallel agents for independent task groups when there are 3+ tasks that don't depend on each other. For each task: write code, write tests, run diagnostics, run package tests. After each parallel group, run integration verification. Fix issues before moving on. Flag any design deviations.
-
-6. **Phase 4 — Integration Check**: After all tasks, run `make build`, test changed packages with `-race`, and lint/vet.
-
-7. **Phase 5 — Summary**: Report all changes, tests added, design doc updates, and any notes.
-
-Use the per-task checklist in docs/skills/implement-feature/references/execution-checklist.md for every task.
+1. **Phase 0 — Load**: Read the design doc, extract tasks and scope.
+2. **Phase 1 — Codebase Analysis**: Read affected files, note patterns.
+3. **Phase 1.5 — Pre-Implementation Quiz**: Surface ambiguities.
+4. **Phase 2 — Execution Plan**: Present tasks with approaches and risks.
+5. **Phase 3 — Implement**: Execute tasks in dependency order with tests.
+6. **Phase 4 — Integration Check**: Build, test, verify.
+7. **Phase 5 — Summary**: Report changes and status.

--- a/.claude/commands/iterate-feature.md
+++ b/.claude/commands/iterate-feature.md
@@ -2,16 +2,11 @@ Iterate on the feature "$ARGUMENTS" to fix issues and address feedback.
 
 Read and follow the full skill specification in docs/skills/iterate-feature/SKILL.md.
 
-Follow all phases in order:
+Follow all phases:
 
-1. **Phase 0 — Load Context**: Find the design doc for "$ARGUMENTS". Gather feedback sources (validation report, PR comments, user feedback). Read changed files.
-
-2. **Phase 1 — Triage**: Categorize all issues by priority (P0 Bug → P3 Polish). Present list and confirm scope.
-
-3. **Phase 2 — Plan Iterations**: Plan each fix with files, approach, risk. Identify parallel fixes. Wait for approval.
-
-4. **Phase 3 — Execute Iterations**: Fix each issue: read → fix → test → diagnose → verify. Report per-fix status. Flag regressions or design changes.
-
-5. **Phase 4 — Re-validate**: Run build, tests, vet. Confirm design compliance. Loop back if failures found.
-
-6. **Phase 5 — Iteration Summary**: Report all changes, design doc updates, re-validation results, and verdict.
+1. **Phase 0 — Load**: Find design doc, gather feedback.
+2. **Phase 1 — Triage**: Categorize issues by priority.
+3. **Phase 2 — Plan**: Identify files and approach for each fix.
+4. **Phase 3 — Execute**: Fix, test, verify each issue.
+5. **Phase 4 — Re-validate**: Build, test, check compliance.
+6. **Phase 5 — Summary**: Report fixes and verdict.

--- a/.claude/commands/iterate-feature.md
+++ b/.claude/commands/iterate-feature.md
@@ -1,0 +1,17 @@
+Iterate on the feature "$ARGUMENTS" to fix issues and address feedback.
+
+Read and follow the full skill specification in docs/skills/iterate-feature/SKILL.md.
+
+Follow all phases in order:
+
+1. **Phase 0 — Load Context**: Find the design doc for "$ARGUMENTS". Gather feedback sources (validation report, PR comments, user feedback). Read changed files.
+
+2. **Phase 1 — Triage**: Categorize all issues by priority (P0 Bug → P3 Polish). Present list and confirm scope.
+
+3. **Phase 2 — Plan Iterations**: Plan each fix with files, approach, risk. Identify parallel fixes. Wait for approval.
+
+4. **Phase 3 — Execute Iterations**: Fix each issue: read → fix → test → diagnose → verify. Report per-fix status. Flag regressions or design changes.
+
+5. **Phase 4 — Re-validate**: Run build, tests, vet. Confirm design compliance. Loop back if failures found.
+
+6. **Phase 5 — Iteration Summary**: Report all changes, design doc updates, re-validation results, and verdict.

--- a/.claude/commands/openusage-provider.md
+++ b/.claude/commands/openusage-provider.md
@@ -1,0 +1,3 @@
+Run the openusage-provider skill
+
+Read and follow the full skill specification in docs/skills/openusage-provider/SKILL.md.

--- a/.claude/commands/review-design.md
+++ b/.claude/commands/review-design.md
@@ -2,14 +2,9 @@ Review the design doc for "$ARGUMENTS" against the current codebase.
 
 Read and follow the full skill specification in docs/skills/review-design/SKILL.md.
 
-Follow all phases in order:
+Follow all phases:
 
-1. **Phase 0 — Load Design**: Find the design doc for "$ARGUMENTS" in `docs/`. Read it fully. Extract the problem statement, affected subsystems, type definitions, and implementation tasks. Confirm with me which doc to review.
-
-2. **Phase 1 — Codebase Audit**: Read the subsystem map in docs/skills/design-feature/references/subsystem-map.md. Read every file referenced in the design doc's implementation tasks. Use the checklist in docs/skills/review-design/references/review-checklist.md to find discrepancies.
-
-3. **Phase 2 — Quiz Loop**: Present each discrepancy as a question with severity and resolution options. Wait for my answer. Apply the resolution (edit the design doc or note as intentional). Re-scan after edits. **Repeat until no issues remain.**
-
-4. **Phase 3 — Final Verification**: Re-read the design doc, verify all tasks reference valid files/types, confirm dependency order, and report the summary.
-
-Do not auto-fix anything — always ask me first.
+1. **Phase 0 — Load**: Find and read the design doc.
+2. **Phase 1 — Audit**: Read primary files for each subsystem, build discrepancy list.
+3. **Phase 2 — Quiz Loop**: Present issues, apply resolutions, re-scan until clean.
+4. **Phase 3 — Verify**: Confirm tasks reference valid files and types.

--- a/.claude/commands/review-design.md
+++ b/.claude/commands/review-design.md
@@ -1,0 +1,15 @@
+Review the design doc for "$ARGUMENTS" against the current codebase.
+
+Read and follow the full skill specification in docs/skills/review-design/SKILL.md.
+
+Follow all phases in order:
+
+1. **Phase 0 — Load Design**: Find the design doc for "$ARGUMENTS" in `docs/`. Read it fully. Extract the problem statement, affected subsystems, type definitions, and implementation tasks. Confirm with me which doc to review.
+
+2. **Phase 1 — Codebase Audit**: Read the subsystem map in docs/skills/design-feature/references/subsystem-map.md. Read every file referenced in the design doc's implementation tasks. Use the checklist in docs/skills/review-design/references/review-checklist.md to find discrepancies.
+
+3. **Phase 2 — Quiz Loop**: Present each discrepancy as a question with severity and resolution options. Wait for my answer. Apply the resolution (edit the design doc or note as intentional). Re-scan after edits. **Repeat until no issues remain.**
+
+4. **Phase 3 — Final Verification**: Re-read the design doc, verify all tasks reference valid files/types, confirm dependency order, and report the summary.
+
+Do not auto-fix anything — always ask me first.

--- a/.claude/commands/validate-feature.md
+++ b/.claude/commands/validate-feature.md
@@ -1,0 +1,19 @@
+Validate the feature "$ARGUMENTS" implementation.
+
+Read and follow the full skill specification in docs/skills/validate-feature/SKILL.md.
+
+Follow all phases in order:
+
+1. **Phase 0 — Load Context**: Find the design doc for "$ARGUMENTS" in `docs/`. Extract tasks, files, and test requirements. Get list of changed files.
+
+2. **Phase 1 — Build Verification**: Run make build, vet, fmt, lint. All must pass.
+
+3. **Phase 2 — Test Verification**: Run tests for all changed packages with -race. Check coverage. Flag missing tests.
+
+4. **Phase 3 — Design Compliance**: Cross-reference design tasks against actual changes. Build compliance matrix.
+
+5. **Phase 4 — Code Quality Scan**: Check for debug artifacts, unused code, error handling, import hygiene, secrets.
+
+6. **Phase 5 — Integration Smoke Test**: Final build, demo run, combined test run.
+
+7. **Phase 6 — Validation Report**: Produce summary with verdict: READY FOR REVIEW or NEEDS ITERATION.

--- a/.claude/commands/validate-feature.md
+++ b/.claude/commands/validate-feature.md
@@ -2,18 +2,12 @@ Validate the feature "$ARGUMENTS" implementation.
 
 Read and follow the full skill specification in docs/skills/validate-feature/SKILL.md.
 
-Follow all phases in order:
+Follow all phases:
 
-1. **Phase 0 — Load Context**: Find the design doc for "$ARGUMENTS" in `docs/`. Extract tasks, files, and test requirements. Get list of changed files.
-
-2. **Phase 1 — Build Verification**: Run make build, vet, fmt, lint. All must pass.
-
-3. **Phase 2 — Test Verification**: Run tests for all changed packages with -race. Check coverage. Flag missing tests.
-
-4. **Phase 3 — Design Compliance**: Cross-reference design tasks against actual changes. Build compliance matrix.
-
-5. **Phase 4 — Code Quality Scan**: Check for debug artifacts, unused code, error handling, import hygiene, secrets.
-
-6. **Phase 5 — Integration Smoke Test**: Final build, demo run, combined test run.
-
-7. **Phase 6 — Validation Report**: Produce summary with verdict: READY FOR REVIEW or NEEDS ITERATION.
+1. **Phase 0 — Load**: Find design doc, extract tasks, get changed files.
+2. **Phase 1 — Build**: `make build`, `make vet`, `make fmt`, `make lint`.
+3. **Phase 2 — Tests**: Run tests for changed packages.
+4. **Phase 3 — Compliance**: Cross-reference design tasks vs actual changes.
+5. **Phase 4 — Quality**: Scan for debug artifacts, unused code, secrets.
+6. **Phase 5 — Smoke Test**: Final build and combined tests.
+7. **Phase 6 — Report**: Verdict: READY FOR REVIEW or NEEDS ITERATION.

--- a/.cursor/rules/add-new-provider.mdc
+++ b/.cursor/rules/add-new-provider.mdc
@@ -1,0 +1,20 @@
+---
+description: Add a new AI provider to OpenUsage. Invoke when the user asks to add, create, or implement a new provider (e.g. "add z.ai provider").
+globs:
+alwaysApply: false
+---
+
+@docs/skills/add-new-provider.md contains the full skill specification. Read and follow it completely.
+
+The user's request is to add a new provider. The provider name may be part of their message.
+
+Follow all phases in order:
+1. Phase 0: Quiz the user for required information
+2. Phase 1: Research the provider's API
+3. Phase 2: Create the provider package
+4. Phase 3: Configure the dashboard widget
+5. Phase 4: Register the provider and add auto-detection
+6. Phase 5: Write tests
+7. Phase 6: Verify with build + test + vet
+
+Do NOT skip the quiz phase. Do NOT proceed without all answers.

--- a/.cursor/rules/design-feature.mdc
+++ b/.cursor/rules/design-feature.mdc
@@ -1,0 +1,17 @@
+---
+description: Design a new feature for OpenUsage. Invoke when the user asks to design a feature, create a design doc, or plan a new capability.
+globs:
+alwaysApply: false
+---
+
+@docs/skills/design-feature/SKILL.md contains the full skill specification. Read and follow it completely.
+
+The user's request is to design the feature "$ARGUMENTS".
+
+Follow all phases in order:
+1. Phase 0: Quiz the user for requirements (8 questions)
+2. Phase 1: Explore the codebase using the subsystem map
+3. Phase 2: Write the design doc to docs/
+4. Phase 3: Break into concrete implementation tasks
+
+Do NOT skip the quiz phase. Do NOT start designing without all answers.

--- a/.cursor/rules/develop-feature.mdc
+++ b/.cursor/rules/develop-feature.mdc
@@ -1,0 +1,21 @@
+---
+description: Develop a feature end-to-end from design to PR. Invoke when the user asks to build, develop, or ship a complete feature.
+globs:
+alwaysApply: false
+---
+
+@docs/skills/develop-feature/SKILL.md contains the full skill specification. Read and follow it completely.
+
+The user's request is to develop the feature "$ARGUMENTS" through the full lifecycle.
+
+This orchestrates all phases:
+1. Phase 0: Intake — check for existing design doc, confirm scope
+2. Phase 1: Design (design-feature skill)
+3. Phase 2: Review (review-design skill)
+4. Phase 3: Implement (implement-feature skill)
+5. Phase 4: Validate (validate-feature skill)
+6. Phase 5: Iterate (iterate-feature skill)
+7. Phase 6: Finalize (finalize-feature skill)
+8. Phase 7: Summary
+
+Pause for user confirmation between each phase.

--- a/.cursor/rules/finalize-feature.mdc
+++ b/.cursor/rules/finalize-feature.mdc
@@ -1,0 +1,16 @@
+---
+description: Finalize a feature — create branch, commit, and open PR. Invoke when the user asks to finalize, ship, commit, or create a PR for a feature.
+globs:
+alwaysApply: false
+---
+
+@docs/skills/finalize-feature/SKILL.md contains the full skill specification. Read and follow it completely.
+
+The user's request is to finalize the feature "$ARGUMENTS".
+
+Follow all phases in order:
+1. Phase 0: Pre-flight checks (build, vet, tests, scan for secrets)
+2. Phase 1: Create feature branch
+3. Phase 2: Stage and commit with conventional message
+4. Phase 3: Push and create PR via gh
+5. Phase 4: Final checklist with branch, commit, PR URL

--- a/.cursor/rules/implement-feature.mdc
+++ b/.cursor/rules/implement-feature.mdc
@@ -1,0 +1,20 @@
+---
+description: Implement a feature from its design doc. Invoke when the user asks to implement, code, or build a feature that already has a design doc.
+globs:
+alwaysApply: false
+---
+
+@docs/skills/implement-feature/SKILL.md contains the full skill specification. Read and follow it completely.
+
+The user's request is to implement the feature "$ARGUMENTS" from its design doc.
+
+Follow all phases in order:
+1. Phase 0: Load the design doc, extract tasks
+2. Phase 1: Analyze the codebase for affected files
+3. Phase 1.5: Pre-implementation quiz for ambiguities
+4. Phase 2: Present execution plan, wait for approval
+5. Phase 3: Execute tasks with tests, parallel where possible
+6. Phase 4: Integration check (build, test, lint)
+7. Phase 5: Summary of all changes
+
+Do NOT skip loading the design doc. Do NOT code without an approved plan.

--- a/.cursor/rules/iterate-feature.mdc
+++ b/.cursor/rules/iterate-feature.mdc
@@ -1,0 +1,17 @@
+---
+description: Iterate on a feature to fix issues and address feedback. Invoke when the user asks to fix, iterate, or address review feedback.
+globs:
+alwaysApply: false
+---
+
+@docs/skills/iterate-feature/SKILL.md contains the full skill specification. Read and follow it completely.
+
+The user's request is to iterate on the feature "$ARGUMENTS".
+
+Follow all phases in order:
+1. Phase 0: Load context — design doc, feedback sources, changed files
+2. Phase 1: Triage issues by priority (P0–P3)
+3. Phase 2: Plan iterations with approach and risk
+4. Phase 3: Execute fixes with per-fix verification
+5. Phase 4: Re-validate (build, tests, design compliance)
+6. Phase 5: Iteration summary with verdict

--- a/.cursor/rules/review-design.mdc
+++ b/.cursor/rules/review-design.mdc
@@ -1,0 +1,17 @@
+---
+description: Review a design doc against the codebase. Invoke when the user asks to review, validate, or check a design doc.
+globs:
+alwaysApply: false
+---
+
+@docs/skills/review-design/SKILL.md contains the full skill specification. Read and follow it completely.
+
+The user's request is to review the design doc for "$ARGUMENTS".
+
+Follow all phases in order:
+1. Phase 0: Load the design doc, extract references
+2. Phase 1: Audit codebase against design using the review checklist
+3. Phase 2: Quiz loop — present discrepancies, get user decisions, repeat until clean
+4. Phase 3: Final verification of the updated design doc
+
+Do NOT auto-fix discrepancies. Always ask the user first.

--- a/.cursor/rules/validate-feature.mdc
+++ b/.cursor/rules/validate-feature.mdc
@@ -1,0 +1,18 @@
+---
+description: Validate a feature implementation. Invoke when the user asks to validate, verify, or check a feature before PR.
+globs:
+alwaysApply: false
+---
+
+@docs/skills/validate-feature/SKILL.md contains the full skill specification. Read and follow it completely.
+
+The user's request is to validate the feature "$ARGUMENTS".
+
+Follow all phases in order:
+1. Phase 0: Load context — design doc, changed files
+2. Phase 1: Build verification (build, vet, fmt, lint)
+3. Phase 2: Test verification (tests with -race, coverage)
+4. Phase 3: Design compliance matrix
+5. Phase 4: Code quality scan
+6. Phase 5: Integration smoke test
+7. Phase 6: Validation report with verdict

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ vendor/
 *.swp
 *.swo
 *~
-.claude/
-.opencode/
+#.claude/
+#.opencode/
 
 # OS
 .DS_Store

--- a/.opencode/skills/add-new-provider/SKILL.md
+++ b/.opencode/skills/add-new-provider/SKILL.md
@@ -1,0 +1,18 @@
+# Skill: Add New Provider
+
+> **Invocation**: When a user asks to add, create, or implement a new AI provider.
+
+Read and follow the full skill specification in `docs/skills/add-new-provider.md`.
+
+The user's request is to add a new provider. The provider name may be part of their message.
+
+Follow all phases in order:
+1. Phase 0: Quiz the user for required information
+2. Phase 1: Research the provider's API
+3. Phase 2: Create the provider package
+4. Phase 3: Configure the dashboard widget
+5. Phase 4: Register the provider and add auto-detection
+6. Phase 5: Write tests
+7. Phase 6: Verify with build + test + vet
+
+Do NOT skip the quiz phase. Do NOT proceed without all answers.

--- a/.opencode/skills/design-feature/SKILL.md
+++ b/.opencode/skills/design-feature/SKILL.md
@@ -1,15 +1,5 @@
 # Skill: Design Feature
 
-> **Invocation**: When a user asks to design a feature, create a design doc, or plan a new capability.
+> **Invocation**: Design a feature: quiz, explore codebase, write design doc with tasks
 
 Read and follow the full skill specification in `docs/skills/design-feature/SKILL.md`.
-
-The user's request is to design a feature. The feature name may be part of their message.
-
-Follow all phases in order:
-1. Phase 0: Quiz the user for requirements (8 questions)
-2. Phase 1: Explore the codebase using the subsystem map
-3. Phase 2: Write the design doc to docs/
-4. Phase 3: Break into concrete implementation tasks
-
-Do NOT skip the quiz phase. Do NOT start designing without all answers.

--- a/.opencode/skills/design-feature/SKILL.md
+++ b/.opencode/skills/design-feature/SKILL.md
@@ -1,0 +1,15 @@
+# Skill: Design Feature
+
+> **Invocation**: When a user asks to design a feature, create a design doc, or plan a new capability.
+
+Read and follow the full skill specification in `docs/skills/design-feature/SKILL.md`.
+
+The user's request is to design a feature. The feature name may be part of their message.
+
+Follow all phases in order:
+1. Phase 0: Quiz the user for requirements (8 questions)
+2. Phase 1: Explore the codebase using the subsystem map
+3. Phase 2: Write the design doc to docs/
+4. Phase 3: Break into concrete implementation tasks
+
+Do NOT skip the quiz phase. Do NOT start designing without all answers.

--- a/.opencode/skills/dev-workflow-improvements/SKILL.md
+++ b/.opencode/skills/dev-workflow-improvements/SKILL.md
@@ -1,0 +1,5 @@
+# Skill: Dev Workflow Improvements
+
+> **Invocation**: Audit and improve the development workflow, sync tool configs
+
+Read and follow the full skill specification in `docs/skills/dev-workflow-improvements/SKILL.md`.

--- a/.opencode/skills/develop-feature/SKILL.md
+++ b/.opencode/skills/develop-feature/SKILL.md
@@ -1,19 +1,5 @@
 # Skill: Develop Feature
 
-> **Invocation**: When a user asks to build, develop, or ship a complete feature end-to-end.
+> **Invocation**: Develop a feature end-to-end from design to pull request
 
 Read and follow the full skill specification in `docs/skills/develop-feature/SKILL.md`.
-
-The user's request is to develop a feature through the full lifecycle.
-
-This orchestrates all phases:
-1. Phase 0: Intake — check for existing design doc, confirm scope
-2. Phase 1: Design (design-feature skill)
-3. Phase 2: Review (review-design skill)
-4. Phase 3: Implement (implement-feature skill)
-5. Phase 4: Validate (validate-feature skill)
-6. Phase 5: Iterate (iterate-feature skill)
-7. Phase 6: Finalize (finalize-feature skill)
-8. Phase 7: Summary
-
-Pause for user confirmation between each phase.

--- a/.opencode/skills/develop-feature/SKILL.md
+++ b/.opencode/skills/develop-feature/SKILL.md
@@ -1,0 +1,19 @@
+# Skill: Develop Feature
+
+> **Invocation**: When a user asks to build, develop, or ship a complete feature end-to-end.
+
+Read and follow the full skill specification in `docs/skills/develop-feature/SKILL.md`.
+
+The user's request is to develop a feature through the full lifecycle.
+
+This orchestrates all phases:
+1. Phase 0: Intake — check for existing design doc, confirm scope
+2. Phase 1: Design (design-feature skill)
+3. Phase 2: Review (review-design skill)
+4. Phase 3: Implement (implement-feature skill)
+5. Phase 4: Validate (validate-feature skill)
+6. Phase 5: Iterate (iterate-feature skill)
+7. Phase 6: Finalize (finalize-feature skill)
+8. Phase 7: Summary
+
+Pause for user confirmation between each phase.

--- a/.opencode/skills/finalize-feature/SKILL.md
+++ b/.opencode/skills/finalize-feature/SKILL.md
@@ -1,0 +1,14 @@
+# Skill: Finalize Feature
+
+> **Invocation**: When a user asks to finalize, ship, commit, or create a PR for a feature.
+
+Read and follow the full skill specification in `docs/skills/finalize-feature/SKILL.md`.
+
+The user's request is to finalize a feature.
+
+Follow all phases in order:
+1. Phase 0: Pre-flight checks (build, vet, tests, scan for secrets)
+2. Phase 1: Create feature branch
+3. Phase 2: Stage and commit with conventional message
+4. Phase 3: Push and create PR via gh
+5. Phase 4: Final checklist with branch, commit, PR URL

--- a/.opencode/skills/finalize-feature/SKILL.md
+++ b/.opencode/skills/finalize-feature/SKILL.md
@@ -1,14 +1,5 @@
 # Skill: Finalize Feature
 
-> **Invocation**: When a user asks to finalize, ship, commit, or create a PR for a feature.
+> **Invocation**: Finalize a feature: create branch, commit, open PR
 
 Read and follow the full skill specification in `docs/skills/finalize-feature/SKILL.md`.
-
-The user's request is to finalize a feature.
-
-Follow all phases in order:
-1. Phase 0: Pre-flight checks (build, vet, tests, scan for secrets)
-2. Phase 1: Create feature branch
-3. Phase 2: Stage and commit with conventional message
-4. Phase 3: Push and create PR via gh
-5. Phase 4: Final checklist with branch, commit, PR URL

--- a/.opencode/skills/implement-feature/SKILL.md
+++ b/.opencode/skills/implement-feature/SKILL.md
@@ -1,18 +1,5 @@
 # Skill: Implement Feature
 
-> **Invocation**: When a user asks to implement, code, or build a feature that already has a design doc.
+> **Invocation**: Implement a feature from its design doc with tests
 
 Read and follow the full skill specification in `docs/skills/implement-feature/SKILL.md`.
-
-The user's request is to implement a feature from its design doc.
-
-Follow all phases in order:
-1. Phase 0: Load the design doc, extract tasks
-2. Phase 1: Analyze the codebase for affected files
-3. Phase 1.5: Pre-implementation quiz for ambiguities
-4. Phase 2: Present execution plan, wait for approval
-5. Phase 3: Execute tasks with tests, parallel where possible
-6. Phase 4: Integration check (build, test, lint)
-7. Phase 5: Summary of all changes
-
-Do NOT skip loading the design doc. Do NOT code without an approved plan.

--- a/.opencode/skills/implement-feature/SKILL.md
+++ b/.opencode/skills/implement-feature/SKILL.md
@@ -1,0 +1,18 @@
+# Skill: Implement Feature
+
+> **Invocation**: When a user asks to implement, code, or build a feature that already has a design doc.
+
+Read and follow the full skill specification in `docs/skills/implement-feature/SKILL.md`.
+
+The user's request is to implement a feature from its design doc.
+
+Follow all phases in order:
+1. Phase 0: Load the design doc, extract tasks
+2. Phase 1: Analyze the codebase for affected files
+3. Phase 1.5: Pre-implementation quiz for ambiguities
+4. Phase 2: Present execution plan, wait for approval
+5. Phase 3: Execute tasks with tests, parallel where possible
+6. Phase 4: Integration check (build, test, lint)
+7. Phase 5: Summary of all changes
+
+Do NOT skip loading the design doc. Do NOT code without an approved plan.

--- a/.opencode/skills/iterate-feature/SKILL.md
+++ b/.opencode/skills/iterate-feature/SKILL.md
@@ -1,15 +1,5 @@
 # Skill: Iterate Feature
 
-> **Invocation**: When a user asks to fix issues, iterate, or address review feedback on a feature.
+> **Invocation**: Iterate on a feature to fix issues and address feedback
 
 Read and follow the full skill specification in `docs/skills/iterate-feature/SKILL.md`.
-
-The user's request is to iterate on a feature.
-
-Follow all phases in order:
-1. Phase 0: Load context — design doc, feedback sources, changed files
-2. Phase 1: Triage issues by priority (P0–P3)
-3. Phase 2: Plan iterations with approach and risk
-4. Phase 3: Execute fixes with per-fix verification
-5. Phase 4: Re-validate (build, tests, design compliance)
-6. Phase 5: Iteration summary with verdict

--- a/.opencode/skills/iterate-feature/SKILL.md
+++ b/.opencode/skills/iterate-feature/SKILL.md
@@ -1,0 +1,15 @@
+# Skill: Iterate Feature
+
+> **Invocation**: When a user asks to fix issues, iterate, or address review feedback on a feature.
+
+Read and follow the full skill specification in `docs/skills/iterate-feature/SKILL.md`.
+
+The user's request is to iterate on a feature.
+
+Follow all phases in order:
+1. Phase 0: Load context — design doc, feedback sources, changed files
+2. Phase 1: Triage issues by priority (P0–P3)
+3. Phase 2: Plan iterations with approach and risk
+4. Phase 3: Execute fixes with per-fix verification
+5. Phase 4: Re-validate (build, tests, design compliance)
+6. Phase 5: Iteration summary with verdict

--- a/.opencode/skills/openusage-provider/SKILL.md
+++ b/.opencode/skills/openusage-provider/SKILL.md
@@ -1,0 +1,5 @@
+# Skill: Openusage Provider
+
+> **Invocation**: Run the openusage-provider skill
+
+Read and follow the full skill specification in `docs/skills/openusage-provider/SKILL.md`.

--- a/.opencode/skills/review-design/SKILL.md
+++ b/.opencode/skills/review-design/SKILL.md
@@ -1,0 +1,15 @@
+# Skill: Review Design
+
+> **Invocation**: When a user asks to review, validate, or check a design doc against the codebase.
+
+Read and follow the full skill specification in `docs/skills/review-design/SKILL.md`.
+
+The user's request is to review a design doc.
+
+Follow all phases in order:
+1. Phase 0: Load the design doc, extract references
+2. Phase 1: Audit codebase against design using the review checklist
+3. Phase 2: Quiz loop — present discrepancies, get user decisions, repeat until clean
+4. Phase 3: Final verification of the updated design doc
+
+Do NOT auto-fix discrepancies. Always ask the user first.

--- a/.opencode/skills/review-design/SKILL.md
+++ b/.opencode/skills/review-design/SKILL.md
@@ -1,15 +1,5 @@
 # Skill: Review Design
 
-> **Invocation**: When a user asks to review, validate, or check a design doc against the codebase.
+> **Invocation**: Review a design doc against the codebase
 
 Read and follow the full skill specification in `docs/skills/review-design/SKILL.md`.
-
-The user's request is to review a design doc.
-
-Follow all phases in order:
-1. Phase 0: Load the design doc, extract references
-2. Phase 1: Audit codebase against design using the review checklist
-3. Phase 2: Quiz loop — present discrepancies, get user decisions, repeat until clean
-4. Phase 3: Final verification of the updated design doc
-
-Do NOT auto-fix discrepancies. Always ask the user first.

--- a/.opencode/skills/validate-feature/SKILL.md
+++ b/.opencode/skills/validate-feature/SKILL.md
@@ -1,16 +1,5 @@
 # Skill: Validate Feature
 
-> **Invocation**: When a user asks to validate, verify, or check a feature implementation before PR.
+> **Invocation**: Validate a feature implementation: build, tests, compliance, quality
 
 Read and follow the full skill specification in `docs/skills/validate-feature/SKILL.md`.
-
-The user's request is to validate a feature implementation.
-
-Follow all phases in order:
-1. Phase 0: Load context — design doc, changed files
-2. Phase 1: Build verification (build, vet, fmt, lint)
-3. Phase 2: Test verification (tests with -race, coverage)
-4. Phase 3: Design compliance matrix
-5. Phase 4: Code quality scan
-6. Phase 5: Integration smoke test
-7. Phase 6: Validation report with verdict

--- a/.opencode/skills/validate-feature/SKILL.md
+++ b/.opencode/skills/validate-feature/SKILL.md
@@ -1,0 +1,16 @@
+# Skill: Validate Feature
+
+> **Invocation**: When a user asks to validate, verify, or check a feature implementation before PR.
+
+Read and follow the full skill specification in `docs/skills/validate-feature/SKILL.md`.
+
+The user's request is to validate a feature implementation.
+
+Follow all phases in order:
+1. Phase 0: Load context — design doc, changed files
+2. Phase 1: Build verification (build, vet, fmt, lint)
+3. Phase 2: Test verification (tests with -race, coverage)
+4. Phase 3: Design compliance matrix
+5. Phase 4: Code quality scan
+6. Phase 5: Integration smoke test
+7. Phase 6: Validation report with verdict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ make fmt            # go fmt ./...
 make vet            # go vet ./...
 make run            # go run cmd/openusage/main.go
 make demo           # build and run demo with dummy data (for screenshots)
+make sync-tools     # regenerate all AI tool configs from canonical template
 
 # Run a single test
 go test ./internal/providers/openai/ -run TestFetch -v
@@ -128,6 +129,12 @@ Use these directly when you need a specific phase, or let `/develop-feature` cha
 | `/iterate-feature <name>` | [SKILL.md](docs/skills/iterate-feature/SKILL.md) | Triage and fix issues from validation or PR review |
 | `/finalize-feature <name>` | [SKILL.md](docs/skills/finalize-feature/SKILL.md) | Create branch, commit, open PR with summary |
 | `/add-new-provider <name>` | [add-new-provider.md](docs/skills/add-new-provider.md) | Add a new AI provider (specialized 7-phase process) |
+
+### Meta / Tooling
+
+| Command | Skill | Purpose |
+|---------|-------|---------|
+| `/dev-workflow-improvements` | [SKILL.md](docs/skills/dev-workflow-improvements/SKILL.md) | Audit dev workflow, sync tool configs, validate skill completeness |
 
 ### Lifecycle Flow
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ demo: deps ## Build and run the demo with dummy data (for screenshots)
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/$(APP_NAME)-demo ./cmd/demo
 	$(BIN_DIR)/$(APP_NAME)-demo
 
+.PHONY: sync-tools
+sync-tools: ## Regenerate all AI tool config files from canonical template
+	@./scripts/sync-tool-configs.sh
+
 .PHONY: clean
 clean: ## Clean build artifacts
 	@rm -rf $(BIN_DIR) dist coverage.out

--- a/cmd/openusage/integrations.go
+++ b/cmd/openusage/integrations.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/janekbaraniewski/openusage/internal/config"
+	"github.com/janekbaraniewski/openusage/internal/detect"
+	"github.com/janekbaraniewski/openusage/internal/integrations"
+	"github.com/spf13/cobra"
+)
+
+func newIntegrationsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "integrations",
+		Aliases: []string{"int"},
+		Short:   "Manage tool integrations (hooks, plugins)",
+		Long:    "List, install, upgrade, and uninstall integrations for supported AI coding tools.",
+	}
+
+	cmd.AddCommand(newIntegrationsListCommand())
+	cmd.AddCommand(newIntegrationsInstallCommand())
+	cmd.AddCommand(newIntegrationsUninstallCommand())
+	cmd.AddCommand(newIntegrationsUpgradeCommand())
+
+	return cmd
+}
+
+func newIntegrationsListCommand() *cobra.Command {
+	var showAll bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List integration statuses",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			dirs := integrations.NewDefaultDirs()
+			defs := integrations.AllDefinitions()
+			detected := detect.AutoDetect()
+			matches := integrations.MatchDetected(defs, detected, dirs)
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tNAME\tSTATE\tVERSION\tSUMMARY")
+			for _, m := range matches {
+				if !showAll && !m.Actionable && m.Status.State == "missing" {
+					continue
+				}
+				ver := m.Status.InstalledVersion
+				if ver == "" {
+					ver = "-"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+					m.Definition.ID,
+					m.Definition.Name,
+					m.Status.State,
+					ver,
+					m.Status.Summary,
+				)
+			}
+			return w.Flush()
+		},
+	}
+
+	cmd.Flags().BoolVarP(&showAll, "all", "a", false, "show all integrations, including undetected ones")
+	return cmd
+}
+
+func newIntegrationsInstallCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "install <id>",
+		Short: "Install an integration",
+		Long:  "Install a hook or plugin for a supported tool. Use 'integrations list --all' to see available IDs.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			id := integrations.ID(args[0])
+			def, ok := integrations.DefinitionByID(id)
+			if !ok {
+				return fmt.Errorf("unknown integration %q; run 'openusage integrations list --all' to see options", id)
+			}
+
+			dirs := integrations.NewDefaultDirs()
+			result, err := integrations.Install(def, dirs)
+			if err != nil {
+				return fmt.Errorf("install %s: %w", id, err)
+			}
+
+			if err := config.SaveIntegrationState(string(id), config.IntegrationState{
+				Installed: true,
+				Version:   result.InstalledVer,
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: integration installed but failed to save state: %v\n", err)
+			}
+
+			fmt.Printf("%s %s (version %s)\n", def.Name, result.Action, result.InstalledVer)
+			fmt.Printf("  template: %s\n", result.TemplateFile)
+			fmt.Printf("  config:   %s\n", result.ConfigFile)
+			return nil
+		},
+	}
+}
+
+func newIntegrationsUninstallCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "uninstall <id>",
+		Short: "Uninstall an integration",
+		Long:  "Remove a hook or plugin and unregister it from the target tool's config.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			id := integrations.ID(args[0])
+			def, ok := integrations.DefinitionByID(id)
+			if !ok {
+				return fmt.Errorf("unknown integration %q", id)
+			}
+
+			dirs := integrations.NewDefaultDirs()
+			if err := integrations.Uninstall(def, dirs); err != nil {
+				return fmt.Errorf("uninstall %s: %w", id, err)
+			}
+
+			if err := config.SaveIntegrationState(string(id), config.IntegrationState{
+				Installed: false,
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: integration uninstalled but failed to save state: %v\n", err)
+			}
+
+			fmt.Printf("%s uninstalled\n", def.Name)
+			return nil
+		},
+	}
+}
+
+func newIntegrationsUpgradeCommand() *cobra.Command {
+	var upgradeAll bool
+
+	cmd := &cobra.Command{
+		Use:   "upgrade [id]",
+		Short: "Upgrade an integration to the latest embedded version",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			dirs := integrations.NewDefaultDirs()
+
+			if upgradeAll {
+				return upgradeAllIntegrations(dirs)
+			}
+
+			if len(args) == 0 {
+				return fmt.Errorf("provide an integration id or use --all")
+			}
+
+			id := integrations.ID(args[0])
+			def, ok := integrations.DefinitionByID(id)
+			if !ok {
+				return fmt.Errorf("unknown integration %q", id)
+			}
+
+			result, err := integrations.Upgrade(def, dirs)
+			if err != nil {
+				return fmt.Errorf("upgrade %s: %w", id, err)
+			}
+
+			if err := config.SaveIntegrationState(string(id), config.IntegrationState{
+				Installed: true,
+				Version:   result.InstalledVer,
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: integration upgraded but failed to save state: %v\n", err)
+			}
+
+			fmt.Printf("%s upgraded (%s -> %s)\n", def.Name, result.PreviousVer, result.InstalledVer)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&upgradeAll, "all", false, "upgrade all installed integrations")
+	return cmd
+}
+
+func upgradeAllIntegrations(dirs integrations.Dirs) error {
+	defs := integrations.AllDefinitions()
+	upgraded := 0
+	for _, def := range defs {
+		st := def.Detector(dirs)
+		if !st.NeedsUpgrade {
+			continue
+		}
+		result, err := integrations.Upgrade(def, dirs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error upgrading %s: %v\n", def.ID, err)
+			continue
+		}
+		if err := config.SaveIntegrationState(string(def.ID), config.IntegrationState{
+			Installed: true,
+			Version:   result.InstalledVer,
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %s upgraded but failed to save state: %v\n", def.ID, err)
+		}
+		fmt.Printf("%s upgraded (%s -> %s)\n", def.Name, result.PreviousVer, result.InstalledVer)
+		upgraded++
+	}
+	if upgraded == 0 {
+		fmt.Println("all integrations are up to date")
+	}
+	return nil
+}

--- a/cmd/openusage/main.go
+++ b/cmd/openusage/main.go
@@ -33,6 +33,7 @@ func main() {
 	}
 
 	root.AddCommand(newTelemetryCommand())
+	root.AddCommand(newIntegrationsCommand())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)

--- a/configs/example_settings.json
+++ b/configs/example_settings.json
@@ -114,5 +114,16 @@
       "api_key_env": "ALIBABA_CLOUD_API_KEY"
     }
   ],
-  "auto_detected_accounts": []
+  "auto_detected_accounts": [],
+  "integrations": {
+    "claude-code-hooks": {
+      "installed": true,
+      "version": "1.0.0",
+      "installed_at": "2025-01-15T10:30:00Z"
+    },
+    "cursor-rules": {
+      "installed": false,
+      "declined": true
+    }
+  }
 }

--- a/configs/example_settings.json
+++ b/configs/example_settings.json
@@ -5,6 +5,10 @@
     "crit_threshold": 0.05
   },
   "theme": "Gruvbox",
+  "data": {
+    "time_window": "7d",
+    "retention_days": 30
+  },
   "experimental": {
     "analytics": false
   },

--- a/docs/INTEGRATION_LIFECYCLE_DESIGN.md
+++ b/docs/INTEGRATION_LIFECYCLE_DESIGN.md
@@ -303,14 +303,13 @@ func checkIntegrations(cfg config.Config, dirs integrations.Dirs) {
 
 Non-interactive: just logs a message. No interactive prompts in daemon mode. The TUI can show a banner with the same info.
 
-### 5.7 Deprecation of `plugins/` Shell Scripts
+### 5.7 Remove `plugins/` Directory
 
-After the CLI install command works:
+The `plugins/` directory contains shell install scripts and source file copies that duplicate the embedded templates and Go manager logic. Remove it entirely:
 
-1. Update `plugins/*/README.md` to say: "Deprecated. Use `openusage integrations install <id>` instead."
-2. Update `TELEMETRY_INTEGRATIONS.md` to reference the CLI command.
-3. Keep the `plugins/` directory for one release cycle, then remove.
-4. The shell `install.sh` scripts are no longer needed — all logic lives in the Go manager.
+1. Delete `plugins/` directory (9 files: 3 install.sh, 3 hook/plugin source copies, 3 READMEs).
+2. Update `TELEMETRY_INTEGRATIONS.md` to reference `openusage integrations install` as the sole install method.
+3. Update `.gitignore` if it references `plugins/`.
 
 ### 5.8 Backward Compatibility
 
@@ -386,10 +385,10 @@ Tests: Rewrite `manager_test.go` — existing tests directly call removed method
 
 ### Task 8: Update docs and deprecate shell scripts
 
-Files: `docs/TELEMETRY_INTEGRATIONS.md`, `plugins/*/README.md`
+Files: `docs/TELEMETRY_INTEGRATIONS.md`, `plugins/` (delete entire directory)
 Depends on: Task 5
-Description: Update `TELEMETRY_INTEGRATIONS.md` to document the CLI command as the primary install method. Add deprecation notices to `plugins/*/README.md` pointing to `openusage integrations install`. Add a section to the main README if it references plugin installation.
-Tests: None (documentation only).
+Description: Delete `plugins/` directory entirely (redundant shell scripts and source copies). Update `TELEMETRY_INTEGRATIONS.md` to document `openusage integrations install` as the sole install method. Update any other docs that reference `plugins/`.
+Tests: None (documentation + deletion only).
 
 ### Task 9: Integration verification (end-to-end)
 

--- a/docs/INTEGRATION_LIFECYCLE_DESIGN.md
+++ b/docs/INTEGRATION_LIFECYCLE_DESIGN.md
@@ -1,0 +1,424 @@
+# Integration Lifecycle Design
+
+Date: 2026-02-24
+Status: Proposed
+Author: OpenUsage
+
+## 1. Problem Statement
+
+The plugin/integration system for external tool telemetry (Claude Code, Codex, OpenCode) exists as embedded templates and a Go manager, but there is no CLI command to install, upgrade, or manage integrations — users must run standalone shell scripts from the `plugins/` directory, there is no auto-install when tools are detected, and adding new integrations requires duplicating boilerplate across templates, manager methods, and install scripts.
+
+## 2. Goals
+
+1. Provide a single `openusage integrations` CLI command to list, install, upgrade, and uninstall integrations.
+2. Auto-prompt for integration install when `openusage telemetry daemon` starts and detects uninstalled tools.
+3. Embed all integration definitions in the binary so installs work without the source repo.
+4. Make adding a new integration a data-driven process (add a definition + template, not new methods).
+5. Remove redundant shell install scripts in `plugins/` — the Go manager becomes the single source of truth.
+
+## 3. Non-Goals
+
+1. Changing the telemetry pipeline or data model (covered by `UNIFIED_AGENT_USAGE_TRACKING_DESIGN.md`).
+2. Third-party/external plugin SDK — integrations remain built-in only.
+3. Remote plugin delivery or auto-update from a registry.
+4. Full TUI integrations redesign — the existing settings modal integrations tab (`internal/tui/settings_modal.go`) will be updated to use the new registry, but a major TUI revamp is out of scope for this design.
+5. Adding new integrations beyond the existing three (Claude Code, Codex, OpenCode) — but the system must make future additions trivial.
+
+## 4. Impact Analysis
+
+### Affected Subsystems
+
+| Subsystem | Impact | Summary |
+|-----------|--------|---------|
+| core types | none | No changes to `UsageProvider`, `UsageSnapshot`, or `AccountConfig`. |
+| providers | none | Provider implementations unchanged. `TelemetrySource` interface unchanged. |
+| TUI | minor | Existing settings modal integrations tab (`settings_modal.go`, `model.go`) updated to use new registry instead of calling `Manager` directly. |
+| config | minor | New `integrations` section in settings.json for tracking install state. |
+| detect | minor | `AutoDetect` result gains a helper to match detected tools to available integrations. |
+| daemon | minor | Daemon startup checks for uninstalled integrations and logs/prompts. |
+| telemetry | none | Pipeline, store, and spool unchanged. |
+| CLI | major | New `integrations` subcommand with list/install/upgrade/uninstall/status. |
+| integrations | major | Refactor manager from per-integration methods to data-driven registry + installer. |
+
+### Existing Design Doc Overlap
+
+- **`UNIFIED_AGENT_USAGE_TRACKING_DESIGN.md`**: Covers the telemetry data pipeline (ingestion, dedup, normalization, reconciliation). This design is complementary — it handles the *lifecycle* of getting hooks installed, not the data flow after hooks fire. Section 10 of that doc ("Agent Integration Design") describes per-agent adapter behavior; this design references but does not duplicate that.
+- **`TELEMETRY_INTEGRATIONS.md`**: Documents current manual install procedures. This design **supersedes** that doc — once the CLI command exists, `TELEMETRY_INTEGRATIONS.md` should be updated to point users to `openusage integrations install`.
+
+## 5. Detailed Design
+
+### 5.1 Integration Registry (data-driven definitions)
+
+Replace the current per-integration methods in `manager.go` (`detectOpenCode()`, `detectCodex()`, `detectClaudeCode()`, `installOpenCode()`, etc.) with a data-driven registry. Each integration is a struct with all the metadata the installer needs.
+
+```go
+// internal/integrations/registry.go
+
+type IntegrationType string
+
+const (
+    TypeHookScript IntegrationType = "hook_script"   // Bash script invoked by tool
+    TypePlugin     IntegrationType = "plugin"         // TypeScript/JS plugin loaded by tool
+)
+
+type ConfigFormat string
+
+const (
+    ConfigJSON ConfigFormat = "json"
+    ConfigTOML ConfigFormat = "toml"
+)
+
+// Definition is the complete, self-contained description of one integration.
+type Definition struct {
+    ID          ID              // "claude_code", "codex", "opencode"
+    Name        string          // "Claude Code Hooks"
+    Description string          // one-line for CLI help
+    Type        IntegrationType // hook_script or plugin
+    Template    string          // embedded template content (from go:embed)
+
+    // Where to write the rendered template
+    TargetFileFunc func(dirs Dirs) string // returns absolute path
+
+    // Target tool's config file to patch.
+    // Implementations must check tool-specific env var overrides internally:
+    //   - Codex: CODEX_CONFIG_DIR (defaults to ~/.codex)
+    //   - Claude Code: CLAUDE_SETTINGS_FILE (defaults to ~/.claude/settings.json)
+    ConfigFileFunc func(dirs Dirs) string
+    ConfigFormat   ConfigFormat
+    ConfigPatcher  ConfigPatchFunc // patches the tool's config to register the hook/plugin
+
+    // Detection: how to check if installed + configured
+    Detector DetectFunc
+
+    // Matching: how to correlate with auto-detection results.
+    // Match against detect.Result.Accounts[].Provider (e.g., "claude_code", "codex", "opencode").
+    // This is the stable identifier — DetectedTool.Name varies ("Claude Code CLI", "OpenAI Codex CLI")
+    // and some tools (OpenCode) have no DetectedTool entry, only account entries via env keys.
+    MatchProviderIDs []string // e.g., ["claude_code"] or ["opencode"]
+}
+
+// Dirs holds resolved filesystem paths used by all integrations.
+type Dirs struct {
+    Home          string
+    ConfigRoot    string // XDG_CONFIG_HOME or ~/.config
+    HooksDir      string // ~/.config/openusage/hooks
+    OpenusageBin  string // resolved binary path
+}
+
+// NewDefaultDirs resolves Dirs from environment variables and platform defaults.
+// Extracts the shared path resolution logic currently in NewDefaultManager().
+func NewDefaultDirs() Dirs
+
+// ConfigPatchFunc patches a tool's config file to register/unregister the integration.
+// install=true adds the hook, install=false removes it.
+type ConfigPatchFunc func(configData []byte, targetFile string, install bool) ([]byte, error)
+
+// DetectFunc checks whether the integration is installed and configured.
+type DetectFunc func(dirs Dirs) Status
+
+// AllDefinitions returns the built-in integration definitions.
+func AllDefinitions() []Definition {
+    return []Definition{
+        claudeCodeDef(),
+        codexDef(),
+        opencodeDef(),
+    }
+}
+```
+
+Each definition is constructed by a factory function (e.g. `claudeCodeDef()`) that wires the embedded template, path functions, and config patcher together. The existing `installClaudeCode()`, `installCodex()`, `installOpenCode()` logic moves into `ConfigPatchFunc` implementations — same logic, just structured as data rather than methods.
+
+### 5.2 Installer (generic, definition-driven)
+
+A single `Install` function operates on any `Definition`:
+
+```go
+// internal/integrations/installer.go
+
+type InstallResult struct {
+    ID             ID
+    Action         string // "installed", "upgraded", "already_current", "uninstalled"
+    TemplateFile   string // path to written template
+    ConfigFile     string // path to patched config
+    PreviousVer    string
+    InstalledVer   string
+}
+
+// Install renders the template, writes the target file, patches the tool config.
+func Install(def Definition, dirs Dirs) (InstallResult, error)
+
+// Uninstall removes the target file and un-patches the tool config.
+func Uninstall(def Definition, dirs Dirs) error
+
+// Upgrade is Install when already installed (same flow, result.Action = "upgraded").
+func Upgrade(def Definition, dirs Dirs) (InstallResult, error)
+```
+
+The `Install` flow:
+1. Resolve paths via `def.TargetFileFunc(dirs)` and `def.ConfigFileFunc(dirs)`.
+2. Render template: replace `__OPENUSAGE_INTEGRATION_VERSION__` and `__OPENUSAGE_BIN_DEFAULT__`.
+3. `backupIfExists()` on both target file and config file (existing behavior).
+4. Write rendered template to target path.
+5. Read tool config, call `def.ConfigPatcher(configData, targetFile, true)`, write back.
+6. Return `InstallResult`.
+
+This eliminates the `switch id` dispatch in the current `Manager.Install()`.
+
+### 5.3 Config Persistence (integration state)
+
+Add an `integrations` section to the config file to track what the user has installed:
+
+```go
+// Added to internal/config/config.go Config struct
+
+type IntegrationState struct {
+    Installed   bool   `json:"installed"`
+    Version     string `json:"version,omitempty"`
+    InstalledAt string `json:"installed_at,omitempty"` // RFC3339
+    Declined    bool   `json:"declined,omitempty"`     // user said "no" to auto-install
+}
+
+// In Config:
+// Integrations map[string]IntegrationState `json:"integrations,omitempty"`
+```
+
+Example in settings.json:
+```json
+{
+  "integrations": {
+    "claude_code": {
+      "installed": true,
+      "version": "2026-02-24.1",
+      "installed_at": "2026-02-24T12:00:00Z"
+    },
+    "codex": {
+      "declined": true
+    }
+  }
+}
+```
+
+New config methods:
+- `SaveIntegrationState(id string, state IntegrationState) error`
+
+### 5.4 Detection Bridge
+
+Add a helper that matches detected tools/accounts to available integration definitions:
+
+```go
+// internal/integrations/match.go
+
+type Match struct {
+    Definition   Definition
+    Tool         *detect.DetectedTool   // the detected tool, if found (nil for env-key-only like OpenCode)
+    Account      *core.AccountConfig    // the detected account, if found
+    Status       Status                 // current install/config status
+    Actionable   bool                   // true if not installed and tool/account is detected
+}
+
+// MatchDetected takes detection results and returns integration matches.
+// Matching strategy: each Definition has MatchProviderIDs (e.g., ["claude_code"]).
+// These are matched against detect.Result.Accounts[].Provider — the stable identifier.
+// Additionally, if a DetectedTool exists for that provider, it's included in the Match.
+// This handles all cases:
+//   - Claude Code: detected as tool ("Claude Code CLI") + account (provider="claude_code")
+//   - Codex: detected as tool ("OpenAI Codex CLI") + account (provider="codex")
+//   - OpenCode: detected via env keys only, account (provider="opencode"), no DetectedTool
+func MatchDetected(defs []Definition, detected detect.Result, dirs Dirs) []Match
+```
+
+This does not change the detect package itself. The matching is done in the integrations package, which imports detect and core types. The provider ID is the stable join key — `DetectedTool.Name` is display-only and varies across tools.
+
+### 5.5 CLI Commands
+
+New cobra command group registered on root:
+
+```
+openusage integrations list               # list all integrations + status
+openusage integrations install <id|--all> # install one or all detected
+openusage integrations upgrade <id|--all> # upgrade outdated integrations
+openusage integrations uninstall <id>     # remove integration
+openusage integrations status [id]        # detailed status of one or all
+```
+
+```go
+// cmd/openusage/integrations.go
+
+func newIntegrationsCommand() *cobra.Command {
+    cmd := &cobra.Command{
+        Use:   "integrations",
+        Short: "Manage telemetry integrations with coding tools",
+    }
+    cmd.AddCommand(
+        newIntegrationsListCommand(),
+        newIntegrationsInstallCommand(),
+        newIntegrationsUpgradeCommand(),
+        newIntegrationsUninstallCommand(),
+        newIntegrationsStatusCommand(),
+    )
+    return cmd
+}
+```
+
+**`integrations list`** output example:
+```
+Integration       Status      Version       Tool Detected
+─────────────────────────────────────────────────────────
+Claude Code       installed   2026-02-24.1  yes (claude @ /usr/local/bin/claude)
+Codex             missing     -             yes (codex @ ~/.local/bin/codex)
+OpenCode          outdated    2026-02-20.1  yes (opencode @ /usr/local/bin/opencode)
+```
+
+**`integrations install`** flow:
+1. Run `detect.AutoDetect()` to find tools.
+2. Run `MatchDetected()` to find actionable integrations.
+3. If `--all`: install all actionable. If `<id>`: install that one (even if tool not detected, with a warning).
+4. For each: call `Install(def, dirs)`, then `config.SaveIntegrationState(id, state)`.
+5. Print results.
+
+### 5.6 Daemon Auto-Prompt
+
+When `openusage telemetry daemon` starts, check for uninstalled integrations:
+
+```go
+// In daemon startup (cmd/openusage/telemetry.go or internal/daemon/server.go)
+
+func checkIntegrations(cfg config.Config, dirs integrations.Dirs) {
+    defs := integrations.AllDefinitions()
+    detected := detect.AutoDetect()
+    matches := integrations.MatchDetected(defs, detected, dirs)
+
+    for _, m := range matches {
+        if !m.Actionable {
+            continue
+        }
+        // Check if user already declined
+        if state, ok := cfg.Integrations[string(m.Definition.ID)]; ok && state.Declined {
+            continue
+        }
+        log.Printf("integration: %s detected but not installed — run: openusage integrations install %s", m.Definition.Name, m.Definition.ID)
+    }
+}
+```
+
+Non-interactive: just logs a message. No interactive prompts in daemon mode. The TUI can show a banner with the same info.
+
+### 5.7 Deprecation of `plugins/` Shell Scripts
+
+After the CLI install command works:
+
+1. Update `plugins/*/README.md` to say: "Deprecated. Use `openusage integrations install <id>` instead."
+2. Update `TELEMETRY_INTEGRATIONS.md` to reference the CLI command.
+3. Keep the `plugins/` directory for one release cycle, then remove.
+4. The shell `install.sh` scripts are no longer needed — all logic lives in the Go manager.
+
+### 5.8 Backward Compatibility
+
+- **Existing manually-installed hooks continue to work.** The version marker (`openusage-integration-version: ...`) is already embedded in templates. The `Detector` function checks both file existence and config registration — it will correctly detect manually-installed hooks as "installed".
+- **Config file gains a new `integrations` key.** This is additive — existing configs without this key work fine (treated as empty map, all integrations unknown).
+- **No changes to the telemetry pipeline.** Hook payloads, spool format, and SQLite schema are unchanged.
+- **No changes to provider interfaces.** `UsageProvider`, `TelemetrySource`, and `UsageSnapshot` are untouched.
+
+## 6. Alternatives Considered
+
+### Keep per-integration methods, just add CLI
+
+We could keep the current `installClaudeCode()`, `installCodex()`, `installOpenCode()` methods and just wrap them in a CLI command. Rejected because: adding a 4th integration (e.g., Gemini CLI) would require adding another method to the manager, another `case` in `Install()`, another `detect*()` method — the switch/method fan-out grows linearly. The data-driven approach makes new integrations a single definition.
+
+### External plugin system (load definitions from files)
+
+We could allow users to drop integration definitions into a directory. Rejected because: this adds complexity (parsing, validation, security) for a use case that doesn't exist yet. All current and foreseeable integrations are built-in. If needed later, `AllDefinitions()` can be extended to load external definitions.
+
+### Full TUI integrations redesign
+
+The existing settings modal integrations tab already supports install/upgrade. A more ambitious redesign (dedicated screen, richer status display, auto-detect prompts) was considered but deferred — the existing tab will be updated to use the new registry, which is sufficient for now.
+
+## 7. Implementation Tasks
+
+### Task 1: Define integration registry types and move definitions
+
+Files: `internal/integrations/registry.go` (new), `internal/integrations/definitions.go` (new)
+Depends on: none
+Description: Create the `Definition`, `Dirs`, `ConfigPatchFunc`, `DetectFunc` types and `NewDefaultDirs()` constructor in `registry.go`. `NewDefaultDirs()` extracts the shared path resolution logic currently in `NewDefaultManager()` (home dir, XDG_CONFIG_HOME, OPENUSAGE_BIN, binary discovery). Create `AllDefinitions()` in `definitions.go` with the three existing integrations as data-driven definitions. Each definition's `ConfigPatcher` and `Detector` reuses the existing logic from `manager.go` (extract into standalone functions). Wire in the existing `go:embed` templates. Each definition's `ConfigFileFunc` checks its tool-specific env var override (e.g., `CODEX_CONFIG_DIR`, `CLAUDE_SETTINGS_FILE`).
+Tests: `internal/integrations/registry_test.go` — test that `AllDefinitions()` returns 3 definitions, each with non-empty ID/Name/Template. Test that `NewDefaultDirs()` resolves correctly from env vars and defaults.
+
+### Task 2: Implement generic Install/Uninstall/Upgrade
+
+Files: `internal/integrations/installer.go` (new), `internal/integrations/installer_test.go` (new)
+Depends on: Task 1
+Description: Implement `Install()`, `Uninstall()`, and `Upgrade()` that operate on any `Definition`. Template rendering (version/bin substitution), file writing with backup, and config patching via `ConfigPatchFunc`. The uninstall path calls `ConfigPatchFunc` with `install=false` to remove the hook entry. Use `t.TempDir()` in tests to simulate the full install/uninstall cycle.
+Tests: For each of the 3 integrations: test install creates expected files + patches config correctly. Test uninstall removes hook from config. Test upgrade replaces template and updates version marker. Test install is idempotent (running twice doesn't duplicate hook entries).
+
+### Task 3: Add integration state to config
+
+Files: `internal/config/config.go`, `configs/example_settings.json`
+Depends on: none
+Description: Add `IntegrationState` struct and `Integrations map[string]IntegrationState` field to `Config`. Add `SaveIntegrationState(id string, state IntegrationState) error` method following the existing RMW pattern. Update example config with a sample `integrations` section.
+Tests: `internal/config/config_test.go` — test round-trip: save integration state, reload config, verify state preserved. Test that missing `integrations` key in existing config loads as empty map (backward compat).
+
+### Task 4: Detection bridge (match tools/accounts to integrations)
+
+Files: `internal/integrations/match.go` (new), `internal/integrations/match_test.go` (new)
+Depends on: Task 1
+Description: Implement `MatchDetected()` that takes `AllDefinitions()`, a `detect.Result`, and `Dirs`, returning `[]Match`. Matching uses `Definition.MatchProviderIDs` against `detect.Result.Accounts[].Provider` as the stable join key. If a `DetectedTool` exists for the same provider, it's included in the `Match` for display (binary path, config dir). Handles OpenCode (env-key-only, no DetectedTool) correctly.
+Tests: Test with mock accounts matching by provider ID. Test OpenCode case (account with provider="opencode", no DetectedTool). Test that an account with no matching integration is ignored. Test that an installed integration shows as not-actionable.
+
+### Task 5: CLI `integrations` command group
+
+Files: `cmd/openusage/integrations.go` (new), `cmd/openusage/main.go` (register command)
+Depends on: Task 1, 2, 3, 4
+Description: Implement `integrations list`, `integrations install <id|--all>`, `integrations upgrade <id|--all>`, `integrations uninstall <id>`, `integrations status [id]`. The `list` command runs auto-detect + match and prints a table. The `install` command calls `Install()` + `SaveIntegrationState()`. The `upgrade` command re-installs outdated integrations. Register the command group on root in `main.go`.
+Tests: Since CLI commands do I/O, test the core logic (list formatting, install orchestration) as exported functions called from the command handlers. Use `t.TempDir()` for filesystem operations.
+
+### Task 6: Daemon startup integration check
+
+Files: `cmd/openusage/telemetry.go`
+Depends on: Task 1, 3, 4
+Description: Add `checkIntegrations()` call during daemon startup. Runs detection, matches to definitions, logs suggestions for uninstalled integrations (skipping declined ones). Non-interactive — log only.
+Tests: Test `checkIntegrations()` with a config that has one declined integration — verify it's not logged. Test with a detected-but-uninstalled integration — verify the log message includes the install command.
+
+### Task 7: Refactor manager.go to use registry and update TUI callers
+
+Files: `internal/integrations/manager.go`, `internal/tui/model.go`, `internal/tui/settings_modal.go`
+Depends on: Task 1, 2
+Description: Refactor `Manager` to delegate to the registry + installer instead of per-integration methods. `ListStatuses()` iterates `AllDefinitions()` and calls each `Detector`. `Install(id)` looks up the definition and calls `Install()`. Keep the `Manager` struct for `Dirs` resolution (it still knows about env vars and default paths). Remove `installOpenCode()`, `installCodex()`, `installClaudeCode()`, `detectOpenCode()`, `detectCodex()`, `detectClaudeCode()` — their logic now lives in definitions. Update TUI callers: `model.go:290` (`installIntegrationCmd`) and `model.go:1902` (`refreshIntegrationStatuses`) both call `integrations.NewDefaultManager()` directly — update these to use the refactored Manager API.
+Tests: Rewrite `manager_test.go` — existing tests directly call removed methods (`m.detectOpenCode()`, `m.detectCodex()`, `m.detectClaudeCode()`). New tests should exercise `Manager.ListStatuses()` and `Manager.Install(id)` through the registry-backed implementation. Add test that `Install()` with unknown ID returns error.
+
+### Task 8: Update docs and deprecate shell scripts
+
+Files: `docs/TELEMETRY_INTEGRATIONS.md`, `plugins/*/README.md`
+Depends on: Task 5
+Description: Update `TELEMETRY_INTEGRATIONS.md` to document the CLI command as the primary install method. Add deprecation notices to `plugins/*/README.md` pointing to `openusage integrations install`. Add a section to the main README if it references plugin installation.
+Tests: None (documentation only).
+
+### Task 9: Integration verification (end-to-end)
+
+Files: `internal/integrations/installer_test.go` (extend)
+Depends on: Task 1, 2, 3, 4, 5, 7
+Description: End-to-end test: create a temp dir structure simulating a workstation with Claude Code and Codex config dirs. Run detection, match, install all, verify files created, verify config files patched correctly, verify config state saved. Then run upgrade (bump version), verify template updated. Then uninstall, verify hooks removed from config. This validates the full lifecycle.
+Tests: Single comprehensive test function covering install → verify → upgrade → uninstall cycle for all 3 integrations.
+
+### Dependency Graph
+
+```
+Sequential: Task 1 (registry types)
+Parallel group: Tasks 2, 3, 4 (all depend on Task 1 only, independent of each other)
+Sequential: Task 5 (CLI commands, depends on 1-4)
+Parallel group: Tasks 6, 7 (depend on 1+3+4 and 1+2 respectively, independent of each other)
+Sequential: Task 8 (docs, depends on 5)
+Sequential: Task 9 (end-to-end verification, depends on all above)
+```
+
+```
+        ┌──── Task 2 (installer) ──────┐
+        │                               │
+Task 1 ─┼──── Task 3 (config) ─────────┼── Task 5 (CLI) ── Task 8 (docs)
+        │                               │       │
+        └──── Task 4 (match) ──────────┘       │
+                │                               │
+                └── Task 6 (daemon check) ──────┤
+                                                │
+                    Task 7 (refactor manager) ──┤
+                                                │
+                                          Task 9 (e2e)
+```

--- a/docs/TELEMETRY_INTEGRATIONS.md
+++ b/docs/TELEMETRY_INTEGRATIONS.md
@@ -1,4 +1,4 @@
-# Telemetry Integrations (Native Setup)
+# Telemetry Integrations
 
 This repository supports three native coding-agent telemetry streams:
 
@@ -13,6 +13,55 @@ All streams emit normalized telemetry events into the same SQLite store:
 When the OpenUsage app is running, background collection and canonical telemetry read-model updates are automatic.
 You do not need to run `openusage telemetry collect` manually for normal operation.
 OpenUsage does not auto-create synthetic providers from telemetry. Unmapped telemetry provider IDs are flagged for explicit user action.
+
+## Installing Integrations
+
+All integration hook/plugin definitions are embedded in the `openusage` binary.
+Use the built-in CLI to install, upgrade, or uninstall them:
+
+```bash
+# List detected integrations and their status
+openusage integrations list
+
+# List all integrations, including ones for tools not detected on this machine
+openusage integrations list --all
+
+# Install an integration by ID
+openusage integrations install claude_code
+openusage integrations install codex
+openusage integrations install opencode
+
+# Upgrade an integration to the latest embedded version
+openusage integrations upgrade claude_code
+
+# Upgrade all outdated integrations at once
+openusage integrations upgrade --all
+
+# Uninstall an integration (removes hook and unregisters from tool config)
+openusage integrations uninstall claude_code
+```
+
+The daemon also prints a hint at startup when it detects tools with missing integrations.
+
+## What Gets Installed
+
+### OpenCode (Plugin)
+
+- `~/.config/opencode/plugins/openusage-telemetry.ts`
+- plugin entry in `~/.config/opencode/opencode.json`
+
+### Codex (Notify Hook)
+
+- `~/.config/openusage/hooks/codex-notify.sh`
+- `notify = ["~/.config/openusage/hooks/codex-notify.sh"]` in `~/.codex/config.toml`
+
+### Claude Code (Command Hooks)
+
+- `~/.config/openusage/hooks/claude-hook.sh`
+- command hooks in `~/.claude/settings.json` for:
+  - `Stop`
+  - `SubagentStop`
+  - `PostToolUse`
 
 ## Provider Linking (Explicit Control)
 
@@ -35,48 +84,6 @@ Behavior:
    - `telemetry_unmapped_providers`
    - `telemetry_provider_link_hint`
 3. Canonical telemetry usage metrics are applied only to configured providers (or explicitly linked providers).
-
-## 1) OpenCode (Plugin)
-
-Install:
-
-```bash
-./plugins/openusage-telemetry/install.sh
-```
-
-This installs:
-
-- `~/.config/opencode/plugins/openusage-telemetry.ts`
-- plugin entry in `~/.config/opencode/opencode.json`
-
-## 2) Codex (Native notify)
-
-Install:
-
-```bash
-./plugins/codex-telemetry/install.sh
-```
-
-This installs:
-
-- `~/.config/openusage/hooks/codex-notify.sh`
-- `notify = ["~/.config/openusage/hooks/codex-notify.sh"]` in `~/.codex/config.toml`
-
-## 3) Claude Code (Native hooks)
-
-Install:
-
-```bash
-./plugins/claude-code-telemetry/install.sh
-```
-
-This installs:
-
-- `~/.config/openusage/hooks/claude-hook.sh`
-- command hooks in `~/.claude/settings.json` for:
-  - `Stop`
-  - `SubagentStop`
-  - `PostToolUse`
 
 ## Optional runtime env vars (all integrations)
 

--- a/docs/skills/dev-workflow-improvements/SKILL.md
+++ b/docs/skills/dev-workflow-improvements/SKILL.md
@@ -1,0 +1,129 @@
+# Skill: Dev Workflow Improvements
+
+Audit and improve the OpenUsage development workflow. Ensures the dev flow is complete, consistent, and propagated to all AI tools.
+
+## When to use
+
+- After adding/modifying a skill in `docs/skills/`
+- After changing tool config content (code style, architecture, commands)
+- When onboarding a new AI tool
+- Periodically to check for drift or staleness
+- When the development flow feels broken or incomplete
+
+## Architecture
+
+### Source of truth
+
+```
+docs/skills/tool-configs/template.md      ← shared content (style, architecture, commands)
+docs/skills/tool-configs/skills-table.md   ← skills registry (single table, all skills)
+docs/skills/<skill-name>/SKILL.md          ← individual skill specifications
+```
+
+### Generated files (never edit directly)
+
+```
+.continuerules                    ← Continue.dev
+.windsurfrules                    ← Windsurf
+.github/copilot-instructions.md  ← GitHub Copilot
+.aider/conventions.md            ← Aider
+.opencode/skills/*/SKILL.md      ← OpenCode (thin stubs → docs/skills/)
+.claude/commands/*.md             ← Claude Code (slash command stubs)
+```
+
+### Generator
+
+`scripts/sync-tool-configs.sh` — reads template + skills table, writes all generated files.
+Run via `make sync-tools`.
+
+## Phases
+
+### Phase 0 — Audit
+
+1. Run `make sync-tools` and check if any files changed (`git diff`).
+   - If changes: report which files drifted and what changed.
+   - If clean: report "All tool configs are in sync."
+
+2. Validate skill completeness:
+   - For each directory in `docs/skills/*/`:
+     - Has a `SKILL.md`?
+     - Listed in `docs/skills/tool-configs/skills-table.md`?
+     - Has a matching `.claude/commands/<name>.md`?
+     - Has a matching `.opencode/skills/<name>/SKILL.md`?
+   - Report any gaps.
+
+3. Validate skill references:
+   - For each skill's SKILL.md, check that referenced files exist:
+     - `references/*.md` files mentioned in the skill
+     - Source files mentioned (e.g., `internal/core/types.go`)
+     - Other skills referenced (e.g., `/design-feature`)
+   - Report broken references.
+
+4. Check CLAUDE.md skills table matches `skills-table.md`:
+   - Compare the skills table in `CLAUDE.md` with `docs/skills/tool-configs/skills-table.md`.
+   - Report any mismatches.
+
+### Phase 1 — Fix
+
+Based on audit findings, fix issues in priority order:
+
+1. **Sync drift**: Run `make sync-tools` to regenerate.
+2. **Missing registrations**: Add skill to `skills-table.md`, re-run sync.
+3. **Missing stubs**: The sync script generates these automatically.
+4. **Broken references**: Fix or remove stale file references in SKILL.md.
+5. **CLAUDE.md mismatch**: Update the skills table in CLAUDE.md.
+
+After each fix category, re-run the audit for that category to confirm.
+
+### Phase 2 — Improve
+
+If the user requested workflow improvements (not just sync):
+
+1. **Quiz** (ask the user):
+   - What part of the workflow feels broken or incomplete?
+   - Any new skills needed?
+   - Any existing skills that need updating?
+   - Any new AI tools to onboard?
+
+2. **Execute improvements** based on answers:
+   - New skill: create `docs/skills/<name>/SKILL.md`, add to skills-table, run sync.
+   - Update skill: edit the SKILL.md, check if tool configs need template changes, run sync.
+   - New tool: add to `scripts/sync-tool-configs.sh`, add generation target, run sync.
+   - Workflow gap: identify the gap, propose a fix, implement after user approval.
+
+3. **Final sync**: Run `make sync-tools` to propagate all changes.
+
+### Phase 3 — Verify
+
+1. Run `make sync-tools` — should produce no changes (idempotent).
+2. Run `make build` — project still compiles.
+3. Run `make test` — tests still pass.
+4. `git diff` — show all changes for user review.
+
+## Rules
+
+1. NEVER edit generated files directly — always edit the source of truth and run sync.
+2. Every new skill MUST be added to `skills-table.md` — this is the single registry.
+3. After ANY skill change, run `make sync-tools` before committing.
+4. The template is authoritative — if a tool config disagrees, the template wins.
+5. Claude commands get more detail than other tools (phase breakdowns) — this is intentional.
+6. OpenCode skills are thin stubs pointing to `docs/skills/` — don't duplicate content.
+
+## Adding a new AI tool
+
+1. Add a `generate_config` call in `scripts/sync-tool-configs.sh`.
+2. Add the output file to the "Generated files" list in this doc.
+3. Add the output file to `docs/skills/tool-configs/README.md`.
+4. Run `make sync-tools`.
+5. Commit the script change + generated file together.
+
+## Checklist
+
+- [ ] `make sync-tools` produces no diff (all configs in sync)
+- [ ] Every `docs/skills/*/SKILL.md` is in `skills-table.md`
+- [ ] Every skill has a `.claude/commands/<name>.md` stub
+- [ ] Every skill has a `.opencode/skills/<name>/SKILL.md` stub
+- [ ] CLAUDE.md skills table matches `skills-table.md`
+- [ ] No broken file references in any SKILL.md
+- [ ] `make build` passes
+- [ ] `make test` passes

--- a/docs/skills/dev-workflow-improvements/references/audit-checklist.md
+++ b/docs/skills/dev-workflow-improvements/references/audit-checklist.md
@@ -1,0 +1,63 @@
+# Dev Workflow Audit Checklist
+
+## 1. Tool Config Sync
+
+For each generated file, verify it matches what `make sync-tools` would produce:
+
+| File | Source |
+|------|--------|
+| `.continuerules` | `template.md` with title "Continue.dev Rules" |
+| `.windsurfrules` | `template.md` with title "Windsurf Rules" |
+| `.github/copilot-instructions.md` | `template.md` with title "GitHub Copilot Instructions" |
+| `.aider/conventions.md` | `template.md` with title "Aider Conventions" |
+
+## 2. Skill Registration
+
+For each skill in `docs/skills/*/SKILL.md`:
+
+- [ ] Row exists in `docs/skills/tool-configs/skills-table.md`
+- [ ] Entry exists in `.claude/commands/<skill-name>.md`
+- [ ] Entry exists in `.opencode/skills/<skill-name>/SKILL.md`
+- [ ] Entry exists in CLAUDE.md's skills table (if applicable)
+
+## 3. Skill Quality
+
+For each SKILL.md:
+
+- [ ] Has clear "When to use" section
+- [ ] Has numbered phases
+- [ ] All referenced files exist on disk
+- [ ] All referenced skills exist in `docs/skills/`
+- [ ] References directory paths use correct format
+- [ ] No TODO or FIXME markers left in
+
+## 4. Template Completeness
+
+The template (`docs/skills/tool-configs/template.md`) should contain:
+
+- [ ] Project overview (what is OpenUsage, key tech: Go, Bubble Tea, CGO)
+- [ ] Key commands (make build, test, vet, single provider test)
+- [ ] Code style (gofmt, imports, error wrapping, pointer fields, JSON tags, testing)
+- [ ] Architecture (core interface, registry, detect, config path)
+- [ ] Skills table (via `{{SKILLS_TABLE}}` placeholder)
+- [ ] Mandatory phase rule
+
+## 5. Generator Completeness
+
+The generator (`scripts/sync-tool-configs.sh`) should:
+
+- [ ] Generate all 4 tool config files
+- [ ] Generate all OpenCode skill stubs
+- [ ] Generate all Claude command stubs
+- [ ] Be idempotent (running twice produces same output)
+- [ ] Handle new skills added to `docs/skills/` automatically
+- [ ] Have descriptions for each skill in both SKILL_DESCRIPTIONS and CLAUDE_DESCRIPTIONS arrays
+
+## 6. Cross-References
+
+| From | To | Check |
+|------|----|-------|
+| CLAUDE.md skills table | `skills-table.md` | Content matches |
+| `.claude/commands/*.md` | `docs/skills/*/SKILL.md` | Every command has a skill |
+| `docs/skills/*/SKILL.md` | Referenced source files | Files exist |
+| `docs/skills/develop-feature/SKILL.md` | All other skills | Skill names match |

--- a/docs/skills/tool-configs/README.md
+++ b/docs/skills/tool-configs/README.md
@@ -1,0 +1,29 @@
+# Tool Config Templates
+
+This directory contains the **single source of truth** for all AI tool configuration files in the repository.
+
+## How it works
+
+1. `template.md` defines the canonical content shared across all tool configs
+2. `scripts/sync-tool-configs.sh` generates tool-specific configs from the template
+3. `make sync-tools` runs the generator
+
+## Generated files
+
+| Tool | Generated file |
+|------|---------------|
+| Continue.dev | `.continuerules` |
+| Windsurf | `.windsurfrules` |
+| GitHub Copilot | `.github/copilot-instructions.md` |
+| Aider | `.aider/conventions.md` |
+| OpenCode | `.opencode/skills/*/SKILL.md` |
+
+Claude Code commands (`.claude/commands/`) are **not** generated — they use a different format (slash command stubs that reference `docs/skills/`).
+
+## When to update
+
+1. Edit `template.md` (the source of truth)
+2. Run `make sync-tools`
+3. Commit all generated files together
+
+Never edit the generated files directly — they'll be overwritten on next sync.

--- a/docs/skills/tool-configs/skills-table.md
+++ b/docs/skills/tool-configs/skills-table.md
@@ -1,0 +1,11 @@
+| Trigger | Skill File | Purpose |
+|---------|-----------|---------|
+| add a new provider | `docs/skills/add-new-provider.md` | Add a new AI provider (quiz, research, implement, test) |
+| design a feature | `docs/skills/design-feature/SKILL.md` | Design a feature: quiz, explore codebase, write design doc with tasks |
+| develop a feature | `docs/skills/develop-feature/SKILL.md` | Full lifecycle from design to PR |
+| implement a feature | `docs/skills/implement-feature/SKILL.md` | Execute design tasks with tests |
+| review a design | `docs/skills/review-design/SKILL.md` | Validate design doc against codebase |
+| validate a feature | `docs/skills/validate-feature/SKILL.md` | Verify build, tests, design compliance, code quality |
+| iterate on a feature | `docs/skills/iterate-feature/SKILL.md` | Triage and fix issues from validation or PR review |
+| finalize a feature | `docs/skills/finalize-feature/SKILL.md` | Create branch, commit, open PR |
+| improve dev workflow | `docs/skills/dev-workflow-improvements/SKILL.md` | Audit and improve the development workflow, sync tool configs |

--- a/docs/skills/tool-configs/template.md
+++ b/docs/skills/tool-configs/template.md
@@ -1,0 +1,40 @@
+# {{TOOL_TITLE}} — OpenUsage
+
+## Project Overview
+
+OpenUsage is a Go terminal dashboard (TUI) for monitoring AI coding tool usage and spend.
+Built with Bubble Tea. CGO required (`CGO_ENABLED=1`) for `mattn/go-sqlite3`.
+
+## Key Commands
+
+```bash
+make build          # build binary
+make test           # run all tests with -race
+make vet            # go vet
+go test ./internal/providers/<name>/ -v  # test single provider
+```
+
+## Code Style
+
+- Standard `gofmt` with `goimports`. Tabs for indentation.
+- Import groups (separated by blank lines): stdlib, third-party, internal.
+- Bubble Tea aliased as `tea`.
+- Errors wrapped with provider prefix: `fmt.Errorf("openai: creating request: %w", err)`.
+- Pointer fields for optional numerics: `Limit *float64`.
+- JSON tags use `snake_case` with `omitempty` for optional fields.
+- No mocking frameworks — use `httptest.NewServer` and table-driven tests.
+
+## Architecture
+
+Every provider implements `core.UsageProvider` (ID, Describe, Spec, DashboardWidget, DetailWidget, Fetch).
+Providers registered in `internal/providers/registry.go` via `AllProviders()`.
+Auto-detection in `internal/detect/detect.go`.
+Config: `~/.config/openusage/settings.json`.
+
+## Skills
+
+This project has structured workflow skills stored in `docs/skills/`. When asked to perform any of these tasks, read and follow the full specification from the linked file.
+
+{{SKILLS_TABLE}}
+
+Each skill has a mandatory quiz or intake phase. Do NOT skip any phase. Always read the full skill file first.

--- a/internal/integrations/definitions.go
+++ b/internal/integrations/definitions.go
@@ -1,0 +1,388 @@
+package integrations
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+//go:embed assets/opencode-telemetry.ts.tpl
+var opencodeTemplate string
+
+//go:embed assets/codex-notify.sh.tpl
+var codexTemplate string
+
+//go:embed assets/claude-hook.sh.tpl
+var claudeTemplate string
+
+// AllDefinitions returns the built-in integration definitions.
+func AllDefinitions() []Definition {
+	return []Definition{
+		claudeCodeDef(),
+		codexDef(),
+		opencodeDef(),
+	}
+}
+
+// DefinitionByID returns the definition with the given ID, or false if not found.
+func DefinitionByID(id ID) (Definition, bool) {
+	for _, def := range AllDefinitions() {
+		if def.ID == id {
+			return def, true
+		}
+	}
+	return Definition{}, false
+}
+
+func claudeCodeDef() Definition {
+	return Definition{
+		ID:          ClaudeCodeID,
+		Name:        "Claude Code Hooks",
+		Description: "Telemetry hooks for Claude Code (Stop, SubagentStop, PostToolUse)",
+		Type:        TypeHookScript,
+		Template:    claudeTemplate,
+
+		TargetFileFunc: func(dirs Dirs) string {
+			return filepath.Join(dirs.HooksDir, "claude-hook.sh")
+		},
+		ConfigFileFunc: func(dirs Dirs) string {
+			if f := strings.TrimSpace(os.Getenv("CLAUDE_SETTINGS_FILE")); f != "" {
+				return f
+			}
+			return filepath.Join(dirs.Home, ".claude", "settings.json")
+		},
+		ConfigFormat:  ConfigJSON,
+		ConfigPatcher: patchClaudeCodeConfig,
+		Detector:      detectClaudeCodeStatus,
+
+		MatchProviderIDs:  []string{"claude_code"},
+		MatchToolNameHint: "Claude Code",
+		TemplateFileMode:  0o755,
+		EscapeBin:         escapeForShellString,
+	}
+}
+
+func codexDef() Definition {
+	return Definition{
+		ID:          CodexID,
+		Name:        "Codex Notify Hook",
+		Description: "Telemetry notify hook for OpenAI Codex CLI",
+		Type:        TypeHookScript,
+		Template:    codexTemplate,
+
+		TargetFileFunc: func(dirs Dirs) string {
+			return filepath.Join(dirs.HooksDir, "codex-notify.sh")
+		},
+		ConfigFileFunc: func(dirs Dirs) string {
+			codexDir := strings.TrimSpace(os.Getenv("CODEX_CONFIG_DIR"))
+			if codexDir == "" {
+				codexDir = filepath.Join(dirs.Home, ".codex")
+			}
+			return filepath.Join(codexDir, "config.toml")
+		},
+		ConfigFormat:  ConfigTOML,
+		ConfigPatcher: patchCodexConfig,
+		Detector:      detectCodexStatus,
+
+		MatchProviderIDs:  []string{"codex"},
+		MatchToolNameHint: "Codex",
+		TemplateFileMode:  0o755,
+		EscapeBin:         escapeForShellString,
+	}
+}
+
+func opencodeDef() Definition {
+	return Definition{
+		ID:          OpenCodeID,
+		Name:        "OpenCode Plugin",
+		Description: "Telemetry plugin for OpenCode IDE",
+		Type:        TypePlugin,
+		Template:    opencodeTemplate,
+
+		TargetFileFunc: func(dirs Dirs) string {
+			return filepath.Join(dirs.ConfigRoot, "opencode", "plugins", "openusage-telemetry.ts")
+		},
+		ConfigFileFunc: func(dirs Dirs) string {
+			return filepath.Join(dirs.ConfigRoot, "opencode", "opencode.json")
+		},
+		ConfigFormat:  ConfigJSON,
+		ConfigPatcher: patchOpenCodeConfig,
+		Detector:      detectOpenCodeStatus,
+
+		MatchProviderIDs:  []string{"opencode"},
+		MatchToolNameHint: "",
+		TemplateFileMode:  0o644,
+		EscapeBin:         escapeForTSString,
+	}
+}
+
+// --- Config patchers ---
+
+func patchClaudeCodeConfig(configData []byte, targetFile string, install bool) ([]byte, error) {
+	cfg := map[string]any{}
+	if len(bytes.TrimSpace(configData)) > 0 {
+		if err := json.Unmarshal(configData, &cfg); err != nil {
+			return nil, fmt.Errorf("parse claude settings: %w", err)
+		}
+	}
+
+	hooks, _ := cfg["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	cfg["hooks"] = hooks
+
+	events := []string{"Stop", "SubagentStop", "PostToolUse"}
+
+	if install {
+		for _, event := range events {
+			entries, _ := hooks[event].([]any)
+			if !entriesContainCommand(entries, targetFile) {
+				entries = append(entries, map[string]any{
+					"matcher": "*",
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": targetFile,
+						},
+					},
+				})
+			}
+			hooks[event] = entries
+		}
+	} else {
+		for _, event := range events {
+			entries, _ := hooks[event].([]any)
+			hooks[event] = removeCommandEntries(entries, targetFile)
+		}
+	}
+
+	payload, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("serialize claude settings: %w", err)
+	}
+	return append(payload, '\n'), nil
+}
+
+func patchCodexConfig(configData []byte, targetFile string, install bool) ([]byte, error) {
+	notifyLine := fmt.Sprintf("notify = [\"%s\"]", targetFile)
+
+	if install {
+		out := notifyLine + "\n"
+		if len(configData) > 0 {
+			lines := strings.Split(string(configData), "\n")
+			replaced := false
+			for i, line := range lines {
+				if strings.HasPrefix(strings.TrimSpace(line), "notify") && strings.Contains(line, "=") {
+					lines[i] = notifyLine
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				if len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) != "" {
+					lines = append(lines, "")
+				}
+				lines = append(lines, notifyLine)
+			}
+			out = strings.Join(lines, "\n")
+			if !strings.HasSuffix(out, "\n") {
+				out += "\n"
+			}
+		}
+		return []byte(out), nil
+	}
+
+	// Uninstall: remove the notify line.
+	if len(configData) == 0 {
+		return configData, nil
+	}
+	lines := strings.Split(string(configData), "\n")
+	var filtered []string
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "notify") && strings.Contains(line, "=") {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	out := strings.Join(filtered, "\n")
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return []byte(out), nil
+}
+
+func patchOpenCodeConfig(configData []byte, targetFile string, install bool) ([]byte, error) {
+	cfg := map[string]any{
+		"$schema": "https://opencode.ai/config.json",
+	}
+	if len(bytes.TrimSpace(configData)) > 0 {
+		if err := json.Unmarshal(configData, &cfg); err != nil {
+			return nil, fmt.Errorf("parse opencode config: %w", err)
+		}
+	}
+
+	plugins := []string{}
+	if raw, ok := cfg["plugin"].([]any); ok {
+		for _, item := range raw {
+			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
+				plugins = append(plugins, text)
+			}
+		}
+	}
+
+	pluginURL := "file://" + targetFile
+
+	if install {
+		if !slices.Contains(plugins, pluginURL) {
+			plugins = append(plugins, pluginURL)
+		}
+	} else {
+		plugins = slices.DeleteFunc(plugins, func(s string) bool {
+			return s == pluginURL || strings.Contains(s, "openusage-telemetry.ts")
+		})
+	}
+	cfg["plugin"] = plugins
+
+	payload, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("serialize opencode config: %w", err)
+	}
+	return append(payload, '\n'), nil
+}
+
+// --- Detectors ---
+
+func detectClaudeCodeStatus(dirs Dirs) Status {
+	def := claudeCodeDef()
+	st := Status{
+		ID:             ClaudeCodeID,
+		Name:           def.Name,
+		DesiredVersion: IntegrationVersion,
+	}
+
+	hookFile := def.TargetFileFunc(dirs)
+	hookData, hookErr := os.ReadFile(hookFile)
+	st.Installed = hookErr == nil
+	st.InstalledVersion = parseIntegrationVersion(hookData)
+
+	configured := false
+	configFile := def.ConfigFileFunc(dirs)
+	if settingsData, err := os.ReadFile(configFile); err == nil {
+		var cfg map[string]any
+		if json.Unmarshal(settingsData, &cfg) == nil {
+			configured = hasCommandHook(cfg, "Stop", "claude-hook.sh") &&
+				hasCommandHook(cfg, "SubagentStop", "claude-hook.sh") &&
+				hasCommandHook(cfg, "PostToolUse", "claude-hook.sh")
+		}
+	}
+	st.Configured = configured
+	deriveState(&st)
+	return st
+}
+
+func detectCodexStatus(dirs Dirs) Status {
+	def := codexDef()
+	st := Status{
+		ID:             CodexID,
+		Name:           def.Name,
+		DesiredVersion: IntegrationVersion,
+	}
+
+	hookFile := def.TargetFileFunc(dirs)
+	hookData, hookErr := os.ReadFile(hookFile)
+	st.Installed = hookErr == nil
+	st.InstalledVersion = parseIntegrationVersion(hookData)
+
+	configured := false
+	configFile := def.ConfigFileFunc(dirs)
+	if cfgData, err := os.ReadFile(configFile); err == nil {
+		content := string(cfgData)
+		if strings.Contains(content, "notify") && strings.Contains(content, "codex-notify.sh") {
+			configured = true
+		}
+	}
+	st.Configured = configured
+	deriveState(&st)
+	return st
+}
+
+func detectOpenCodeStatus(dirs Dirs) Status {
+	def := opencodeDef()
+	st := Status{
+		ID:             OpenCodeID,
+		Name:           def.Name,
+		DesiredVersion: IntegrationVersion,
+	}
+
+	pluginFile := def.TargetFileFunc(dirs)
+	pluginData, pluginErr := os.ReadFile(pluginFile)
+	st.Installed = pluginErr == nil
+	st.InstalledVersion = parseIntegrationVersion(pluginData)
+
+	configured := false
+	configFile := def.ConfigFileFunc(dirs)
+	if configData, err := os.ReadFile(configFile); err == nil {
+		var cfg map[string]any
+		if json.Unmarshal(configData, &cfg) == nil {
+			if list, ok := cfg["plugin"].([]any); ok {
+				for _, item := range list {
+					text, ok := item.(string)
+					if !ok {
+						continue
+					}
+					if text == "file://"+pluginFile || strings.Contains(text, "openusage-telemetry.ts") {
+						configured = true
+						break
+					}
+				}
+			}
+		}
+	}
+	st.Configured = configured
+	deriveState(&st)
+	return st
+}
+
+// --- Helpers (shared) ---
+
+func removeCommandEntries(entries []any, command string) []any {
+	var filtered []any
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			filtered = append(filtered, entry)
+			continue
+		}
+		hooksList, ok := entryMap["hooks"].([]any)
+		if !ok {
+			filtered = append(filtered, entry)
+			continue
+		}
+		var remainingHooks []any
+		for _, hook := range hooksList {
+			hookMap, ok := hook.(map[string]any)
+			if !ok {
+				remainingHooks = append(remainingHooks, hook)
+				continue
+			}
+			if strings.TrimSpace(stringOrEmpty(hookMap["type"])) == "command" {
+				cmd := strings.TrimSpace(stringOrEmpty(hookMap["command"]))
+				if cmd == command || strings.Contains(cmd, filepath.Base(command)) {
+					continue
+				}
+			}
+			remainingHooks = append(remainingHooks, hook)
+		}
+		if len(remainingHooks) > 0 {
+			entryMap["hooks"] = remainingHooks
+			filtered = append(filtered, entryMap)
+		}
+	}
+	return filtered
+}

--- a/internal/integrations/installer.go
+++ b/internal/integrations/installer.go
@@ -1,0 +1,122 @@
+package integrations
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// InstallResult describes the outcome of an Install or Upgrade operation.
+type InstallResult struct {
+	ID           ID
+	Action       string // "installed", "upgraded", "already_current", "uninstalled"
+	TemplateFile string
+	ConfigFile   string
+	PreviousVer  string
+	InstalledVer string
+}
+
+// Install renders the integration template, writes it to disk, and patches
+// the target tool's config file to register the hook/plugin.
+func Install(def Definition, dirs Dirs) (InstallResult, error) {
+	targetFile := def.TargetFileFunc(dirs)
+	configFile := def.ConfigFileFunc(dirs)
+
+	// Determine previous version (if any) for the result action.
+	previousVer := ""
+	if data, err := os.ReadFile(targetFile); err == nil {
+		previousVer = parseIntegrationVersion(data)
+	}
+
+	// Create parent directories.
+	if err := os.MkdirAll(filepath.Dir(targetFile), 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("integrations: create target dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configFile), 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("integrations: create config dir: %w", err)
+	}
+
+	// Render template with version and binary placeholders.
+	content := strings.ReplaceAll(def.Template, "__OPENUSAGE_INTEGRATION_VERSION__", IntegrationVersion)
+	content = strings.ReplaceAll(content, "__OPENUSAGE_BIN_DEFAULT__", def.EscapeBin(dirs.OpenusageBin))
+
+	// Backup existing files before overwriting.
+	if err := backupIfExists(targetFile); err != nil {
+		return InstallResult{}, fmt.Errorf("integrations: backup target: %w", err)
+	}
+	if err := backupIfExists(configFile); err != nil {
+		return InstallResult{}, fmt.Errorf("integrations: backup config: %w", err)
+	}
+
+	// Write rendered template.
+	if err := os.WriteFile(targetFile, []byte(content), def.TemplateFileMode); err != nil {
+		return InstallResult{}, fmt.Errorf("integrations: write template: %w", err)
+	}
+
+	// Read config, patch it, write it back.
+	configData, err := os.ReadFile(configFile)
+	if err != nil && !os.IsNotExist(err) {
+		return InstallResult{}, fmt.Errorf("integrations: read config: %w", err)
+	}
+	patched, err := def.ConfigPatcher(configData, targetFile, true)
+	if err != nil {
+		return InstallResult{}, fmt.Errorf("integrations: patch config: %w", err)
+	}
+	if err := os.WriteFile(configFile, patched, 0o600); err != nil {
+		return InstallResult{}, fmt.Errorf("integrations: write config: %w", err)
+	}
+
+	action := "installed"
+	if previousVer != "" {
+		action = "upgraded"
+	}
+
+	return InstallResult{
+		ID:           def.ID,
+		Action:       action,
+		TemplateFile: targetFile,
+		ConfigFile:   configFile,
+		PreviousVer:  previousVer,
+		InstalledVer: IntegrationVersion,
+	}, nil
+}
+
+// Uninstall removes the integration's template file and patches the target
+// tool's config file to unregister the hook/plugin.
+func Uninstall(def Definition, dirs Dirs) error {
+	targetFile := def.TargetFileFunc(dirs)
+	configFile := def.ConfigFileFunc(dirs)
+
+	// Patch config to remove hook/plugin entries.
+	configData, err := os.ReadFile(configFile)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("integrations: read config for uninstall: %w", err)
+	}
+	if len(configData) > 0 {
+		patched, err := def.ConfigPatcher(configData, targetFile, false)
+		if err != nil {
+			return fmt.Errorf("integrations: unpatch config: %w", err)
+		}
+		if err := os.WriteFile(configFile, patched, 0o600); err != nil {
+			return fmt.Errorf("integrations: write config: %w", err)
+		}
+	}
+
+	// Remove the template file.
+	if err := os.Remove(targetFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("integrations: remove template: %w", err)
+	}
+
+	return nil
+}
+
+// Upgrade re-installs the integration, always reporting the action as "upgraded".
+func Upgrade(def Definition, dirs Dirs) (InstallResult, error) {
+	result, err := Install(def, dirs)
+	if err != nil {
+		return result, err
+	}
+	result.Action = "upgraded"
+	return result, nil
+}

--- a/internal/integrations/installer_test.go
+++ b/internal/integrations/installer_test.go
@@ -1,0 +1,500 @@
+package integrations
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testDirs(root string) Dirs {
+	return Dirs{
+		Home:         root,
+		ConfigRoot:   filepath.Join(root, ".config"),
+		HooksDir:     filepath.Join(root, ".config", "openusage", "hooks"),
+		OpenusageBin: "/usr/local/bin/openusage",
+	}
+}
+
+// --- Install tests ---
+
+func TestInstallClaudeCode(t *testing.T) {
+	root := t.TempDir()
+	dirs := testDirs(root)
+	def, ok := DefinitionByID(ClaudeCodeID)
+	if !ok {
+		t.Fatal("ClaudeCodeID definition not found")
+	}
+
+	result, err := Install(def, dirs)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if result.Action != "installed" {
+		t.Fatalf("result.Action = %q, want %q", result.Action, "installed")
+	}
+	if result.InstalledVer != IntegrationVersion {
+		t.Fatalf("result.InstalledVer = %q, want %q", result.InstalledVer, IntegrationVersion)
+	}
+
+	// Verify template file was created with version marker.
+	templateData, err := os.ReadFile(result.TemplateFile)
+	if err != nil {
+		t.Fatalf("read template file: %v", err)
+	}
+	templateStr := string(templateData)
+	if !strings.Contains(templateStr, "openusage-integration-version: "+IntegrationVersion) {
+		t.Fatalf("template missing version marker, got:\n%s", templateStr[:200])
+	}
+	if strings.Contains(templateStr, "__OPENUSAGE_INTEGRATION_VERSION__") {
+		t.Fatal("template still contains unreplaced version placeholder")
+	}
+	if strings.Contains(templateStr, "__OPENUSAGE_BIN_DEFAULT__") {
+		t.Fatal("template still contains unreplaced bin placeholder")
+	}
+	if !strings.Contains(templateStr, "/usr/local/bin/openusage") {
+		t.Fatal("template missing openusage bin path")
+	}
+
+	// Verify config was patched correctly.
+	configData, err := os.ReadFile(result.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(configData, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	hooks, ok := cfg["hooks"].(map[string]any)
+	if !ok {
+		t.Fatal("config missing hooks key")
+	}
+	for _, event := range []string{"Stop", "SubagentStop", "PostToolUse"} {
+		entries, ok := hooks[event].([]any)
+		if !ok || len(entries) == 0 {
+			t.Fatalf("config missing hook entries for %s", event)
+		}
+	}
+}
+
+func TestInstallCodex(t *testing.T) {
+	root := t.TempDir()
+	dirs := testDirs(root)
+	def, ok := DefinitionByID(CodexID)
+	if !ok {
+		t.Fatal("CodexID definition not found")
+	}
+
+	result, err := Install(def, dirs)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if result.Action != "installed" {
+		t.Fatalf("result.Action = %q, want %q", result.Action, "installed")
+	}
+
+	// Verify template.
+	templateData, err := os.ReadFile(result.TemplateFile)
+	if err != nil {
+		t.Fatalf("read template file: %v", err)
+	}
+	if !strings.Contains(string(templateData), "openusage-integration-version: "+IntegrationVersion) {
+		t.Fatal("template missing version marker")
+	}
+
+	// Verify config has notify line.
+	configData, err := os.ReadFile(result.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	configStr := string(configData)
+	if !strings.Contains(configStr, "notify") {
+		t.Fatal("config missing notify line")
+	}
+	if !strings.Contains(configStr, "codex-notify.sh") {
+		t.Fatal("config missing hook file reference")
+	}
+}
+
+func TestInstallOpenCode(t *testing.T) {
+	root := t.TempDir()
+	dirs := testDirs(root)
+	def, ok := DefinitionByID(OpenCodeID)
+	if !ok {
+		t.Fatal("OpenCodeID definition not found")
+	}
+
+	result, err := Install(def, dirs)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if result.Action != "installed" {
+		t.Fatalf("result.Action = %q, want %q", result.Action, "installed")
+	}
+
+	// Verify template.
+	templateData, err := os.ReadFile(result.TemplateFile)
+	if err != nil {
+		t.Fatalf("read template file: %v", err)
+	}
+	if !strings.Contains(string(templateData), "openusage-integration-version: "+IntegrationVersion) {
+		t.Fatal("template missing version marker")
+	}
+	if !strings.Contains(string(templateData), "/usr/local/bin/openusage") {
+		t.Fatal("template missing openusage bin path")
+	}
+
+	// Verify config has plugin entry.
+	configData, err := os.ReadFile(result.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(configData, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	list, ok := cfg["plugin"].([]any)
+	if !ok || len(list) == 0 {
+		t.Fatal("config missing plugin list")
+	}
+	wantURL := "file://" + result.TemplateFile
+	found := false
+	for _, item := range list {
+		text, _ := item.(string)
+		if text == wantURL {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("plugin list missing %q: %#v", wantURL, list)
+	}
+}
+
+// --- Uninstall tests ---
+
+func TestUninstallClaudeCode(t *testing.T) {
+	root := t.TempDir()
+	dirs := testDirs(root)
+	def, _ := DefinitionByID(ClaudeCodeID)
+
+	// Install first.
+	result, err := Install(def, dirs)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	// Uninstall.
+	if err := Uninstall(def, dirs); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+
+	// Template file should be gone.
+	if _, err := os.Stat(result.TemplateFile); !os.IsNotExist(err) {
+		t.Fatal("template file still exists after uninstall")
+	}
+
+	// Config should have hooks removed.
+	configData, err := os.ReadFile(result.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(configData, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	hooks, _ := cfg["hooks"].(map[string]any)
+	for _, event := range []string{"Stop", "SubagentStop", "PostToolUse"} {
+		entries, _ := hooks[event].([]any)
+		if len(entries) > 0 {
+			t.Fatalf("config still has hook entries for %s after uninstall", event)
+		}
+	}
+}
+
+func TestUninstallCodex(t *testing.T) {
+	root := t.TempDir()
+	dirs := testDirs(root)
+	def, _ := DefinitionByID(CodexID)
+
+	result, err := Install(def, dirs)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	if err := Uninstall(def, dirs); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+
+	if _, err := os.Stat(result.TemplateFile); !os.IsNotExist(err) {
+		t.Fatal("template file still exists after uninstall")
+	}
+
+	configData, err := os.ReadFile(result.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(configData), "notify") {
+		t.Fatal("config still has notify line after uninstall")
+	}
+}
+
+func TestUninstallOpenCode(t *testing.T) {
+	root := t.TempDir()
+	dirs := testDirs(root)
+	def, _ := DefinitionByID(OpenCodeID)
+
+	result, err := Install(def, dirs)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	if err := Uninstall(def, dirs); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+
+	if _, err := os.Stat(result.TemplateFile); !os.IsNotExist(err) {
+		t.Fatal("template file still exists after uninstall")
+	}
+
+	configData, err := os.ReadFile(result.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(configData, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	list, _ := cfg["plugin"].([]any)
+	if len(list) > 0 {
+		t.Fatalf("config still has plugins after uninstall: %#v", list)
+	}
+}
+
+// --- Idempotency tests ---
+
+func TestInstallIdempotent(t *testing.T) {
+	for _, id := range []ID{ClaudeCodeID, CodexID, OpenCodeID} {
+		t.Run(string(id), func(t *testing.T) {
+			root := t.TempDir()
+			dirs := testDirs(root)
+			def, ok := DefinitionByID(id)
+			if !ok {
+				t.Fatalf("definition not found for %s", id)
+			}
+
+			// Install twice.
+			result1, err := Install(def, dirs)
+			if err != nil {
+				t.Fatalf("first Install() error = %v", err)
+			}
+			result2, err := Install(def, dirs)
+			if err != nil {
+				t.Fatalf("second Install() error = %v", err)
+			}
+
+			// Second install sees existing version, so action is "upgraded".
+			if result2.Action != "upgraded" {
+				t.Fatalf("second result.Action = %q, want %q", result2.Action, "upgraded")
+			}
+
+			// Config should not have duplicate entries.
+			configData, err := os.ReadFile(result1.ConfigFile)
+			if err != nil {
+				t.Fatalf("read config: %v", err)
+			}
+
+			switch id {
+			case ClaudeCodeID:
+				var cfg map[string]any
+				if err := json.Unmarshal(configData, &cfg); err != nil {
+					t.Fatalf("parse config: %v", err)
+				}
+				hooks, _ := cfg["hooks"].(map[string]any)
+				for _, event := range []string{"Stop", "SubagentStop", "PostToolUse"} {
+					entries, _ := hooks[event].([]any)
+					if len(entries) != 1 {
+						t.Fatalf("expected 1 entry for %s, got %d", event, len(entries))
+					}
+				}
+			case CodexID:
+				// Count lines that start with "notify" key assignment.
+				notifyCount := 0
+				for _, line := range strings.Split(string(configData), "\n") {
+					trimmed := strings.TrimSpace(line)
+					if strings.HasPrefix(trimmed, "notify") && strings.Contains(trimmed, "=") {
+						notifyCount++
+					}
+				}
+				if notifyCount != 1 {
+					t.Fatalf("expected 1 notify key line, found %d in:\n%s", notifyCount, string(configData))
+				}
+			case OpenCodeID:
+				var cfg map[string]any
+				if err := json.Unmarshal(configData, &cfg); err != nil {
+					t.Fatalf("parse config: %v", err)
+				}
+				list, _ := cfg["plugin"].([]any)
+				if len(list) != 1 {
+					t.Fatalf("expected 1 plugin entry, got %d", len(list))
+				}
+			}
+		})
+	}
+}
+
+// --- E2E lifecycle test ---
+
+func TestLifecycle_InstallDetectUpgradeUninstall(t *testing.T) {
+	for _, id := range []ID{ClaudeCodeID, CodexID, OpenCodeID} {
+		t.Run(string(id), func(t *testing.T) {
+			root := t.TempDir()
+			dirs := testDirs(root)
+			def, ok := DefinitionByID(id)
+			if !ok {
+				t.Fatalf("definition not found for %s", id)
+			}
+
+			// Phase 1: Before install, status should be "missing".
+			st := def.Detector(dirs)
+			if st.State != "missing" {
+				t.Fatalf("before install: state = %q, want %q", st.State, "missing")
+			}
+			if st.Installed {
+				t.Fatal("before install: Installed should be false")
+			}
+
+			// Phase 2: Install.
+			result, err := Install(def, dirs)
+			if err != nil {
+				t.Fatalf("Install() error = %v", err)
+			}
+			if result.Action != "installed" {
+				t.Fatalf("Install action = %q, want %q", result.Action, "installed")
+			}
+
+			// Phase 3: After install, status should be "ready".
+			st = def.Detector(dirs)
+			if st.State != "ready" {
+				t.Fatalf("after install: state = %q, want %q", st.State, "ready")
+			}
+			if !st.Installed || !st.Configured {
+				t.Fatalf("after install: Installed=%v, Configured=%v", st.Installed, st.Configured)
+			}
+			if st.InstalledVersion != IntegrationVersion {
+				t.Fatalf("after install: version = %q, want %q", st.InstalledVersion, IntegrationVersion)
+			}
+			if st.NeedsUpgrade {
+				t.Fatal("after install: NeedsUpgrade should be false")
+			}
+
+			// Phase 4: Simulate old version → detect as outdated.
+			targetFile := def.TargetFileFunc(dirs)
+			oldContent, err := os.ReadFile(targetFile)
+			if err != nil {
+				t.Fatalf("read target: %v", err)
+			}
+			// Replace version marker with an old one.
+			oldStr := strings.ReplaceAll(string(oldContent),
+				"openusage-integration-version: "+IntegrationVersion,
+				"openusage-integration-version: 2020-01-01.0")
+			if err := os.WriteFile(targetFile, []byte(oldStr), def.TemplateFileMode); err != nil {
+				t.Fatalf("write old version: %v", err)
+			}
+			st = def.Detector(dirs)
+			if st.State != "outdated" {
+				t.Fatalf("after downgrade: state = %q, want %q", st.State, "outdated")
+			}
+			if !st.NeedsUpgrade {
+				t.Fatal("after downgrade: NeedsUpgrade should be true")
+			}
+
+			// Phase 5: Upgrade.
+			upgradeResult, err := Upgrade(def, dirs)
+			if err != nil {
+				t.Fatalf("Upgrade() error = %v", err)
+			}
+			if upgradeResult.Action != "upgraded" {
+				t.Fatalf("Upgrade action = %q, want %q", upgradeResult.Action, "upgraded")
+			}
+			if upgradeResult.PreviousVer != "2020-01-01.0" {
+				t.Fatalf("Upgrade PreviousVer = %q, want %q", upgradeResult.PreviousVer, "2020-01-01.0")
+			}
+
+			// Phase 6: After upgrade, status should be "ready" again.
+			st = def.Detector(dirs)
+			if st.State != "ready" {
+				t.Fatalf("after upgrade: state = %q, want %q", st.State, "ready")
+			}
+			if st.NeedsUpgrade {
+				t.Fatal("after upgrade: NeedsUpgrade should be false")
+			}
+
+			// Phase 7: Uninstall.
+			if err := Uninstall(def, dirs); err != nil {
+				t.Fatalf("Uninstall() error = %v", err)
+			}
+
+			// Phase 8: After uninstall, status should be "missing".
+			st = def.Detector(dirs)
+			if st.Installed {
+				t.Fatal("after uninstall: Installed should be false")
+			}
+			// Config file still exists (just patched), but template is gone.
+			if _, err := os.Stat(targetFile); !os.IsNotExist(err) {
+				t.Fatal("after uninstall: template file should not exist")
+			}
+		})
+	}
+}
+
+// --- Upgrade tests ---
+
+func TestUpgrade(t *testing.T) {
+	for _, id := range []ID{ClaudeCodeID, CodexID, OpenCodeID} {
+		t.Run(string(id), func(t *testing.T) {
+			root := t.TempDir()
+			dirs := testDirs(root)
+			def, ok := DefinitionByID(id)
+			if !ok {
+				t.Fatalf("definition not found for %s", id)
+			}
+
+			targetFile := def.TargetFileFunc(dirs)
+
+			// Seed an old version template file.
+			if err := os.MkdirAll(filepath.Dir(targetFile), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			oldContent := "# openusage-integration-version: 2025-01-01.0\nold content\n"
+			if err := os.WriteFile(targetFile, []byte(oldContent), def.TemplateFileMode); err != nil {
+				t.Fatalf("write old template: %v", err)
+			}
+
+			result, err := Upgrade(def, dirs)
+			if err != nil {
+				t.Fatalf("Upgrade() error = %v", err)
+			}
+			if result.Action != "upgraded" {
+				t.Fatalf("result.Action = %q, want %q", result.Action, "upgraded")
+			}
+			if result.PreviousVer != "2025-01-01.0" {
+				t.Fatalf("result.PreviousVer = %q, want %q", result.PreviousVer, "2025-01-01.0")
+			}
+			if result.InstalledVer != IntegrationVersion {
+				t.Fatalf("result.InstalledVer = %q, want %q", result.InstalledVer, IntegrationVersion)
+			}
+
+			// Verify new version is in the template.
+			templateData, err := os.ReadFile(targetFile)
+			if err != nil {
+				t.Fatalf("read template: %v", err)
+			}
+			ver := parseIntegrationVersion(templateData)
+			if ver != IntegrationVersion {
+				t.Fatalf("template version = %q, want %q", ver, IntegrationVersion)
+			}
+		})
+	}
+}

--- a/internal/integrations/manager.go
+++ b/internal/integrations/manager.go
@@ -1,14 +1,10 @@
 package integrations
 
 import (
-	"bytes"
-	_ "embed"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
 )
 
@@ -37,167 +33,30 @@ type Status struct {
 }
 
 type Manager struct {
-	openCodeConfigFile string
-	openCodePluginFile string
-	codexConfigFile    string
-	codexHookFile      string
-	claudeSettingsFile string
-	claudeHookFile     string
-	openusageBin       string
+	dirs Dirs
 }
 
 var integrationVersionRe = regexp.MustCompile(`openusage-integration-version:\s*([^\s]+)`)
 
-//go:embed assets/opencode-telemetry.ts.tpl
-var opencodeTemplate string
-
-//go:embed assets/codex-notify.sh.tpl
-var codexTemplate string
-
-//go:embed assets/claude-hook.sh.tpl
-var claudeTemplate string
-
 func NewDefaultManager() Manager {
-	home, _ := os.UserHomeDir()
-	configRoot := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME"))
-	if configRoot == "" {
-		configRoot = filepath.Join(home, ".config")
-	}
-
-	codexConfigDir := strings.TrimSpace(os.Getenv("CODEX_CONFIG_DIR"))
-	if codexConfigDir == "" {
-		codexConfigDir = filepath.Join(home, ".codex")
-	}
-
-	claudeSettingsFile := strings.TrimSpace(os.Getenv("CLAUDE_SETTINGS_FILE"))
-	if claudeSettingsFile == "" {
-		claudeSettingsFile = filepath.Join(home, ".claude", "settings.json")
-	}
-
-	openusageBin := strings.TrimSpace(os.Getenv("OPENUSAGE_BIN"))
-	if openusageBin == "" {
-		if exe, err := os.Executable(); err == nil {
-			openusageBin = exe
-		}
-	}
-	if openusageBin == "" {
-		openusageBin = "openusage"
-	}
-
-	hooksDir := filepath.Join(configRoot, "openusage", "hooks")
-	return Manager{
-		openCodeConfigFile: filepath.Join(configRoot, "opencode", "opencode.json"),
-		openCodePluginFile: filepath.Join(configRoot, "opencode", "plugins", "openusage-telemetry.ts"),
-		codexConfigFile:    filepath.Join(codexConfigDir, "config.toml"),
-		codexHookFile:      filepath.Join(hooksDir, "codex-notify.sh"),
-		claudeSettingsFile: claudeSettingsFile,
-		claudeHookFile:     filepath.Join(hooksDir, "claude-hook.sh"),
-		openusageBin:       openusageBin,
-	}
+	return Manager{dirs: NewDefaultDirs()}
 }
 
 func (m Manager) ListStatuses() []Status {
-	statuses := []Status{
-		m.detectOpenCode(),
-		m.detectCodex(),
-		m.detectClaudeCode(),
+	var statuses []Status
+	for _, def := range AllDefinitions() {
+		statuses = append(statuses, def.Detector(m.dirs))
 	}
 	return statuses
 }
 
 func (m Manager) Install(id ID) error {
-	switch id {
-	case OpenCodeID:
-		return m.installOpenCode()
-	case CodexID:
-		return m.installCodex()
-	case ClaudeCodeID:
-		return m.installClaudeCode()
-	default:
+	def, ok := DefinitionByID(id)
+	if !ok {
 		return fmt.Errorf("unknown integration id %q", id)
 	}
-}
-
-func (m Manager) detectOpenCode() Status {
-	st := Status{
-		ID:             OpenCodeID,
-		Name:           "OpenCode Plugin",
-		DesiredVersion: IntegrationVersion,
-	}
-
-	pluginData, pluginErr := os.ReadFile(m.openCodePluginFile)
-	st.Installed = pluginErr == nil
-	st.InstalledVersion = parseIntegrationVersion(pluginData)
-
-	configured := false
-	if configData, err := os.ReadFile(m.openCodeConfigFile); err == nil {
-		var cfg map[string]any
-		if json.Unmarshal(configData, &cfg) == nil {
-			if list, ok := cfg["plugin"].([]any); ok {
-				for _, item := range list {
-					text, ok := item.(string)
-					if !ok {
-						continue
-					}
-					if text == "file://"+m.openCodePluginFile || strings.Contains(text, "openusage-telemetry.ts") {
-						configured = true
-						break
-					}
-				}
-			}
-		}
-	}
-	st.Configured = configured
-	deriveState(&st)
-	return st
-}
-
-func (m Manager) detectCodex() Status {
-	st := Status{
-		ID:             CodexID,
-		Name:           "Codex Notify Hook",
-		DesiredVersion: IntegrationVersion,
-	}
-
-	hookData, hookErr := os.ReadFile(m.codexHookFile)
-	st.Installed = hookErr == nil
-	st.InstalledVersion = parseIntegrationVersion(hookData)
-
-	configured := false
-	if cfgData, err := os.ReadFile(m.codexConfigFile); err == nil {
-		cfg := string(cfgData)
-		if strings.Contains(cfg, "notify") && strings.Contains(cfg, "codex-notify.sh") {
-			configured = true
-		}
-	}
-	st.Configured = configured
-	deriveState(&st)
-	return st
-}
-
-func (m Manager) detectClaudeCode() Status {
-	st := Status{
-		ID:             ClaudeCodeID,
-		Name:           "Claude Code Hooks",
-		DesiredVersion: IntegrationVersion,
-	}
-
-	hookData, hookErr := os.ReadFile(m.claudeHookFile)
-	st.Installed = hookErr == nil
-	st.InstalledVersion = parseIntegrationVersion(hookData)
-
-	configured := false
-	if settingsData, err := os.ReadFile(m.claudeSettingsFile); err == nil {
-		var cfg map[string]any
-		if json.Unmarshal(settingsData, &cfg) == nil {
-			configured = hasCommandHook(cfg, "Stop", "claude-hook.sh") &&
-				hasCommandHook(cfg, "SubagentStop", "claude-hook.sh") &&
-				hasCommandHook(cfg, "PostToolUse", "claude-hook.sh")
-		}
-	}
-	st.Configured = configured
-	deriveState(&st)
-	return st
+	_, err := Install(def, m.dirs)
+	return err
 }
 
 func deriveState(st *Status) {
@@ -276,170 +135,6 @@ func stringOrEmpty(value any) string {
 	return text
 }
 
-func (m Manager) installOpenCode() error {
-	if err := os.MkdirAll(filepath.Dir(m.openCodePluginFile), 0o755); err != nil {
-		return fmt.Errorf("create opencode plugin dir: %w", err)
-	}
-	if err := m.writeVersionedTemplate(
-		opencodeTemplate,
-		m.openCodePluginFile,
-		m.openusageBin,
-		escapeForTSString,
-		0o644,
-	); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(m.openCodeConfigFile), 0o755); err != nil {
-		return fmt.Errorf("create opencode config dir: %w", err)
-	}
-
-	cfg := map[string]any{
-		"$schema": "https://opencode.ai/config.json",
-	}
-	if data, err := os.ReadFile(m.openCodeConfigFile); err == nil && len(bytes.TrimSpace(data)) > 0 {
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			return fmt.Errorf("parse opencode config: %w", err)
-		}
-	}
-
-	plugins := []string{}
-	if raw, ok := cfg["plugin"].([]any); ok {
-		for _, item := range raw {
-			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
-				plugins = append(plugins, text)
-			}
-		}
-	}
-	pluginURL := "file://" + m.openCodePluginFile
-	if !slices.Contains(plugins, pluginURL) {
-		plugins = append(plugins, pluginURL)
-	}
-	cfg["plugin"] = plugins
-
-	payload, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		return fmt.Errorf("serialize opencode config: %w", err)
-	}
-	payload = append(payload, '\n')
-	if err := backupIfExists(m.openCodeConfigFile); err != nil {
-		return err
-	}
-	if err := os.WriteFile(m.openCodeConfigFile, payload, 0o600); err != nil {
-		return fmt.Errorf("write opencode config: %w", err)
-	}
-	return nil
-}
-
-func (m Manager) installCodex() error {
-	if err := os.MkdirAll(filepath.Dir(m.codexHookFile), 0o755); err != nil {
-		return fmt.Errorf("create codex hook dir: %w", err)
-	}
-	if err := m.writeVersionedTemplate(
-		codexTemplate,
-		m.codexHookFile,
-		m.openusageBin,
-		escapeForShellString,
-		0o755,
-	); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(m.codexConfigFile), 0o755); err != nil {
-		return fmt.Errorf("create codex config dir: %w", err)
-	}
-	if err := backupIfExists(m.codexConfigFile); err != nil {
-		return err
-	}
-
-	notifyLine := fmt.Sprintf("notify = [\"%s\"]", m.codexHookFile)
-	out := notifyLine + "\n"
-	if data, err := os.ReadFile(m.codexConfigFile); err == nil {
-		lines := strings.Split(string(data), "\n")
-		replaced := false
-		for i, line := range lines {
-			if strings.HasPrefix(strings.TrimSpace(line), "notify") && strings.Contains(line, "=") {
-				lines[i] = notifyLine
-				replaced = true
-				break
-			}
-		}
-		if !replaced {
-			if len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) != "" {
-				lines = append(lines, "")
-			}
-			lines = append(lines, notifyLine)
-		}
-		out = strings.Join(lines, "\n")
-		if !strings.HasSuffix(out, "\n") {
-			out += "\n"
-		}
-	}
-
-	if err := os.WriteFile(m.codexConfigFile, []byte(out), 0o600); err != nil {
-		return fmt.Errorf("write codex config: %w", err)
-	}
-	return nil
-}
-
-func (m Manager) installClaudeCode() error {
-	if err := os.MkdirAll(filepath.Dir(m.claudeHookFile), 0o755); err != nil {
-		return fmt.Errorf("create claude hook dir: %w", err)
-	}
-	if err := m.writeVersionedTemplate(
-		claudeTemplate,
-		m.claudeHookFile,
-		m.openusageBin,
-		escapeForShellString,
-		0o755,
-	); err != nil {
-		return err
-	}
-
-	if err := os.MkdirAll(filepath.Dir(m.claudeSettingsFile), 0o755); err != nil {
-		return fmt.Errorf("create claude settings dir: %w", err)
-	}
-	if err := backupIfExists(m.claudeSettingsFile); err != nil {
-		return err
-	}
-
-	cfg := map[string]any{}
-	if data, err := os.ReadFile(m.claudeSettingsFile); err == nil && len(bytes.TrimSpace(data)) > 0 {
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			return fmt.Errorf("parse claude settings: %w", err)
-		}
-	}
-	hooks, _ := cfg["hooks"].(map[string]any)
-	if hooks == nil {
-		hooks = map[string]any{}
-	}
-	cfg["hooks"] = hooks
-
-	for _, event := range []string{"Stop", "SubagentStop", "PostToolUse"} {
-		entries, _ := hooks[event].([]any)
-		if !entriesContainCommand(entries, m.claudeHookFile) {
-			entries = append(entries, map[string]any{
-				"matcher": "*",
-				"hooks": []any{
-					map[string]any{
-						"type":    "command",
-						"command": m.claudeHookFile,
-					},
-				},
-			})
-		}
-		hooks[event] = entries
-	}
-
-	payload, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		return fmt.Errorf("serialize claude settings: %w", err)
-	}
-	payload = append(payload, '\n')
-	if err := os.WriteFile(m.claudeSettingsFile, payload, 0o600); err != nil {
-		return fmt.Errorf("write claude settings: %w", err)
-	}
-	return nil
-}
-
 func entriesContainCommand(entries []any, command string) bool {
 	for _, entry := range entries {
 		entryMap, ok := entry.(map[string]any)
@@ -465,19 +160,6 @@ func entriesContainCommand(entries []any, command string) bool {
 		}
 	}
 	return false
-}
-
-func (m Manager) writeVersionedTemplate(
-	templateBody, targetPath, openusageBin string,
-	escapeBin func(string) string,
-	mode os.FileMode,
-) error {
-	content := strings.ReplaceAll(templateBody, "__OPENUSAGE_INTEGRATION_VERSION__", IntegrationVersion)
-	content = strings.ReplaceAll(content, "__OPENUSAGE_BIN_DEFAULT__", escapeBin(openusageBin))
-	if err := os.WriteFile(targetPath, []byte(content), mode); err != nil {
-		return fmt.Errorf("write integration file %s: %w", targetPath, err)
-	}
-	return nil
 }
 
 func escapeForShellString(value string) string {

--- a/internal/integrations/match.go
+++ b/internal/integrations/match.go
@@ -1,0 +1,63 @@
+package integrations
+
+import (
+	"strings"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/janekbaraniewski/openusage/internal/detect"
+)
+
+// Match pairs an integration Definition with auto-detection results.
+type Match struct {
+	Definition Definition
+	Tool       *detect.DetectedTool
+	Account    *core.AccountConfig
+	Status     Status
+	Actionable bool // true if tool/account detected AND not installed
+}
+
+// MatchDetected matches integration definitions against auto-detection results.
+// Uses Definition.MatchProviderIDs to find matching accounts (stable join key).
+// Uses Definition.MatchToolNameHint to find the corresponding DetectedTool (display only).
+func MatchDetected(defs []Definition, detected detect.Result, dirs Dirs) []Match {
+	matches := make([]Match, 0, len(defs))
+
+	for _, def := range defs {
+		m := Match{
+			Definition: def,
+			Status:     def.Detector(dirs),
+		}
+
+		// Match accounts by provider ID.
+		for i := range detected.Accounts {
+			acct := &detected.Accounts[i]
+			for _, pid := range def.MatchProviderIDs {
+				if acct.Provider == pid {
+					m.Account = acct
+					break
+				}
+			}
+			if m.Account != nil {
+				break
+			}
+		}
+
+		// Match tools by name hint substring.
+		if def.MatchToolNameHint != "" {
+			hint := strings.ToLower(def.MatchToolNameHint)
+			for i := range detected.Tools {
+				tool := &detected.Tools[i]
+				if strings.Contains(strings.ToLower(tool.Name), hint) {
+					m.Tool = tool
+					break
+				}
+			}
+		}
+
+		m.Actionable = (m.Account != nil || m.Tool != nil) && m.Status.State != "ready"
+
+		matches = append(matches, m)
+	}
+
+	return matches
+}

--- a/internal/integrations/match_test.go
+++ b/internal/integrations/match_test.go
@@ -1,0 +1,282 @@
+package integrations
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/janekbaraniewski/openusage/internal/detect"
+)
+
+func TestMatchDetected_AccountsByProviderID(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirs := Dirs{
+		Home:         tmpDir,
+		ConfigRoot:   filepath.Join(tmpDir, ".config"),
+		HooksDir:     filepath.Join(tmpDir, ".config", "openusage", "hooks"),
+		OpenusageBin: "/usr/local/bin/openusage",
+	}
+
+	detected := detect.Result{
+		Tools: []detect.DetectedTool{
+			{Name: "Claude Code CLI", BinaryPath: "/usr/bin/claude", Type: "cli"},
+			{Name: "OpenAI Codex CLI", BinaryPath: "/usr/bin/codex", Type: "cli"},
+		},
+		Accounts: []core.AccountConfig{
+			{ID: "claude_code", Provider: "claude_code"},
+			{ID: "codex", Provider: "codex"},
+			{ID: "opencode", Provider: "opencode"},
+		},
+	}
+
+	defs := AllDefinitions()
+	matches := MatchDetected(defs, detected, dirs)
+
+	if len(matches) != len(defs) {
+		t.Fatalf("expected %d matches (one per definition), got %d", len(defs), len(matches))
+	}
+
+	for _, m := range matches {
+		switch m.Definition.ID {
+		case ClaudeCodeID:
+			if m.Account == nil || m.Account.Provider != "claude_code" {
+				t.Errorf("claude_code: expected account with Provider=claude_code, got %v", m.Account)
+			}
+		case CodexID:
+			if m.Account == nil || m.Account.Provider != "codex" {
+				t.Errorf("codex: expected account with Provider=codex, got %v", m.Account)
+			}
+		case OpenCodeID:
+			if m.Account == nil || m.Account.Provider != "opencode" {
+				t.Errorf("opencode: expected account with Provider=opencode, got %v", m.Account)
+			}
+		}
+	}
+}
+
+func TestMatchDetected_OpenCodeNoTool(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirs := Dirs{
+		Home:         tmpDir,
+		ConfigRoot:   filepath.Join(tmpDir, ".config"),
+		HooksDir:     filepath.Join(tmpDir, ".config", "openusage", "hooks"),
+		OpenusageBin: "/usr/local/bin/openusage",
+	}
+
+	detected := detect.Result{
+		Accounts: []core.AccountConfig{
+			{ID: "opencode", Provider: "opencode"},
+		},
+	}
+
+	defs := AllDefinitions()
+	matches := MatchDetected(defs, detected, dirs)
+
+	var ocMatch *Match
+	for i := range matches {
+		if matches[i].Definition.ID == OpenCodeID {
+			ocMatch = &matches[i]
+			break
+		}
+	}
+	if ocMatch == nil {
+		t.Fatal("expected a match for OpenCode definition")
+	}
+
+	if ocMatch.Tool != nil {
+		t.Errorf("expected Tool to be nil for OpenCode (no DetectedTool), got %+v", ocMatch.Tool)
+	}
+	if ocMatch.Account == nil {
+		t.Fatal("expected Account to be set for OpenCode")
+	}
+	if ocMatch.Account.Provider != "opencode" {
+		t.Errorf("expected Account.Provider=opencode, got %s", ocMatch.Account.Provider)
+	}
+	// Not installed, so should be actionable.
+	if !ocMatch.Actionable {
+		t.Error("expected Actionable=true for OpenCode with account detected and integration missing")
+	}
+}
+
+func TestMatchDetected_UnmatchedAccountNoExtraMatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirs := Dirs{
+		Home:         tmpDir,
+		ConfigRoot:   filepath.Join(tmpDir, ".config"),
+		HooksDir:     filepath.Join(tmpDir, ".config", "openusage", "hooks"),
+		OpenusageBin: "/usr/local/bin/openusage",
+	}
+
+	detected := detect.Result{
+		Accounts: []core.AccountConfig{
+			{ID: "openai", Provider: "openai"},
+		},
+	}
+
+	defs := AllDefinitions()
+	matches := MatchDetected(defs, detected, dirs)
+
+	if len(matches) != len(defs) {
+		t.Fatalf("expected exactly %d matches (one per definition), got %d", len(defs), len(matches))
+	}
+
+	for _, m := range matches {
+		if m.Account != nil {
+			t.Errorf("definition %s: expected no account match for Provider=openai, got %+v", m.Definition.ID, m.Account)
+		}
+		if m.Actionable {
+			t.Errorf("definition %s: expected Actionable=false when no account or tool matched", m.Definition.ID)
+		}
+	}
+}
+
+func TestMatchDetected_InstalledIntegrationNotActionable(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirs := Dirs{
+		Home:         tmpDir,
+		ConfigRoot:   filepath.Join(tmpDir, ".config"),
+		HooksDir:     filepath.Join(tmpDir, ".config", "openusage", "hooks"),
+		OpenusageBin: "/usr/local/bin/openusage",
+	}
+
+	// Create the claude hook file with correct version to make it "installed".
+	hookDir := filepath.Join(dirs.HooksDir)
+	if err := os.MkdirAll(hookDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hookContent := "#!/bin/bash\n# OPENUSAGE_INTEGRATION_VERSION=" + IntegrationVersion + "\n"
+	hookFile := filepath.Join(hookDir, "claude-hook.sh")
+	if err := os.WriteFile(hookFile, []byte(hookContent), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the claude settings file with hooks configured.
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := map[string]any{
+		"hooks": map[string]any{
+			"Stop": []any{
+				map[string]any{
+					"matcher": "*",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": hookFile},
+					},
+				},
+			},
+			"SubagentStop": []any{
+				map[string]any{
+					"matcher": "*",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": hookFile},
+					},
+				},
+			},
+			"PostToolUse": []any{
+				map[string]any{
+					"matcher": "*",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": hookFile},
+					},
+				},
+			},
+		},
+	}
+
+	// We need to use the correct settings file path. The claude detector uses
+	// ConfigFileFunc which checks CLAUDE_SETTINGS_FILE env, then falls back to
+	// ~/.claude/settings.json
+	settingsFile := filepath.Join(claudeDir, "settings.json")
+	settingsData, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsFile, settingsData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	detected := detect.Result{
+		Tools: []detect.DetectedTool{
+			{Name: "Claude Code CLI", BinaryPath: "/usr/bin/claude", Type: "cli"},
+		},
+		Accounts: []core.AccountConfig{
+			{ID: "claude_code", Provider: "claude_code"},
+		},
+	}
+
+	defs := AllDefinitions()
+	matches := MatchDetected(defs, detected, dirs)
+
+	var claudeMatch *Match
+	for i := range matches {
+		if matches[i].Definition.ID == ClaudeCodeID {
+			claudeMatch = &matches[i]
+			break
+		}
+	}
+	if claudeMatch == nil {
+		t.Fatal("expected a match for Claude Code definition")
+	}
+
+	if claudeMatch.Status.State != "ready" {
+		t.Errorf("expected status State=ready, got %q", claudeMatch.Status.State)
+	}
+	if claudeMatch.Actionable {
+		t.Error("expected Actionable=false when integration is already installed (state=ready)")
+	}
+	if claudeMatch.Account == nil {
+		t.Error("expected Account to still be matched even when installed")
+	}
+	if claudeMatch.Tool == nil {
+		t.Error("expected Tool to still be matched even when installed")
+	}
+}
+
+func TestMatchDetected_ToolNameMatching(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirs := Dirs{
+		Home:         tmpDir,
+		ConfigRoot:   filepath.Join(tmpDir, ".config"),
+		HooksDir:     filepath.Join(tmpDir, ".config", "openusage", "hooks"),
+		OpenusageBin: "/usr/local/bin/openusage",
+	}
+
+	detected := detect.Result{
+		Tools: []detect.DetectedTool{
+			{Name: "Claude Code CLI", BinaryPath: "/usr/bin/claude", Type: "cli"},
+			{Name: "OpenAI Codex CLI", BinaryPath: "/usr/bin/codex", Type: "cli"},
+			{Name: "Unrelated Tool", BinaryPath: "/usr/bin/other", Type: "cli"},
+		},
+	}
+
+	defs := AllDefinitions()
+	matches := MatchDetected(defs, detected, dirs)
+
+	for _, m := range matches {
+		switch m.Definition.ID {
+		case ClaudeCodeID:
+			// MatchToolNameHint is "Claude Code", tool Name is "Claude Code CLI"
+			if m.Tool == nil {
+				t.Error("claude_code: expected tool match for 'Claude Code CLI' with hint 'Claude Code'")
+			} else if !strings.Contains(m.Tool.Name, "Claude Code") {
+				t.Errorf("claude_code: expected tool name containing 'Claude Code', got %q", m.Tool.Name)
+			}
+		case CodexID:
+			// MatchToolNameHint is "Codex", tool Name is "OpenAI Codex CLI"
+			if m.Tool == nil {
+				t.Error("codex: expected tool match for 'OpenAI Codex CLI' with hint 'Codex'")
+			} else if !strings.Contains(m.Tool.Name, "Codex") {
+				t.Errorf("codex: expected tool name containing 'Codex', got %q", m.Tool.Name)
+			}
+		case OpenCodeID:
+			// MatchToolNameHint is "", so no tool match expected
+			if m.Tool != nil {
+				t.Errorf("opencode: expected no tool match (empty hint), got %+v", m.Tool)
+			}
+		}
+	}
+}

--- a/internal/integrations/registry.go
+++ b/internal/integrations/registry.go
@@ -1,0 +1,103 @@
+package integrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// IntegrationType distinguishes hook scripts from plugins.
+type IntegrationType string
+
+const (
+	TypeHookScript IntegrationType = "hook_script"
+	TypePlugin     IntegrationType = "plugin"
+)
+
+// ConfigFormat describes the format of the target tool's config file.
+type ConfigFormat string
+
+const (
+	ConfigJSON ConfigFormat = "json"
+	ConfigTOML ConfigFormat = "toml"
+)
+
+// ConfigPatchFunc patches a tool's config file to register or unregister
+// an integration. When install is true, the hook/plugin entry is added;
+// when false, it is removed. configData is the raw file content,
+// targetFile is the path to the installed hook/plugin file.
+type ConfigPatchFunc func(configData []byte, targetFile string, install bool) ([]byte, error)
+
+// DetectFunc checks whether the integration is installed and configured.
+type DetectFunc func(dirs Dirs) Status
+
+// Definition is the complete, self-contained description of one built-in integration.
+type Definition struct {
+	ID          ID
+	Name        string
+	Description string
+	Type        IntegrationType
+	Template    string // embedded template content
+
+	// TargetFileFunc returns the absolute path where the rendered template is written.
+	TargetFileFunc func(dirs Dirs) string
+
+	// ConfigFileFunc returns the absolute path to the target tool's config file.
+	// Implementations must check tool-specific env var overrides internally
+	// (e.g., CODEX_CONFIG_DIR, CLAUDE_SETTINGS_FILE).
+	ConfigFileFunc func(dirs Dirs) string
+	ConfigFormat   ConfigFormat
+	ConfigPatcher  ConfigPatchFunc
+
+	Detector DetectFunc
+
+	// MatchProviderIDs lists provider IDs from detect.Result.Accounts that
+	// correspond to this integration. This is the stable join key for
+	// matching auto-detected accounts to integration definitions.
+	MatchProviderIDs []string
+
+	// MatchToolNameHint is a substring to match against detect.DetectedTool.Name
+	// for associating a detected tool entry with this integration. Empty means
+	// no tool matching (env-key-only providers like OpenCode).
+	MatchToolNameHint string
+
+	// TemplateFileMode is the file permission for the rendered template file.
+	TemplateFileMode os.FileMode
+
+	// EscapeBin transforms the openusage binary path for template substitution.
+	EscapeBin func(string) string
+}
+
+// Dirs holds resolved filesystem paths shared across all integrations.
+type Dirs struct {
+	Home         string
+	ConfigRoot   string // XDG_CONFIG_HOME or ~/.config
+	HooksDir     string // ~/.config/openusage/hooks
+	OpenusageBin string // resolved binary path
+}
+
+// NewDefaultDirs resolves Dirs from environment variables and platform defaults.
+func NewDefaultDirs() Dirs {
+	home, _ := os.UserHomeDir()
+	configRoot := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME"))
+	if configRoot == "" {
+		configRoot = filepath.Join(home, ".config")
+	}
+
+	openusageBin := strings.TrimSpace(os.Getenv("OPENUSAGE_BIN"))
+	if openusageBin == "" {
+		if exe, err := os.Executable(); err == nil {
+			openusageBin = exe
+		}
+	}
+	if openusageBin == "" {
+		openusageBin = "openusage"
+	}
+
+	return Dirs{
+		Home:         home,
+		ConfigRoot:   configRoot,
+		HooksDir:     filepath.Join(configRoot, "openusage", "hooks"),
+		OpenusageBin: openusageBin,
+	}
+}

--- a/scripts/sync-tool-configs.sh
+++ b/scripts/sync-tool-configs.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+#
+# sync-tool-configs.sh — Generate all AI tool config files from the canonical template.
+#
+# Source of truth:
+#   docs/skills/tool-configs/template.md    (layout)
+#   docs/skills/tool-configs/skills-table.md (skills table rows)
+#
+# Generated files:
+#   .continuerules
+#   .windsurfrules
+#   .github/copilot-instructions.md
+#   .aider/conventions.md
+#   .opencode/skills/*/SKILL.md (skill stubs)
+#   .claude/commands/*.md (command stubs)
+#
+# Usage:
+#   ./scripts/sync-tool-configs.sh          # from repo root
+#   make sync-tools                         # via Makefile
+
+set -eo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="$REPO_ROOT/docs/skills/tool-configs/template.md"
+SKILLS_TABLE="$REPO_ROOT/docs/skills/tool-configs/skills-table.md"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "Error: Template not found at $TEMPLATE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SKILLS_TABLE" ]]; then
+  echo "Error: Skills table not found at $SKILLS_TABLE" >&2
+  exit 1
+fi
+
+# generate_config <title> <output_file>
+generate_config() {
+  local title="$1"
+  local output="$2"
+
+  mkdir -p "$(dirname "$output")"
+
+  sed \
+    -e "s|{{TOOL_TITLE}}|$title|g" \
+    -e "/{{SKILLS_TABLE}}/{
+      r $SKILLS_TABLE
+      d
+    }" \
+    "$TEMPLATE" > "$output"
+
+  echo "  Generated: $output"
+}
+
+# skill_description <skill-name>
+# Returns a short description for each skill
+skill_description() {
+  case "$1" in
+    add-new-provider)       echo "Add a new AI provider to the dashboard" ;;
+    design-feature)         echo "Design a feature: quiz, explore codebase, write design doc with tasks" ;;
+    develop-feature)        echo "Develop a feature end-to-end from design to pull request" ;;
+    finalize-feature)       echo "Finalize a feature: create branch, commit, open PR" ;;
+    implement-feature)      echo "Implement a feature from its design doc with tests" ;;
+    iterate-feature)        echo "Iterate on a feature to fix issues and address feedback" ;;
+    review-design)          echo "Review a design doc against the codebase" ;;
+    validate-feature)       echo "Validate a feature implementation: build, tests, compliance, quality" ;;
+    dev-workflow-improvements) echo "Audit and improve the development workflow, sync tool configs" ;;
+    *)                      echo "Run the $1 skill" ;;
+  esac
+}
+
+# title_case <hyphenated-string>
+# Converts "design-feature" to "Design Feature"
+title_case() {
+  echo "$1" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1'
+}
+
+echo "Syncing tool configs from template..."
+echo ""
+
+# Generate each tool config
+generate_config "Continue.dev Rules"          "$REPO_ROOT/.continuerules"
+generate_config "Windsurf Rules"              "$REPO_ROOT/.windsurfrules"
+generate_config "GitHub Copilot Instructions" "$REPO_ROOT/.github/copilot-instructions.md"
+generate_config "Aider Conventions"           "$REPO_ROOT/.aider/conventions.md"
+
+# --- OpenCode skill stubs ---
+echo ""
+echo "Syncing OpenCode skill stubs..."
+
+SKILLS_DIR="$REPO_ROOT/docs/skills"
+OPENCODE_DIR="$REPO_ROOT/.opencode/skills"
+
+for skill_dir in "$SKILLS_DIR"/*/; do
+  skill_name=$(basename "$skill_dir")
+
+  # Skip directories without a SKILL.md
+  if [[ ! -f "$skill_dir/SKILL.md" ]]; then
+    continue
+  fi
+
+  desc=$(skill_description "$skill_name")
+  pretty_name=$(title_case "$skill_name")
+  target_dir="$OPENCODE_DIR/$skill_name"
+  target_file="$target_dir/SKILL.md"
+
+  mkdir -p "$target_dir"
+
+  cat > "$target_file" <<EOF
+# Skill: $pretty_name
+
+> **Invocation**: $desc
+
+Read and follow the full skill specification in \`docs/skills/$skill_name/SKILL.md\`.
+EOF
+
+  echo "  Generated: $target_file"
+done
+
+# --- Claude Code command stubs ---
+echo ""
+echo "Syncing Claude Code command stubs..."
+
+CLAUDE_CMD_DIR="$REPO_ROOT/.claude/commands"
+mkdir -p "$CLAUDE_CMD_DIR"
+
+# claude_command_content <skill-name>
+# Returns the full content for a Claude command stub
+claude_command_content() {
+  case "$1" in
+    design-feature)
+      cat <<'CMDEOF'
+Design a new feature "$ARGUMENTS" for the OpenUsage TUI dashboard.
+
+Read and follow the full skill specification in docs/skills/design-feature/SKILL.md.
+
+Follow all phases in order:
+
+1. **Phase 0 — Quiz**: Ask me all 8 questions from the skill doc before doing any design work. If I provided the feature name as "$ARGUMENTS", use that as the starting point but still confirm details. Research the codebase yourself if I don't know an answer.
+
+2. **Phase 1 — Explore**: Read the subsystem map in docs/skills/design-feature/references/subsystem-map.md, then read the primary files for every affected subsystem. Read any overlapping design docs in docs/. Summarize what you learned that affects the design.
+
+3. **Phase 2 — Design**: Write the design doc to docs/<FEATURE_NAME>_DESIGN.md following the template in docs/skills/design-feature/references/design-template.md. Keep it simple — no unnecessary abstractions.
+
+4. **Phase 3 — Tasks**: Break the design into concrete, ordered implementation tasks with specific files and tests. Append to the design doc.
+
+Complete the full checklist at the end of the skill doc before finishing.
+CMDEOF
+      ;;
+    develop-feature)
+      cat <<'CMDEOF'
+Develop the feature "$ARGUMENTS" end-to-end — from design to pull request.
+
+Read and follow the full skill specification in docs/skills/develop-feature/SKILL.md.
+
+This skill orchestrates the full development lifecycle:
+
+1. **Phase 0 — Intake**: Check for existing design doc. Ask: full lifecycle or specific phase?
+
+2. **Phase 1 — Design** (`/design-feature`): Design the feature, produce design doc with tasks.
+
+3. **Phase 2 — Review** (`/review-design`): Validate design against codebase, fix discrepancies.
+
+4. **Phase 3 — Implement** (`/implement-feature`): Execute tasks with tests, parallel where possible.
+
+5. **Phase 4 — Validate** (`/validate-feature`): Build, test, design compliance, code quality checks.
+
+6. **Phase 5 — Iterate** (`/iterate-feature`): Fix issues from validation (loops until clean or user decides).
+
+7. **Phase 6 — Finalize** (`/finalize-feature`): Create branch, commit, open PR.
+
+8. **Phase 7 — Summary**: Report full lifecycle results.
+
+Each phase pauses for user confirmation before proceeding to the next.
+CMDEOF
+      ;;
+    implement-feature)
+      cat <<'CMDEOF'
+Implement the feature "$ARGUMENTS" from its design doc.
+
+Read and follow the full skill specification in docs/skills/implement-feature/SKILL.md.
+
+Follow all phases in order:
+
+1. **Phase 0 — Load**: Read the design doc, extract tasks and scope.
+2. **Phase 1 — Codebase Analysis**: Read affected files, note patterns.
+3. **Phase 1.5 — Pre-Implementation Quiz**: Surface ambiguities.
+4. **Phase 2 — Execution Plan**: Present tasks with approaches and risks.
+5. **Phase 3 — Implement**: Execute tasks in dependency order with tests.
+6. **Phase 4 — Integration Check**: Build, test, verify.
+7. **Phase 5 — Summary**: Report changes and status.
+CMDEOF
+      ;;
+    review-design)
+      cat <<'CMDEOF'
+Review the design doc for "$ARGUMENTS" against the current codebase.
+
+Read and follow the full skill specification in docs/skills/review-design/SKILL.md.
+
+Follow all phases:
+
+1. **Phase 0 — Load**: Find and read the design doc.
+2. **Phase 1 — Audit**: Read primary files for each subsystem, build discrepancy list.
+3. **Phase 2 — Quiz Loop**: Present issues, apply resolutions, re-scan until clean.
+4. **Phase 3 — Verify**: Confirm tasks reference valid files and types.
+CMDEOF
+      ;;
+    validate-feature)
+      cat <<'CMDEOF'
+Validate the feature "$ARGUMENTS" implementation.
+
+Read and follow the full skill specification in docs/skills/validate-feature/SKILL.md.
+
+Follow all phases:
+
+1. **Phase 0 — Load**: Find design doc, extract tasks, get changed files.
+2. **Phase 1 — Build**: `make build`, `make vet`, `make fmt`, `make lint`.
+3. **Phase 2 — Tests**: Run tests for changed packages.
+4. **Phase 3 — Compliance**: Cross-reference design tasks vs actual changes.
+5. **Phase 4 — Quality**: Scan for debug artifacts, unused code, secrets.
+6. **Phase 5 — Smoke Test**: Final build and combined tests.
+7. **Phase 6 — Report**: Verdict: READY FOR REVIEW or NEEDS ITERATION.
+CMDEOF
+      ;;
+    iterate-feature)
+      cat <<'CMDEOF'
+Iterate on the feature "$ARGUMENTS" to fix issues and address feedback.
+
+Read and follow the full skill specification in docs/skills/iterate-feature/SKILL.md.
+
+Follow all phases:
+
+1. **Phase 0 — Load**: Find design doc, gather feedback.
+2. **Phase 1 — Triage**: Categorize issues by priority.
+3. **Phase 2 — Plan**: Identify files and approach for each fix.
+4. **Phase 3 — Execute**: Fix, test, verify each issue.
+5. **Phase 4 — Re-validate**: Build, test, check compliance.
+6. **Phase 5 — Summary**: Report fixes and verdict.
+CMDEOF
+      ;;
+    finalize-feature)
+      cat <<'CMDEOF'
+Finalize the feature "$ARGUMENTS" — create branch, commit, and open PR.
+
+Read and follow the full skill specification in docs/skills/finalize-feature/SKILL.md.
+
+Follow all phases:
+
+1. **Phase 0 — Pre-flight**: Build, vet, tests pass. Check for secrets.
+2. **Phase 1 — Branch**: Create feature branch.
+3. **Phase 2 — Commit**: Draft message, show to user, stage specific files, commit.
+4. **Phase 3 — PR**: Push and create PR via `gh pr create`.
+5. **Phase 4 — Checklist**: Report branch, commit, PR URL.
+CMDEOF
+      ;;
+    add-new-provider)
+      cat <<'CMDEOF'
+Add a new AI provider "$ARGUMENTS" to the OpenUsage TUI dashboard.
+
+Read and follow the full skill specification in docs/skills/add-new-provider.md.
+
+Follow all phases:
+
+1. **Phase 0 — Quiz**: Ask all 10 provider questions.
+2. **Phase 1 — Research**: Study provider API docs.
+3. **Phase 2 — Create Package**: Implement provider in `internal/providers/<id>/`.
+4. **Phase 3 — Dashboard Widget**: Create tile with gauges and compact rows.
+5. **Phase 4 — Register**: Add to registry.go, detect.go, example_settings.json.
+6. **Phase 5 — Tests**: Minimum 3 tests using httptest.NewServer.
+7. **Phase 6 — Verify**: `go build`, `go test`, `make vet`.
+CMDEOF
+      ;;
+    dev-workflow-improvements)
+      cat <<'CMDEOF'
+Audit and improve the development workflow for OpenUsage.
+
+Read and follow the full skill specification in docs/skills/dev-workflow-improvements/SKILL.md.
+
+This skill ensures the development flow is complete, consistent, and propagated to all AI tools.
+
+Follow all phases:
+
+1. **Phase 0 — Audit**: Run `make sync-tools`, check for drift. Validate all skills are registered in skills-table.md, have Claude commands, OpenCode stubs. Check for broken references.
+
+2. **Phase 1 — Fix**: Fix any issues found: sync drift, missing registrations, broken references, CLAUDE.md mismatches.
+
+3. **Phase 2 — Improve**: If improvements requested, quiz the user about what needs changing. Add/update skills, onboard new tools, fix workflow gaps. Run sync after each change.
+
+4. **Phase 3 — Verify**: Run sync (should be clean), build, test, show git diff for review.
+CMDEOF
+      ;;
+    *)
+      # Generic fallback for skills without custom Claude command content
+      local desc
+      desc=$(skill_description "$1")
+      cat <<CMDEOF
+$desc
+
+Read and follow the full skill specification in docs/skills/$1/SKILL.md.
+CMDEOF
+      ;;
+  esac
+}
+
+for skill_dir in "$SKILLS_DIR"/*/; do
+  skill_name=$(basename "$skill_dir")
+
+  # Skip directories without a SKILL.md
+  if [[ ! -f "$skill_dir/SKILL.md" ]]; then
+    continue
+  fi
+
+  target_file="$CLAUDE_CMD_DIR/$skill_name.md"
+  claude_command_content "$skill_name" > "$target_file"
+  echo "  Generated: $target_file"
+done
+
+echo ""
+echo "Done. All tool configs are in sync."
+echo ""
+echo "Files generated:"
+echo "  .continuerules"
+echo "  .windsurfrules"
+echo "  .github/copilot-instructions.md"
+echo "  .aider/conventions.md"
+echo "  .opencode/skills/*/SKILL.md"
+echo "  .claude/commands/*.md"


### PR DESCRIPTION
Add skill commands for Claude, Cursor, and OpenCode agents

Wire all 8 workflow skills (design-feature, develop-feature, implement-feature, review-design, validate-feature, iterate-feature, finalize-feature, add-new-provider) as agent-specific command definitions that redirect to the shared specs in docs/skills/.