### PR TITLE
feat: add dedicated MCP usage section to dashboard and detail views

### DIFF
--- a/docs/MCP_USAGE_SECTION_DESIGN.md
+++ b/docs/MCP_USAGE_SECTION_DESIGN.md
@@ -1,0 +1,252 @@
+# MCP Usage Section Design
+
+Date: 2026-03-05
+Status: Proposed
+Author: janekbaraniewski
+
+## 1. Problem Statement
+
+MCP tool usage is buried in the general "Tool Usage" list alongside native tools like `bash`, `read`, `edit`. There's no grouping by MCP server or breakdown by function, making it impossible to see which MCP servers are most used and what functions are called — either per-session or in aggregate.
+
+## 2. Goals
+
+1. Extract MCP tools from the tool usage list into a dedicated "MCP Usage" section on both the dashboard tile and the detail view.
+2. Group MCP tools by server (e.g., `gopls`, `github`, `slack`) with per-function breakdowns.
+3. Track MCP usage per session so users can see which sessions relied on which MCP servers.
+4. Present the data visually using existing chart infrastructure (horizontal bar charts, dot-leader rows).
+
+## 3. Non-Goals
+
+1. Changing how MCP tools are collected or detected — the existing telemetry pipeline already captures them.
+2. MCP server health/connectivity monitoring.
+3. Adding new config options for MCP grouping or filtering.
+4. Replacing or removing MCP tools from the existing "Tool Usage" section — they stay there too for total tool counts.
+
+## 4. Impact Analysis
+
+### Affected Subsystems
+
+| Subsystem | Impact | Summary |
+|-----------|--------|---------|
+| core types | minor | Add `DetailSectionStyleMCP` constant, `MetricGroupMCP` constant |
+| TUI | moderate | New `renderMCPSection()` in detail.go, new `buildMCPUsageLines()` in tiles.go |
+| telemetry | moderate | New `queryMCPAgg()` query that groups by server/function, new agg struct, emit `mcp_*` metrics |
+| providers | minor | Claude Code and other telemetry providers add MCP section to `DetailWidget()` |
+| config | none | No config changes |
+| detect | none | No detection changes |
+| daemon | none | No collection changes |
+| CLI | none | No command changes |
+
+### Existing Design Doc Overlap
+
+- **UNIFIED_AGENT_USAGE_TRACKING_DESIGN**: Complementary — defines the pipeline that collects tool events including MCP tools.
+- **DETAIL_PAGE_REDESIGN_DESIGN**: Complementary — defines the detail view framework; MCP is a new section slot.
+
+## 5. Detailed Design
+
+### 5.1 MCP Tool Name Parsing
+
+MCP tool names in the database preserve their original format from Claude Code:
+
+```
+mcp__gopls__go_diagnostics       → server: "gopls",       function: "go_diagnostics"
+mcp__github__create_issue        → server: "github",      function: "create_issue"
+mcp__claude_ai_vcluster_yaml_mcp__smart_query → server: "claude_ai_vcluster_yaml_mcp", function: "smart_query"
+```
+
+The raw `tool_name` in SQLite uses double underscores (`__`) to separate `mcp`, server name, and function name. The `sanitizeMetricID()` function collapses these to single underscores for metric keys, but the raw DB values are intact.
+
+**Parsing function** (new, in `internal/telemetry/usage_view.go`):
+
+```go
+// parseMCPToolName extracts server and function from an MCP tool name.
+// Returns ("", "", false) for non-MCP tools.
+func parseMCPToolName(raw string) (server, function string, ok bool) {
+    raw = strings.ToLower(strings.TrimSpace(raw))
+    if !strings.HasPrefix(raw, "mcp__") {
+        return "", "", false
+    }
+    rest := raw[5:] // strip "mcp__"
+    idx := strings.Index(rest, "__")
+    if idx < 0 {
+        return rest, "", true // server only, no function
+    }
+    return rest[:idx], rest[idx+2:], true
+}
+```
+
+### 5.2 Telemetry Aggregation
+
+New SQL query in `usage_view.go` that groups MCP tools by server and function:
+
+```go
+type telemetryMCPAgg struct {
+    Server   string
+    Function string
+    Calls    float64
+    Calls1d  float64
+}
+```
+
+The query uses `queryToolAgg()` results and post-processes in Go (since SQL can't easily parse `__` separators). Filter tool rows where `tool_name LIKE 'mcp__%'`, then use `parseMCPToolName()` to split.
+
+New aggregation struct added to `telemetryUsageAgg`:
+
+```go
+type telemetryUsageAgg struct {
+    // ... existing fields ...
+    MCPServers []telemetryMCPServerAgg  // new
+}
+
+type telemetryMCPServerAgg struct {
+    Server    string
+    Calls     float64
+    Calls1d   float64
+    Functions []telemetryMCPAgg
+}
+```
+
+### 5.3 Metric Emission
+
+New metrics emitted in `applyCanonicalUsageViewWithDB()`:
+
+```
+mcp_<server>_total          → total calls to this MCP server
+mcp_<server>_<function>     → calls to specific function
+mcp_calls_total             → total MCP calls across all servers
+mcp_servers_active          → count of active MCP servers
+```
+
+Per-session MCP data is tracked via session-level aggregation: the existing `session_id` field in `usage_events` allows grouping MCP tool calls by session. This produces a `DailySeries` entry `mcp_calls` for trend visualization.
+
+### 5.4 Metric Classification
+
+Add to `metric_semantics.go`:
+
+```go
+const MetricGroupMCP MetricGroup = "MCP Usage"
+```
+
+Update `InferMetricGroup()` to route `mcp_*` keys to `MetricGroupMCP` (before the default Activity fallback).
+
+### 5.5 Detail View — MCP Section
+
+New `renderMCPSection()` in `detail.go`, dispatched directly from `RenderDetailContent()` (same pattern as Languages/Models/Trends — needs full snapshot context, does NOT go through `renderMetricGroup()`):
+
+```
+┌─────────────────────────────────────────┐
+│  MCP Usage                              │
+│  ▓▓▓▓▓▓▓▒▒▒░░                          │
+│  ■ 1 gopls ·················· 65% 42    │
+│      go_diagnostics ·········· 28       │
+│      go_workspace ············ 14       │
+│  ■ 2 github ················· 25% 16    │
+│      create_issue ············  8       │
+│      search_code ·············  5       │
+│      get_pull_request ········  3       │
+│  ■ 3 slack ··················· 10%  6   │
+│      send_message ············  4       │
+│      read_channel ············  2       │
+│  3 servers · 64 calls                   │
+└─────────────────────────────────────────┘
+```
+
+**Rendering approach:**
+1. Scan `mcp_*` metrics from snapshot, parse server/function using the metric key structure.
+2. Group by server, sort servers by total calls descending.
+3. Render a stacked bar chart for server proportions (reuse `toolMixEntry`, `renderToolMixBar`, `sortToolMixEntries` from tiles.go).
+4. For each server: header row with total, indented function rows below.
+5. Footer: server count + total calls summary.
+
+### 5.6 Dashboard Tile — MCP Section
+
+New `buildMCPUsageLines()` in `tiles.go`, called after `buildActualToolUsageLines()`. Shows a compact server-level summary (no function breakdown to save space):
+
+```
+MCP Usage  64 calls · 3 servers
+▓▓▓▓▓▒▒░░
+■ 1 gopls ················· 65% 42
+■ 2 github ················ 25% 16
+■ 3 slack ················· 10%  6
+```
+
+MCP tools are **not removed** from the Tool Usage section — they remain there for the complete tool picture. The MCP section is an additional focused view.
+
+### 5.7 Tab Integration
+
+Add "MCP" tab to `DetailTabs()` when MCP metrics are present:
+
+```go
+if hasMCPMetrics(snap) {
+    tabs = append(tabs, "MCP Usage")
+}
+```
+
+The `hasMCPMetrics()` helper checks for any `mcp_*` metric keys.
+
+### 5.8 Per-Session MCP Tracking
+
+Extend `queryMCPAgg()` to also query session-level MCP usage:
+
+```sql
+SELECT session_id, tool_name, SUM(COALESCE(requests, 1)) AS calls
+FROM deduped_usage
+WHERE event_type = 'tool_usage' AND tool_name LIKE 'mcp__%'
+GROUP BY session_id, tool_name
+ORDER BY calls DESC
+```
+
+This feeds into a `DailySeries["mcp_calls"]` time series for trend visualization, and session-level MCP breakdowns visible in the detail view.
+
+## 6. Backward Compatibility
+
+Fully backward compatible:
+- New metric keys (`mcp_*`) are additive; no existing keys change.
+- New `DetailSectionStyle` doesn't affect providers that don't declare it.
+- MCP tools remain in `tool_*` metrics for existing Tool Usage views.
+- No config schema changes.
+
+## Implementation Tasks
+
+### Task 1: MCP parsing and telemetry aggregation
+Files: `internal/telemetry/usage_view.go`
+Depends on: none
+Description: Add `parseMCPToolName()` function. Add `telemetryMCPAgg` and `telemetryMCPServerAgg` structs. Add `queryMCPAgg()` function that reuses `queryToolAgg()` results and groups by server/function. Add `MCPServers` field to `telemetryUsageAgg`. Include session-level MCP query for per-session tracking. Emit `mcp_*` metrics in `applyCanonicalUsageViewWithDB()` and `mcp_calls` daily series.
+Tests: Test `parseMCPToolName()` with various formats. Test `queryMCPAgg()` with in-memory SQLite. Test metric emission produces correct `mcp_*` keys.
+
+### Task 2: Core types — metric group and detail section style
+Files: `internal/core/metric_semantics.go`, `internal/core/detail_widget.go`
+Depends on: none
+Description: Add `MetricGroupMCP` constant. Update `InferMetricGroup()` to route `mcp_*` metric keys to `MetricGroupMCP`. Add `DetailSectionStyleMCP` constant.
+Tests: Test `InferMetricGroup()` returns `MetricGroupMCP` for `mcp_gopls_total`, `mcp_calls_total`, etc. Test it still returns `MetricGroupActivity` for `tool_bash`.
+
+### Task 3: TUI detail view — MCP section renderer
+Files: `internal/tui/detail.go`
+Depends on: Task 2
+Description: Add `hasMCPMetrics()` helper. Add "MCP Usage" tab to `DetailTabs()`. Add `renderMCPSection()` that scans `mcp_*` metrics, groups by server, renders stacked bar + server/function breakdown with dot-leader rows. Wire into `RenderDetailContent()` via direct dispatch (same pattern as Languages/Models/Trends — NOT through `renderMetricGroup()`).
+Tests: Test `hasMCPMetrics()`. Test `renderMCPSection()` output with mock snapshot containing MCP metrics.
+
+### Task 4: TUI dashboard tile — MCP section
+Files: `internal/tui/tiles.go`
+Depends on: Task 2
+Description: Add `buildMCPUsageLines()` that extracts `mcp_*` server-level metrics and renders compact bar chart with server rows. Call it from the tile rendering pipeline after tool usage. Mark MCP-related keys as used so they don't double-render.
+Tests: Test `buildMCPUsageLines()` with mock snapshot.
+
+### Task 5: Provider widget configuration
+Files: `internal/providers/claude_code/claude_code.go`, `internal/providers/copilot/copilot.go`, `internal/providers/codex/codex.go`, `internal/providers/gemini_cli/gemini_cli.go`
+Depends on: Task 2
+Description: Add `{Name: "MCP Usage", Order: N, Style: core.DetailSectionStyleMCP}` to `DetailWidget()` for providers that support telemetry (and therefore can have MCP data). Position between Languages and Spending.
+Tests: Verify `DetailWidget()` includes MCP section for telemetry-capable providers.
+
+### Task 6: Integration verification
+Files: none (test-only)
+Depends on: Tasks 1-5
+Description: Run full test suite. Verify `make build` succeeds. Manual smoke test with demo data or real telemetry: confirm MCP section appears on dashboard tile and detail view, confirm grouping by server works, confirm per-session tracking produces trend data.
+Tests: `make test`, `make build`, manual verification.
+
+### Dependency Graph
+- Tasks 1, 2: parallel (no dependencies between them)
+- Tasks 3, 4: parallel (both depend on Task 2, independent of each other)
+- Task 5: depends on Task 2
+- Tasks 3, 4, 5: parallel group (all depend on Task 2, Task 3/4 also benefit from Task 1 metrics but can be developed against mock data)
+- Task 6: depends on all (integration verification)

--- a/internal/core/detail_widget.go
+++ b/internal/core/detail_widget.go
@@ -11,6 +11,7 @@ const (
 	DetailSectionStyleModels    DetailSectionStyle = "models"
 	DetailSectionStyleTrends    DetailSectionStyle = "trends"
 	DetailSectionStyleLanguages DetailSectionStyle = "languages"
+	DetailSectionStyleMCP       DetailSectionStyle = "mcp"
 )
 
 type DetailSection struct {

--- a/internal/core/metric_semantics.go
+++ b/internal/core/metric_semantics.go
@@ -9,6 +9,7 @@ const (
 	MetricGroupSpending MetricGroup = "Spending"
 	MetricGroupTokens   MetricGroup = "Tokens"
 	MetricGroupActivity MetricGroup = "Activity"
+	MetricGroupMCP      MetricGroup = "MCP Usage"
 )
 
 func InferMetricGroup(key string, m Metric) MetricGroup {
@@ -70,6 +71,10 @@ func InferMetricGroup(key string, m Metric) MetricGroup {
 		return MetricGroupTokens
 	case strings.Contains(lk, "token"):
 		return MetricGroupTokens
+	}
+
+	if strings.HasPrefix(key, "mcp_") {
+		return MetricGroupMCP
 	}
 
 	return MetricGroupActivity

--- a/internal/core/widget.go
+++ b/internal/core/widget.go
@@ -95,6 +95,7 @@ const (
 	DashboardSectionClientBurn        DashboardStandardSection = "client_burn"
 	DashboardSectionToolUsage         DashboardStandardSection = "tool_usage"
 	DashboardSectionActualToolUsage   DashboardStandardSection = "actual_tool_usage"
+	DashboardSectionMCPUsage          DashboardStandardSection = "mcp_usage"
 	DashboardSectionLanguageBurn      DashboardStandardSection = "language_burn"
 	DashboardSectionCodeStats         DashboardStandardSection = "code_stats"
 	DashboardSectionDailyUsage        DashboardStandardSection = "daily_usage"
@@ -111,6 +112,7 @@ func defaultDashboardSectionOrder() []DashboardStandardSection {
 		DashboardSectionClientBurn,
 		DashboardSectionToolUsage,
 		DashboardSectionActualToolUsage,
+		DashboardSectionMCPUsage,
 		DashboardSectionLanguageBurn,
 		DashboardSectionCodeStats,
 		DashboardSectionDailyUsage,
@@ -128,6 +130,7 @@ func isKnownDashboardSection(section DashboardStandardSection) bool {
 		DashboardSectionClientBurn,
 		DashboardSectionToolUsage,
 		DashboardSectionActualToolUsage,
+		DashboardSectionMCPUsage,
 		DashboardSectionLanguageBurn,
 		DashboardSectionCodeStats,
 		DashboardSectionDailyUsage,
@@ -162,6 +165,8 @@ type DashboardWidget struct {
 	CodeStatsMetrics CodeStatsConfig
 	// Opt-in actual tool usage panel (tool calls from agent bubbles).
 	ShowActualToolUsage bool
+	// Opt-in MCP server usage panel (MCP tool calls per server).
+	ShowMCPUsage bool
 
 	// API key provider metadata. APIKeyEnv marks a provider as configurable in API Keys tab.
 	APIKeyEnv        string

--- a/internal/core/widget_test.go
+++ b/internal/core/widget_test.go
@@ -12,6 +12,7 @@ func TestDefaultDashboardWidget_StandardSectionOrder(t *testing.T) {
 		DashboardSectionClientBurn,
 		DashboardSectionToolUsage,
 		DashboardSectionActualToolUsage,
+		DashboardSectionMCPUsage,
 		DashboardSectionLanguageBurn,
 		DashboardSectionCodeStats,
 		DashboardSectionDailyUsage,

--- a/internal/providers/claude_code/claude_code.go
+++ b/internal/providers/claude_code/claude_code.go
@@ -302,10 +302,11 @@ func (p *Provider) DetailWidget() core.DetailWidget {
 			{Name: "Usage", Order: 1, Style: core.DetailSectionStyleUsage},
 			{Name: "Models", Order: 2, Style: core.DetailSectionStyleModels},
 			{Name: "Languages", Order: 3, Style: core.DetailSectionStyleLanguages},
-			{Name: "Spending", Order: 4, Style: core.DetailSectionStyleSpending},
-			{Name: "Trends", Order: 5, Style: core.DetailSectionStyleTrends},
-			{Name: "Tokens", Order: 6, Style: core.DetailSectionStyleTokens},
-			{Name: "Activity", Order: 7, Style: core.DetailSectionStyleActivity},
+			{Name: "MCP Usage", Order: 4, Style: core.DetailSectionStyleMCP},
+			{Name: "Spending", Order: 5, Style: core.DetailSectionStyleSpending},
+			{Name: "Trends", Order: 6, Style: core.DetailSectionStyleTrends},
+			{Name: "Tokens", Order: 7, Style: core.DetailSectionStyleTokens},
+			{Name: "Activity", Order: 8, Style: core.DetailSectionStyleActivity},
 		},
 	}
 }

--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -231,10 +231,11 @@ func (p *Provider) DetailWidget() core.DetailWidget {
 			{Name: "Usage", Order: 1, Style: core.DetailSectionStyleUsage},
 			{Name: "Models", Order: 2, Style: core.DetailSectionStyleModels},
 			{Name: "Languages", Order: 3, Style: core.DetailSectionStyleLanguages},
-			{Name: "Spending", Order: 4, Style: core.DetailSectionStyleSpending},
-			{Name: "Trends", Order: 5, Style: core.DetailSectionStyleTrends},
-			{Name: "Tokens", Order: 6, Style: core.DetailSectionStyleTokens},
-			{Name: "Activity", Order: 7, Style: core.DetailSectionStyleActivity},
+			{Name: "MCP Usage", Order: 4, Style: core.DetailSectionStyleMCP},
+			{Name: "Spending", Order: 5, Style: core.DetailSectionStyleSpending},
+			{Name: "Trends", Order: 6, Style: core.DetailSectionStyleTrends},
+			{Name: "Tokens", Order: 7, Style: core.DetailSectionStyleTokens},
+			{Name: "Activity", Order: 8, Style: core.DetailSectionStyleActivity},
 		},
 	}
 }

--- a/internal/providers/copilot/copilot.go
+++ b/internal/providers/copilot/copilot.go
@@ -62,10 +62,11 @@ func (p *Provider) DetailWidget() core.DetailWidget {
 			{Name: "Usage", Order: 1, Style: core.DetailSectionStyleUsage},
 			{Name: "Models", Order: 2, Style: core.DetailSectionStyleModels},
 			{Name: "Languages", Order: 3, Style: core.DetailSectionStyleLanguages},
-			{Name: "Spending", Order: 4, Style: core.DetailSectionStyleSpending},
-			{Name: "Trends", Order: 5, Style: core.DetailSectionStyleTrends},
-			{Name: "Tokens", Order: 6, Style: core.DetailSectionStyleTokens},
-			{Name: "Activity", Order: 7, Style: core.DetailSectionStyleActivity},
+			{Name: "MCP Usage", Order: 4, Style: core.DetailSectionStyleMCP},
+			{Name: "Spending", Order: 5, Style: core.DetailSectionStyleSpending},
+			{Name: "Trends", Order: 6, Style: core.DetailSectionStyleTrends},
+			{Name: "Tokens", Order: 7, Style: core.DetailSectionStyleTokens},
+			{Name: "Activity", Order: 8, Style: core.DetailSectionStyleActivity},
 		},
 	}
 }

--- a/internal/providers/copilot/telemetry.go
+++ b/internal/providers/copilot/telemetry.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	telemetrySchemaVersion    = "copilot_v1"
-	defaultCopilotSessionDir  = ".copilot/session-state"
+	telemetrySchemaVersion   = "copilot_v1"
+	defaultCopilotSessionDir = ".copilot/session-state"
 )
 
 // System returns the telemetry system identifier for the copilot provider.

--- a/internal/providers/cursor/cursor.go
+++ b/internal/providers/cursor/cursor.go
@@ -2225,31 +2225,82 @@ func (p *Provider) readToolUsage(ctx context.Context, db *sql.DB, snap *core.Usa
 }
 
 // normalizeToolName cleans up raw tool names from Cursor bubble data.
-// MCP tools have long prefixed names like "mcp-kubernetes-user-kubernetes-pods_list"
-// which we normalize to shorter display names.
+// MCP tools come in formats like:
+//   - "mcp-kubernetes-user-kubernetes-pods_list" (Cursor's internal format)
+//   - Hyphen-prefixed with "user-" for user-installed MCP servers
+//
+// We normalize MCP tools to the canonical "mcp__server__function" format
+// so the telemetry pipeline handles all providers uniformly.
 func normalizeToolName(raw string) string {
 	name := strings.TrimSpace(raw)
 	if name == "" {
 		return "unknown"
 	}
 
-	// Normalize MCP tool names: "mcp-server-user-server-tool" → "tool (mcp)"
+	// Detect MCP tools by prefix.
 	if strings.HasPrefix(name, "mcp-") || strings.HasPrefix(name, "mcp_") {
-		parts := strings.Split(name, "-")
-		if len(parts) >= 4 {
-			toolPart := strings.Join(parts[3:], "-")
-			return toolPart + " (mcp)"
-		}
-		parts = strings.Split(name, "_")
-		if len(parts) >= 3 {
-			toolPart := strings.Join(parts[2:], "_")
-			return toolPart + " (mcp)"
-		}
+		return normalizeCursorMCPName(name)
 	}
 
 	// Strip version suffixes: "read_file_v2" → "read_file"
 	name = strings.TrimSuffix(name, "_v2")
 	name = strings.TrimSuffix(name, "_v3")
+
+	return name
+}
+
+// normalizeCursorMCPName converts Cursor's MCP tool name format to the
+// canonical "mcp__server__function" format used by the telemetry pipeline.
+//
+// Input formats:
+//
+//	"mcp-kubernetes-user-kubernetes-pods_list"  → "mcp__kubernetes__pods_list"
+//	"mcp-notion-workspace-notion-notion-fetch"  → "mcp__notion__fetch"
+//	"mcp_something_else"                        → "mcp__something__else" (fallback)
+func normalizeCursorMCPName(name string) string {
+	// Primary format: "mcp-SERVER-user-SERVER-FUNCTION" (hyphen-separated).
+	if strings.HasPrefix(name, "mcp-") {
+		rest := name[4:] // strip "mcp-"
+		parts := strings.SplitN(rest, "-user-", 2)
+		if len(parts) == 2 {
+			server := parts[0]
+			// After "user-", the server name is repeated then the function follows.
+			// e.g., "kubernetes-pods_list" where "kubernetes" is the repeated server.
+			afterUser := parts[1]
+			// Strip the repeated server prefix if present.
+			serverDash := server + "-"
+			if strings.HasPrefix(afterUser, serverDash) {
+				function := afterUser[len(serverDash):]
+				return "mcp__" + server + "__" + function
+			}
+			// Server not repeated — the whole remainder is server-function.
+			// Try to split on first hyphen: "notion-fetch" → server=notion, function=fetch.
+			if idx := strings.LastIndex(afterUser, "-"); idx > 0 {
+				return "mcp__" + server + "__" + afterUser[idx+1:]
+			}
+			return "mcp__" + server + "__" + afterUser
+		}
+
+		// Simpler format: "mcp-server-function" (no "user" segment).
+		// e.g., "mcp-kubernetes-pods_log"
+		if idx := strings.Index(rest, "-"); idx > 0 {
+			server := rest[:idx]
+			function := rest[idx+1:]
+			return "mcp__" + server + "__" + function
+		}
+		return "mcp__" + rest + "__"
+	}
+
+	// Underscore format: "mcp_server_function" (less common).
+	if strings.HasPrefix(name, "mcp_") {
+		rest := name[4:]
+		if idx := strings.Index(rest, "_"); idx > 0 {
+			server := rest[:idx]
+			function := rest[idx+1:]
+			return "mcp__" + server + "__" + function
+		}
+		return "mcp__" + rest + "__"
+	}
 
 	return name
 }

--- a/internal/providers/gemini_cli/gemini_cli.go
+++ b/internal/providers/gemini_cli/gemini_cli.go
@@ -71,10 +71,11 @@ func (p *Provider) DetailWidget() core.DetailWidget {
 			{Name: "Usage", Order: 1, Style: core.DetailSectionStyleUsage},
 			{Name: "Models", Order: 2, Style: core.DetailSectionStyleModels},
 			{Name: "Languages", Order: 3, Style: core.DetailSectionStyleLanguages},
-			{Name: "Spending", Order: 4, Style: core.DetailSectionStyleSpending},
-			{Name: "Trends", Order: 5, Style: core.DetailSectionStyleTrends},
-			{Name: "Tokens", Order: 6, Style: core.DetailSectionStyleTokens},
-			{Name: "Activity", Order: 7, Style: core.DetailSectionStyleActivity},
+			{Name: "MCP Usage", Order: 4, Style: core.DetailSectionStyleMCP},
+			{Name: "Spending", Order: 5, Style: core.DetailSectionStyleSpending},
+			{Name: "Trends", Order: 6, Style: core.DetailSectionStyleTrends},
+			{Name: "Tokens", Order: 7, Style: core.DetailSectionStyleTokens},
+			{Name: "Activity", Order: 8, Style: core.DetailSectionStyleActivity},
 		},
 	}
 }

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -73,10 +73,11 @@ func (p *Provider) DetailWidget() core.DetailWidget {
 			{Name: "Usage", Order: 1, Style: core.DetailSectionStyleUsage},
 			{Name: "Models", Order: 2, Style: core.DetailSectionStyleModels},
 			{Name: "Languages", Order: 3, Style: core.DetailSectionStyleLanguages},
-			{Name: "Spending", Order: 4, Style: core.DetailSectionStyleSpending},
-			{Name: "Trends", Order: 5, Style: core.DetailSectionStyleTrends},
-			{Name: "Tokens", Order: 6, Style: core.DetailSectionStyleTokens},
-			{Name: "Activity", Order: 7, Style: core.DetailSectionStyleActivity},
+			{Name: "MCP Usage", Order: 4, Style: core.DetailSectionStyleMCP},
+			{Name: "Spending", Order: 5, Style: core.DetailSectionStyleSpending},
+			{Name: "Trends", Order: 6, Style: core.DetailSectionStyleTrends},
+			{Name: "Tokens", Order: 7, Style: core.DetailSectionStyleTokens},
+			{Name: "Activity", Order: 8, Style: core.DetailSectionStyleActivity},
 		},
 	}
 }

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -849,10 +849,10 @@ func TestParseParameterSize(t *testing.T) {
 func TestDetailWidget(t *testing.T) {
 	p := New()
 	dw := p.DetailWidget()
-	if len(dw.Sections) != 7 {
-		t.Fatalf("DetailWidget sections = %d, want 7", len(dw.Sections))
+	if len(dw.Sections) != 8 {
+		t.Fatalf("DetailWidget sections = %d, want 8", len(dw.Sections))
 	}
-	expectedSections := []string{"Usage", "Models", "Languages", "Spending", "Trends", "Tokens", "Activity"}
+	expectedSections := []string{"Usage", "Models", "Languages", "MCP Usage", "Spending", "Trends", "Tokens", "Activity"}
 	for i, s := range dw.Sections {
 		if s.Name != expectedSections[i] {
 			t.Errorf("section[%d] = %q, want %q", i, s.Name, expectedSections[i])

--- a/internal/providers/providerbase/base.go
+++ b/internal/providers/providerbase/base.go
@@ -173,6 +173,7 @@ func CodingToolDashboard(options ...DashboardOption) core.DashboardWidget {
 	cfg.ClientCompositionHeading = "Clients"
 	cfg.ShowToolComposition = false
 	cfg.ShowActualToolUsage = true
+	cfg.ShowMCPUsage = true
 	cfg.ShowLanguageComposition = true
 	cfg.ShowCodeStatsComposition = true
 	cfg.CodeStatsMetrics = shared.DefaultCodeStatsConfig()

--- a/internal/providers/shared/labels.go
+++ b/internal/providers/shared/labels.go
@@ -50,6 +50,7 @@ func CodingToolSectionOrder() []core.DashboardStandardSection {
 		core.DashboardSectionModelBurn,
 		core.DashboardSectionClientBurn,
 		core.DashboardSectionActualToolUsage,
+		core.DashboardSectionMCPUsage,
 		core.DashboardSectionLanguageBurn,
 		core.DashboardSectionCodeStats,
 		core.DashboardSectionOtherData,

--- a/internal/telemetry/usage_view.go
+++ b/internal/telemetry/usage_view.go
@@ -44,6 +44,19 @@ type telemetryToolAgg struct {
 	Calls1d float64
 }
 
+type telemetryMCPFunctionAgg struct {
+	Function string
+	Calls    float64
+	Calls1d  float64
+}
+
+type telemetryMCPServerAgg struct {
+	Server    string
+	Calls     float64
+	Calls1d   float64
+	Functions []telemetryMCPFunctionAgg
+}
+
 type telemetryLanguageAgg struct {
 	Language string
 	Requests float64
@@ -91,6 +104,7 @@ type telemetryUsageAgg struct {
 	Providers    []telemetryProviderAgg
 	Sources      []telemetrySourceAgg
 	Tools        []telemetryToolAgg
+	MCPServers   []telemetryMCPServerAgg
 	Languages    []telemetryLanguageAgg
 	Activity     telemetryActivityAgg
 	CodeStats    telemetryCodeStatsAgg
@@ -275,16 +289,16 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 		snap.Metrics["model_"+mk+"_requests_today"] = core.Metric{Used: float64Ptr(model.Requests1d), Unit: "requests", Window: "1d"}
 		modelCostTotal += model.CostUSD
 		snap.ModelUsage = append(snap.ModelUsage, core.ModelUsageRecord{
-			RawModelID:  model.Model,
-			RawSource:   "telemetry",
-			Window:      timeWindow,
-			InputTokens: float64Ptr(model.InputTokens),
-			OutputTokens: float64Ptr(model.OutputTokens),
-			CachedTokens: float64Ptr(model.CachedTokens),
+			RawModelID:      model.Model,
+			RawSource:       "telemetry",
+			Window:          timeWindow,
+			InputTokens:     float64Ptr(model.InputTokens),
+			OutputTokens:    float64Ptr(model.OutputTokens),
+			CachedTokens:    float64Ptr(model.CachedTokens),
 			ReasoningTokens: float64Ptr(model.Reasoning),
-			TotalTokens: float64Ptr(model.TotalTokens),
-			CostUSD:     float64Ptr(model.CostUSD),
-			Requests:    float64Ptr(model.Requests),
+			TotalTokens:     float64Ptr(model.TotalTokens),
+			CostUSD:         float64Ptr(model.CostUSD),
+			Requests:        float64Ptr(model.Requests),
 		})
 	}
 	// Only compute unattributed model cost when we have windowed model data.
@@ -335,6 +349,25 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 		tk := sanitizeMetricID(tool.Tool)
 		snap.Metrics["tool_"+tk] = core.Metric{Used: float64Ptr(tool.Calls), Unit: "calls", Window: timeWindow}
 		snap.Metrics["tool_"+tk+"_today"] = core.Metric{Used: float64Ptr(tool.Calls1d), Unit: "calls", Window: "1d"}
+	}
+
+	// MCP server metrics.
+	var mcpTotalCalls, mcpTotalCalls1d float64
+	for _, srv := range agg.MCPServers {
+		sk := sanitizeMetricID(srv.Server)
+		snap.Metrics["mcp_"+sk+"_total"] = core.Metric{Used: float64Ptr(srv.Calls), Unit: "calls", Window: timeWindow}
+		snap.Metrics["mcp_"+sk+"_total_today"] = core.Metric{Used: float64Ptr(srv.Calls1d), Unit: "calls", Window: "1d"}
+		mcpTotalCalls += srv.Calls
+		mcpTotalCalls1d += srv.Calls1d
+		for _, fn := range srv.Functions {
+			fk := sanitizeMetricID(fn.Function)
+			snap.Metrics["mcp_"+sk+"_"+fk] = core.Metric{Used: float64Ptr(fn.Calls), Unit: "calls", Window: timeWindow}
+		}
+	}
+	if mcpTotalCalls > 0 {
+		snap.Metrics["mcp_calls_total"] = core.Metric{Used: float64Ptr(mcpTotalCalls), Unit: "calls", Window: timeWindow}
+		snap.Metrics["mcp_calls_total_today"] = core.Metric{Used: float64Ptr(mcpTotalCalls1d), Unit: "calls", Window: "1d"}
+		snap.Metrics["mcp_servers_active"] = core.Metric{Used: float64Ptr(float64(len(agg.MCPServers))), Unit: "servers", Window: timeWindow}
 	}
 
 	for _, lang := range agg.Languages {
@@ -564,6 +597,7 @@ func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter)
 	agg.Providers = providers
 	agg.Sources = sources
 	agg.Tools = tools
+	agg.MCPServers = buildMCPAgg(tools)
 	agg.Languages = languages
 	agg.Activity = activity
 	agg.CodeStats = codeStats
@@ -1214,7 +1248,6 @@ func pointsFromDaily(in []telemetryDayPoint, pick func(telemetryDayPoint) float6
 	})
 }
 
-
 // isStaleActivityMetric returns true for metrics that are computed by the provider
 // with hardcoded time windows (today/7d/all-time) and should be replaced by
 // telemetry-windowed equivalents.
@@ -1285,6 +1318,144 @@ func sortedSeriesFromByDay(byDay map[string]float64) []core.TimePoint {
 		})
 	}
 	return out
+}
+
+// parseMCPToolName extracts server and function from an MCP tool name.
+// Raw tool names use double underscores: mcp__server__function.
+// Returns ("", "", false) for non-MCP tools.
+// parseMCPToolName extracts server and function from an MCP tool name.
+// Supports two formats:
+//   - Canonical: "mcp__server__function" (double underscores, from Claude Code and normalized Cursor)
+//   - Legacy:    "server-function (mcp)" or "user-server-function (mcp)" (old Cursor data)
+//
+// Returns ("", "", false) for non-MCP tools.
+func parseMCPToolName(raw string) (server, function string, ok bool) {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+
+	// Canonical format: mcp__server__function
+	if strings.HasPrefix(raw, "mcp__") {
+		rest := raw[5:]
+		idx := strings.Index(rest, "__")
+		if idx < 0 {
+			return rest, "", true
+		}
+		return rest[:idx], rest[idx+2:], true
+	}
+
+	// Legacy format: "something (mcp)" from old Cursor data.
+	if strings.HasSuffix(raw, " (mcp)") {
+		body := strings.TrimSuffix(raw, " (mcp)")
+		body = strings.TrimSpace(body)
+		if body == "" {
+			return "", "", false
+		}
+
+		// Strip "user-" prefix if present.
+		body = strings.TrimPrefix(body, "user-")
+
+		// Try to extract server from "server-function" format.
+		// e.g., "kubernetes-pods_log" → server=kubernetes, function=pods_log
+		// e.g., "gcp-gcloud-run_gcloud_command" → server=gcp-gcloud, function=run_gcloud_command
+		// Heuristic: the function part typically contains underscores, so split on the
+		// last hyphen that precedes an underscore-containing segment.
+		if idx := findServerFunctionSplit(body); idx > 0 {
+			return body[:idx], body[idx+1:], true
+		}
+
+		// No clear server-function split — treat whole body as function with unknown server.
+		return "other", body, true
+	}
+
+	return "", "", false
+}
+
+// findServerFunctionSplit finds the best hyphen position to split "server-function"
+// in a Cursor MCP tool name. The function name typically contains underscores
+// (e.g., "pods_list", "search_docs") while server names use hyphens.
+// Strategy: find the last hyphen where the part AFTER it contains an underscore.
+// This handles multi-segment server names like "gcp-gcloud" or "runai-docs".
+func findServerFunctionSplit(s string) int {
+	bestIdx := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] == '-' {
+			rest := s[i+1:]
+			if strings.Contains(rest, "_") {
+				bestIdx = i
+			}
+		}
+	}
+	if bestIdx > 0 {
+		return bestIdx
+	}
+
+	// No underscore-based split found. Fall back to first hyphen if no more hyphens after.
+	// e.g., "kubernetes-pods_log" or "smart-query"
+	if idx := strings.Index(s, "-"); idx > 0 {
+		return idx
+	}
+	return -1
+}
+
+func buildMCPAgg(tools []telemetryToolAgg) []telemetryMCPServerAgg {
+	type serverData struct {
+		calls   float64
+		calls1d float64
+		funcs   map[string]*telemetryMCPFunctionAgg
+	}
+	servers := make(map[string]*serverData)
+
+	for _, tool := range tools {
+		server, function, ok := parseMCPToolName(tool.Tool)
+		if !ok || server == "" {
+			continue
+		}
+		sd, exists := servers[server]
+		if !exists {
+			sd = &serverData{funcs: make(map[string]*telemetryMCPFunctionAgg)}
+			servers[server] = sd
+		}
+		sd.calls += tool.Calls
+		sd.calls1d += tool.Calls1d
+		if function != "" {
+			if f, ok := sd.funcs[function]; ok {
+				f.Calls += tool.Calls
+				f.Calls1d += tool.Calls1d
+			} else {
+				sd.funcs[function] = &telemetryMCPFunctionAgg{
+					Function: function,
+					Calls:    tool.Calls,
+					Calls1d:  tool.Calls1d,
+				}
+			}
+		}
+	}
+
+	result := make([]telemetryMCPServerAgg, 0, len(servers))
+	for name, sd := range servers {
+		var funcs []telemetryMCPFunctionAgg
+		for _, f := range sd.funcs {
+			funcs = append(funcs, *f)
+		}
+		sort.Slice(funcs, func(i, j int) bool {
+			if funcs[i].Calls != funcs[j].Calls {
+				return funcs[i].Calls > funcs[j].Calls
+			}
+			return funcs[i].Function < funcs[j].Function
+		})
+		result = append(result, telemetryMCPServerAgg{
+			Server:    name,
+			Calls:     sd.calls,
+			Calls1d:   sd.calls1d,
+			Functions: funcs,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Calls != result[j].Calls {
+			return result[i].Calls > result[j].Calls
+		}
+		return result[i].Server < result[j].Server
+	})
+	return result
 }
 
 func sanitizeMetricID(raw string) string {

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -36,6 +36,10 @@ func DetailTabs(snap core.UsageSnapshot) []string {
 	if hasLanguageMetrics(snap) {
 		tabs = append(tabs, "Languages")
 	}
+	// Add MCP Usage tab if MCP metrics are available.
+	if hasMCPMetrics(snap) {
+		tabs = append(tabs, "MCP Usage")
+	}
 	// Add Trends tab if daily series has enough data for a chart.
 	if hasChartableSeries(snap.DailySeries) {
 		tabs = append(tabs, "Trends")
@@ -107,6 +111,14 @@ func RenderDetailContent(snap core.UsageSnapshot, w int, warnThresh, critThresh 
 		sb.WriteString("\n")
 		renderDetailSectionHeader(&sb, "Languages", w)
 		renderLanguagesSection(&sb, snap, w)
+	}
+
+	// MCP Usage section — dispatched directly (needs full snapshot metrics).
+	showMCP := tabName == "MCP Usage" || showAll
+	if showMCP && hasMCPMetrics(snap) {
+		sb.WriteString("\n")
+		renderDetailSectionHeader(&sb, "MCP Usage", w)
+		renderMCPSection(&sb, snap, w)
 	}
 
 	// Trends section — dispatched directly (needs full snapshot DailySeries).
@@ -355,6 +367,10 @@ func groupMetrics(metrics map[string]core.Metric, widget core.DashboardWidget, d
 	groups := make(map[string]*metricGroup)
 
 	for key, m := range metrics {
+		// MCP metrics are rendered in their own dedicated section.
+		if strings.HasPrefix(key, "mcp_") {
+			continue
+		}
 		groupName, label, order := classifyMetric(key, m, widget, details)
 		g, ok := groups[groupName]
 		if !ok {
@@ -958,6 +974,167 @@ func renderLanguagesSection(sb *strings.Builder, snap core.UsageSnapshot, w int)
 			sb.WriteString("  " + dimStyle.Render(fmt.Sprintf("+ %d more languages", remaining)) + "\n")
 		}
 	}
+}
+
+// hasMCPMetrics checks if the snapshot contains any MCP metric keys.
+func hasMCPMetrics(snap core.UsageSnapshot) bool {
+	for key := range snap.Metrics {
+		if strings.HasPrefix(key, "mcp_") {
+			return true
+		}
+	}
+	return false
+}
+
+// renderMCPSection renders MCP server and function call metrics.
+// Uses prettifyMCPServerName/prettifyMCPFunctionName from tiles.go (same package).
+func renderMCPSection(sb *strings.Builder, snap core.UsageSnapshot, w int) {
+	type mcpFunc struct {
+		name  string
+		calls float64
+	}
+	type mcpServer struct {
+		rawName string
+		name    string
+		calls   float64
+		funcs   []mcpFunc
+	}
+
+	// Collect server totals from metrics.
+	serverMap := make(map[string]*mcpServer)
+	for key, m := range snap.Metrics {
+		if !strings.HasPrefix(key, "mcp_") || m.Used == nil {
+			continue
+		}
+		if key == "mcp_calls_total" || key == "mcp_calls_total_today" || key == "mcp_servers_active" {
+			continue
+		}
+		if strings.HasSuffix(key, "_today") {
+			continue
+		}
+
+		rest := strings.TrimPrefix(key, "mcp_")
+
+		if strings.HasSuffix(rest, "_total") {
+			rawServerName := strings.TrimSuffix(rest, "_total")
+			if rawServerName == "" {
+				continue
+			}
+			serverMap[rawServerName] = &mcpServer{
+				rawName: rawServerName,
+				name:    prettifyMCPServerName(rawServerName),
+				calls:   *m.Used,
+			}
+		}
+	}
+
+	// Second pass: collect functions for each known server.
+	for key, m := range snap.Metrics {
+		if !strings.HasPrefix(key, "mcp_") || m.Used == nil {
+			continue
+		}
+		if key == "mcp_calls_total" || key == "mcp_calls_total_today" || key == "mcp_servers_active" {
+			continue
+		}
+		if strings.HasSuffix(key, "_today") || strings.HasSuffix(key, "_total") {
+			continue
+		}
+
+		rest := strings.TrimPrefix(key, "mcp_")
+		for rawServerName, srv := range serverMap {
+			prefix := rawServerName + "_"
+			if strings.HasPrefix(rest, prefix) {
+				funcName := strings.TrimPrefix(rest, prefix)
+				if funcName != "" {
+					srv.funcs = append(srv.funcs, mcpFunc{
+						name:  prettifyMCPFunctionName(funcName),
+						calls: *m.Used,
+					})
+				}
+				break
+			}
+		}
+	}
+
+	// Sort servers by calls desc.
+	servers := make([]*mcpServer, 0, len(serverMap))
+	for _, srv := range serverMap {
+		sort.Slice(srv.funcs, func(i, j int) bool {
+			if srv.funcs[i].calls != srv.funcs[j].calls {
+				return srv.funcs[i].calls > srv.funcs[j].calls
+			}
+			return srv.funcs[i].name < srv.funcs[j].name
+		})
+		servers = append(servers, srv)
+	}
+	sort.Slice(servers, func(i, j int) bool {
+		if servers[i].calls != servers[j].calls {
+			return servers[i].calls > servers[j].calls
+		}
+		return servers[i].name < servers[j].name
+	})
+
+	if len(servers) == 0 {
+		return
+	}
+
+	var totalCalls float64
+	for _, srv := range servers {
+		totalCalls += srv.calls
+	}
+	if totalCalls <= 0 {
+		return
+	}
+
+	// Render stacked bar.
+	barW := w - 4
+	if barW < 12 {
+		barW = 12
+	}
+	if barW > 40 {
+		barW = 40
+	}
+
+	// Build color map using prettified names (same as tile).
+	var allEntries []toolMixEntry
+	for _, srv := range servers {
+		allEntries = append(allEntries, toolMixEntry{name: srv.name, count: srv.calls})
+	}
+	toolColors := buildToolColorMap(allEntries, snap.AccountID)
+
+	sb.WriteString(fmt.Sprintf("  %s\n", renderToolMixBar(allEntries, totalCalls, barW, toolColors)))
+
+	// Render server + function rows.
+	for i, srv := range servers {
+		toolColor := colorForTool(toolColors, srv.name)
+		colorDot := lipgloss.NewStyle().Foreground(toolColor).Render("■")
+		serverLabel := fmt.Sprintf("%s %d %s", colorDot, i+1, srv.name)
+		pct := srv.calls / totalCalls * 100
+		valueStr := fmt.Sprintf("%2.0f%% %.0f", pct, srv.calls)
+		sb.WriteString(renderDotLeaderRow(serverLabel, valueStr, w-2))
+		sb.WriteString("\n")
+
+		// Show up to 8 functions.
+		maxFuncs := 8
+		if len(srv.funcs) < maxFuncs {
+			maxFuncs = len(srv.funcs)
+		}
+		for j := 0; j < maxFuncs; j++ {
+			fn := srv.funcs[j]
+			fnLabel := "    " + fn.name
+			fnValue := fmt.Sprintf("%.0f", fn.calls)
+			sb.WriteString(renderDotLeaderRow(fnLabel, fnValue, w-2))
+			sb.WriteString("\n")
+		}
+		if len(srv.funcs) > 8 {
+			sb.WriteString(dimStyle.Render(fmt.Sprintf("    + %d more functions", len(srv.funcs)-8)))
+			sb.WriteString("\n")
+		}
+	}
+
+	// Footer.
+	footer := fmt.Sprintf("%d servers · %.0f calls", len(servers), totalCalls)
+	sb.WriteString("  " + dimStyle.Render(footer) + "\n")
 }
 
 // hasModelCostMetrics checks if the snapshot contains model cost metric keys.
@@ -1567,6 +1744,8 @@ func sectionIcon(title string) string {
 		return "🗂"
 	case "Trends":
 		return "📈"
+	case "MCP Usage":
+		return "🔌"
 	case "Attributes":
 		return "📋"
 	case "Diagnostics":
@@ -1596,6 +1775,8 @@ func sectionColor(title string) lipgloss.Color {
 		return colorPeach
 	case "Trends":
 		return colorSapphire
+	case "MCP Usage":
+		return colorSky
 	case "Attributes":
 		return colorBlue
 	case "Diagnostics":

--- a/internal/tui/tiles.go
+++ b/internal/tui/tiles.go
@@ -584,6 +584,16 @@ func (m Model) renderTile(snap core.UsageSnapshot, selected, modelMixExpanded bo
 	}
 	compactMetricKeys = addUsedKeys(compactMetricKeys, actualToolKeys)
 
+	var mcpUsageLines []string
+	var mcpUsageKeys map[string]bool
+	if widget.ShowMCPUsage {
+		mcpUsageLines, mcpUsageKeys = buildMCPUsageLines(snap, innerW)
+		if len(mcpUsageLines) > 0 {
+			sectionsByID[core.DashboardSectionMCPUsage] = section{withSectionPadding(mcpUsageLines)}
+		}
+	}
+	compactMetricKeys = addUsedKeys(compactMetricKeys, mcpUsageKeys)
+
 	var langBurnLines []string
 	var langBurnKeys map[string]bool
 	if widget.ShowLanguageComposition {
@@ -4533,6 +4543,11 @@ func buildActualToolUsageLines(snap core.UsageSnapshot, innerW int, expanded boo
 		if name == "" {
 			continue
 		}
+		// Skip MCP tools — they have their own dedicated section.
+		if strings.HasPrefix(name, "mcp_") {
+			usedKeys[key] = true
+			continue
+		}
 		byTool[name] += *met.Used
 		usedKeys[key] = true
 	}
@@ -4616,6 +4631,218 @@ func buildActualToolUsageLines(snap core.UsageSnapshot, innerW int, expanded boo
 
 	if hiddenCount > 0 {
 		lines = append(lines, dimStyle.Render(fmt.Sprintf("+ %d more tools (Ctrl+O)", hiddenCount)))
+	}
+
+	return lines, usedKeys
+}
+
+// prettifyMCPServerName cleans up raw MCP server identifiers for display.
+// Strips common prefixes (claude_ai_, plugin_), suffixes (_mcp), deduplicates,
+// and title-cases the result.
+func prettifyMCPServerName(raw string) string {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	if s == "" {
+		return "unknown"
+	}
+
+	// Strip known prefixes from claude.ai marketplace and plugin system.
+	s = strings.TrimPrefix(s, "claude_ai_")
+	s = strings.TrimPrefix(s, "plugin_")
+
+	// Strip trailing _mcp suffix (redundant — everything here is MCP).
+	s = strings.TrimSuffix(s, "_mcp")
+
+	// Deduplicate: "slack_slack" → "slack".
+	parts := strings.Split(s, "_")
+	if len(parts) >= 2 && parts[0] == parts[len(parts)-1] {
+		parts = parts[:len(parts)-1]
+	}
+	s = strings.Join(parts, "_")
+
+	if s == "" {
+		return raw
+	}
+
+	// Title case with separators preserved.
+	return prettifyMCPName(s)
+}
+
+// prettifyMCPFunctionName cleans up raw MCP function names for display.
+func prettifyMCPFunctionName(raw string) string {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	if s == "" {
+		return raw
+	}
+	return prettifyMCPName(s)
+}
+
+// prettifyMCPName converts snake_case/kebab-case to Title Case.
+func prettifyMCPName(s string) string {
+	// Replace underscores and hyphens with spaces, then title-case each word.
+	s = strings.NewReplacer("_", " ", "-", " ").Replace(s)
+	words := strings.Fields(s)
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func buildMCPUsageLines(snap core.UsageSnapshot, innerW int) ([]string, map[string]bool) {
+	usedKeys := make(map[string]bool)
+
+	type funcEntry struct {
+		name  string
+		calls float64
+	}
+	type serverEntry struct {
+		rawName string
+		name    string
+		calls   float64
+		funcs   []funcEntry
+	}
+
+	// First pass: collect server totals.
+	serverMap := make(map[string]*serverEntry)
+	for key, m := range snap.Metrics {
+		if !strings.HasPrefix(key, "mcp_") || m.Used == nil {
+			continue
+		}
+		usedKeys[key] = true
+
+		if key == "mcp_calls_total" || key == "mcp_calls_total_today" || key == "mcp_servers_active" {
+			continue
+		}
+		if strings.HasSuffix(key, "_today") {
+			continue
+		}
+
+		rest := strings.TrimPrefix(key, "mcp_")
+		if !strings.HasSuffix(rest, "_total") {
+			continue
+		}
+		rawServerName := strings.TrimSuffix(rest, "_total")
+		if rawServerName == "" {
+			continue
+		}
+		serverMap[rawServerName] = &serverEntry{
+			rawName: rawServerName,
+			name:    prettifyMCPServerName(rawServerName),
+			calls:   *m.Used,
+		}
+	}
+
+	// Second pass: collect functions for each known server.
+	for key, m := range snap.Metrics {
+		if !strings.HasPrefix(key, "mcp_") || m.Used == nil {
+			continue
+		}
+		if key == "mcp_calls_total" || key == "mcp_calls_total_today" || key == "mcp_servers_active" {
+			continue
+		}
+		if strings.HasSuffix(key, "_today") || strings.HasSuffix(key, "_total") {
+			continue
+		}
+		rest := strings.TrimPrefix(key, "mcp_")
+		for rawServerName, srv := range serverMap {
+			prefix := rawServerName + "_"
+			if strings.HasPrefix(rest, prefix) {
+				funcName := strings.TrimPrefix(rest, prefix)
+				if funcName != "" {
+					srv.funcs = append(srv.funcs, funcEntry{
+						name:  prettifyMCPFunctionName(funcName),
+						calls: *m.Used,
+					})
+				}
+				break
+			}
+		}
+	}
+
+	// Sort servers and their functions.
+	var servers []*serverEntry
+	var totalCalls float64
+	for _, srv := range serverMap {
+		sort.Slice(srv.funcs, func(i, j int) bool {
+			if srv.funcs[i].calls != srv.funcs[j].calls {
+				return srv.funcs[i].calls > srv.funcs[j].calls
+			}
+			return srv.funcs[i].name < srv.funcs[j].name
+		})
+		servers = append(servers, srv)
+		totalCalls += srv.calls
+	}
+	sort.Slice(servers, func(i, j int) bool {
+		if servers[i].calls != servers[j].calls {
+			return servers[i].calls > servers[j].calls
+		}
+		return servers[i].name < servers[j].name
+	})
+
+	if len(servers) == 0 || totalCalls <= 0 {
+		return nil, usedKeys
+	}
+
+	// Header.
+	headerSuffix := shortCompact(totalCalls) + " calls · " + fmt.Sprintf("%d servers", len(servers))
+	heading := lipgloss.NewStyle().Foreground(colorSubtext).Bold(true).Render("MCP Usage") +
+		"  " + dimStyle.Render(headerSuffix)
+
+	// Build entries for the bar using prettified names.
+	var allEntries []toolMixEntry
+	for _, srv := range servers {
+		allEntries = append(allEntries, toolMixEntry{name: srv.name, count: srv.calls})
+	}
+
+	barW := innerW - 2
+	if barW < 12 {
+		barW = 12
+	}
+	if barW > 40 {
+		barW = 40
+	}
+
+	toolColors := buildToolColorMap(allEntries, snap.AccountID)
+
+	lines := []string{
+		heading,
+		"  " + renderToolMixBar(allEntries, totalCalls, barW, toolColors),
+	}
+
+	// Show up to 6 servers with nested function breakdown.
+	displayLimit := 6
+	visible := servers
+	if len(visible) > displayLimit {
+		visible = visible[:displayLimit]
+	}
+
+	for idx, srv := range visible {
+		pct := srv.calls / totalCalls * 100
+		toolColor := colorForTool(toolColors, srv.name)
+		colorDot := lipgloss.NewStyle().Foreground(toolColor).Render("■")
+		displayLabel := fmt.Sprintf("%s %d %s", colorDot, idx+1, srv.name)
+		valueStr := fmt.Sprintf("%2.0f%% %s", pct, shortCompact(srv.calls))
+		lines = append(lines, renderDotLeaderRow(displayLabel, valueStr, innerW))
+
+		// Show top 3 functions per server, indented.
+		maxFuncs := 3
+		if len(srv.funcs) < maxFuncs {
+			maxFuncs = len(srv.funcs)
+		}
+		for j := 0; j < maxFuncs; j++ {
+			fn := srv.funcs[j]
+			fnLabel := "    " + fn.name
+			fnValue := fmt.Sprintf("%.0f", fn.calls)
+			lines = append(lines, renderDotLeaderRow(fnLabel, fnValue, innerW))
+		}
+		if len(srv.funcs) > 3 {
+			lines = append(lines, dimStyle.Render(fmt.Sprintf("    + %d more", len(srv.funcs)-3)))
+		}
+	}
+
+	if len(servers) > displayLimit {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("+ %d more servers", len(servers)-displayLimit)))
 	}
 
 	return lines, usedKeys


### PR DESCRIPTION
Extract MCP tool usage from the general Tool Usage section into a dedicated MCP Usage section. Groups MCP tools by server with per-function breakdowns, prettified server names, and stable sorted display.

- Parse MCP tools using canonical `mcp__server__function` format
- Normalize Cursor's `mcp-server-user-server-function` format to canonical
- Handle legacy `(mcp)` suffix format for already-stored telemetry data
- Add MCP section to dashboard tiles with nested server/function breakdown
- Add MCP Usage detail tab with bar charts and hierarchical display
- Filter MCP tools out of general Tool Usage section to avoid duplication
- Prettify server names (strip claude_ai_, plugin_ prefixes, _mcp suffix)
- Stable alphabetical sort tiebreaker to prevent UI flickering
- Enable MCP section for all telemetry-capable providers