### PR TITLE
perf: optimize telemetry read model and expand cursor data extraction

### DIFF
--- a/configs/example_settings.json
+++ b/configs/example_settings.json
@@ -38,6 +38,28 @@
         "account_id": "openrouter",
         "enabled": false
       }
+    ],
+    "widget_sections": [
+      {
+        "id": "top_usage_progress",
+        "enabled": true
+      },
+      {
+        "id": "model_burn",
+        "enabled": true
+      },
+      {
+        "id": "client_burn",
+        "enabled": true
+      },
+      {
+        "id": "other_data",
+        "enabled": true
+      },
+      {
+        "id": "daily_usage",
+        "enabled": false
+      }
     ]
   },
   "auto_detect": true,

--- a/docs/PROVIDER_WIDGET_SECTION_SETTINGS_DESIGN.md
+++ b/docs/PROVIDER_WIDGET_SECTION_SETTINGS_DESIGN.md
@@ -1,0 +1,189 @@
+# Provider Widget Section Settings Design
+
+Date: 2026-03-05
+Status: Proposed
+Author: Codex
+
+## 0. Pre-Design Quiz Answers
+
+1. Problem solved: provider tiles have hardcoded section ordering/visibility, so users cannot tailor what they see globally.
+2. Beneficiaries: primarily end users; secondarily contributors (clearer widget configuration contract).
+3. Affected subsystems: core types, providers, TUI, config.
+4. Out of scope: changing telemetry ingestion/metrics semantics; redesigning detail panel sections.
+5. Overlapping docs: `MCP_USAGE_SECTION_DESIGN.md` (adds MCP section usage), `DETAIL_PAGE_REDESIGN_DESIGN.md` (detail page only, not tile settings).
+6. MVP: settings tab that edits a single global dashboard tile section visibility/order configuration, persisted to `settings.json`.
+7. Public interfaces changed: config JSON schema (`dashboard.widget_sections`) and core helper exports for dashboard sections.
+8. Backward compatibility: additive config only; missing field falls back to current provider defaults.
+
+## 1. Problem Statement
+
+Provider widgets expose standardized tile sections, but section visibility/order is fixed in code and cannot be configured by users in Settings.
+
+## 2. Goals
+
+1. Add a Settings tab to configure dashboard tile section visibility and order.
+2. Persist global widget section preferences in config.
+3. Apply preferences at render time without changing provider fetch logic.
+4. Strengthen provider/widget interface consistency with explicit validation around standardized section usage.
+
+## 3. Non-Goals
+
+1. Changing provider data collection or metric key generation.
+2. Adding per-account or per-provider overrides in this iteration.
+3. Reworking detail-page section abstractions in this iteration.
+
+## 4. Impact Analysis
+
+### Affected Subsystems
+
+| Subsystem | Impact | Summary |
+|-----------|--------|---------|
+| core types | minor | Export canonical dashboard section list helpers for UI/config normalization |
+| providers | minor | Add provider/widget consistency test coverage using existing interfaces |
+| TUI | major | New Settings tab for section configuration + runtime widget override application |
+| config | major | New persisted dashboard widget section config schema and save helpers |
+| detect | none | No changes |
+| daemon | none | No changes |
+| telemetry | none | No changes |
+| CLI | none | No command changes |
+
+### Existing Design Doc Overlap
+
+- `docs/MCP_USAGE_SECTION_DESIGN.md`: complementary; introduces `mcp_usage` section, which this feature makes user-toggleable/reorderable.
+- `docs/DETAIL_PAGE_REDESIGN_DESIGN.md`: no conflict; this feature targets dashboard tile widget sections only.
+
+## 5. Detailed Design
+
+### 5.1 Core Section Catalog
+
+`internal/core/widget.go` currently has unexported section-order helpers. Add exported helpers:
+
+- `DashboardStandardSections() []DashboardStandardSection`
+- `IsKnownDashboardStandardSection(section DashboardStandardSection) bool`
+
+These provide a canonical section list for config normalization and the settings UI.
+
+### 5.2 Config Schema
+
+Add additive dashboard widget section configuration:
+
+```go
+type DashboardWidgetSection struct {
+    ID      core.DashboardStandardSection `json:"id"`
+    Enabled bool                          `json:"enabled"`
+}
+
+type DashboardConfig struct {
+    Providers      []DashboardProviderConfig       `json:"providers"`
+    View           string                          `json:"view"`
+    WidgetSections []DashboardWidgetSection        `json:"widget_sections,omitempty"`
+}
+```
+
+Normalization rules:
+
+1. Unknown section IDs are dropped.
+2. Duplicate section IDs are deduplicated by first occurrence.
+3. `header` is dropped (header is always rendered outside body section ordering).
+
+Add save API:
+
+- `SaveDashboardWidgetSections(sections []DashboardWidgetSection) error`
+- `SaveDashboardWidgetSectionsTo(path string, sections []DashboardWidgetSection) error`
+
+### 5.3 Runtime Widget Override Path
+
+Provider defaults remain source-of-truth. TUI applies config overrides at render time:
+
+1. Keep provider-defined `DashboardWidget().StandardSectionOrder` as fallback.
+2. If global override exists, derive `StandardSectionOrder` from enabled section entries in configured order.
+3. If override produces zero enabled sections, render no body sections (header remains).
+4. If no override exists, preserve current behavior exactly.
+
+Implementation approach:
+
+- Extend `internal/tui/provider_widget.go` with thread-safe in-memory global override state.
+- Add setter used by model initialization/update whenever config changes.
+
+### 5.4 Settings Modal: “Widget Sections” Tab
+
+Add new tab in `settings_modal.go`:
+
+- Top line: global scope indicator.
+- Body: all canonical dashboard sections (excluding header) with checkbox (`enabled`) and ordered index.
+- Controls:
+  - `Up/Down`: select section row.
+  - `Space/Enter`: toggle section enabled.
+  - `Shift+Up/Down` or `Shift+J/K`: move section row.
+- Persist after each mutation via new config save command.
+
+UI uses canonical section defaults when no global override exists.
+
+### 5.5 Provider Interface Consistency Check
+
+Add regression tests in `internal/providers` that enforce:
+
+1. Every provider ID is unique/non-empty.
+2. `p.Spec().ID` resolves correctly against `p.ID()`.
+3. `p.DashboardWidget().EffectiveStandardSectionOrder()` contains only known standard sections.
+4. No provider emits duplicate section IDs in effective order.
+
+This keeps interfaces well-defined and prevents drift as providers evolve.
+
+### 5.6 Backward Compatibility
+
+Backward compatible:
+
+1. `dashboard.widget_sections` is optional and additive.
+2. Existing configs load unchanged and keep current provider defaults.
+3. Providers need no data-path changes; only presentation is overridden at render time.
+
+## 6. Alternatives Considered
+
+### Per-provider section overrides
+
+Rejected for this iteration. A single global configuration is simpler, matches user intent, and is easier to reason about in Settings.
+
+### Per-account section configuration
+
+Rejected for MVP to avoid significantly larger settings surface/state. Global configuration provides the needed value with lower complexity.
+
+## 7. Implementation Tasks
+
+### Task 1: Core + Config schema for widget section preferences
+Files: `internal/core/widget.go`, `internal/config/config.go`, `internal/config/config_test.go`, `configs/example_settings.json`
+Depends on: none
+Description: Export canonical dashboard section helper(s). Add dashboard widget section config structs/normalization and save functions. Ensure loading defaults preserve legacy behavior. Update example config with a global widget section override.
+Tests: Extend config tests for normalization, persistence, and backward compatibility with missing `widget_sections`.
+
+### Task 2: TUI runtime support for section overrides
+Files: `internal/tui/provider_widget.go`, `internal/tui/model.go`
+Depends on: Task 1
+Description: Add model-held global widget section preferences and plumbing to pass normalized global overrides into the widget lookup path. Apply override order/visibility on top of provider defaults before rendering.
+Tests: Add focused tests in `internal/tui` to verify overridden section order and visibility are honored.
+
+### Task 3: Settings modal tab for widget sections
+Files: `internal/tui/settings_modal.go`, `internal/tui/model.go`, `internal/tui/telemetry_mapping_test.go` (or new settings modal test file)
+Depends on: Task 2
+Description: Add new “Widget Sections” tab, key handling, section toggle/reorder UI, and persistence command wiring. Keep existing settings tab behavior unchanged.
+Tests: Add tab rendering and key-interaction tests for toggle, reorder, and persisted-save command emission.
+
+### Task 4: Provider/widget interface consistency coverage
+Files: `internal/providers/registry_test.go` (new or existing)
+Depends on: none
+Description: Add provider abstraction compliance tests covering provider IDs, spec alignment, and valid dashboard standard section usage.
+Tests: New table-driven tests over `AllProviders()`.
+
+### Task 5: Integration verification
+Files: none (test/build only)
+Depends on: Tasks 1-4
+Description: Run build/tests/lint/vet for changed areas and verify no regressions in dashboard rendering and settings navigation.
+Tests: `make build`, `go test ./internal/config ./internal/tui ./internal/providers -race`, `make vet`, `make lint` (skip if unavailable).
+
+### Dependency Graph
+
+- Task 1: foundational
+- Task 4: parallel with Task 1
+- Task 2: depends on Task 1
+- Task 3: depends on Task 2
+- Task 5: depends on Tasks 1-4

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,11 @@ type DashboardProviderConfig struct {
 	Enabled   bool   `json:"enabled"`
 }
 
+type DashboardWidgetSection struct {
+	ID      core.DashboardStandardSection `json:"id"`
+	Enabled bool                          `json:"enabled"`
+}
+
 const (
 	DashboardViewGrid    = "grid"
 	DashboardViewStacked = "stacked"
@@ -67,9 +72,29 @@ func (p *DashboardProviderConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *DashboardWidgetSection) UnmarshalJSON(data []byte) error {
+	type rawDashboardWidgetSection struct {
+		ID      string `json:"id"`
+		Enabled *bool  `json:"enabled"`
+	}
+
+	var raw rawDashboardWidgetSection
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	s.ID = core.DashboardStandardSection(raw.ID)
+	s.Enabled = true
+	if raw.Enabled != nil {
+		s.Enabled = *raw.Enabled
+	}
+	return nil
+}
+
 type DashboardConfig struct {
-	Providers []DashboardProviderConfig `json:"providers"`
-	View      string                    `json:"view"`
+	Providers      []DashboardProviderConfig `json:"providers"`
+	View           string                    `json:"view"`
+	WidgetSections []DashboardWidgetSection  `json:"widget_sections,omitempty"`
 }
 
 type IntegrationState struct {
@@ -167,6 +192,7 @@ func LoadFrom(path string) (Config, error) {
 	cfg.AutoDetectedAccounts = normalizeAccounts(cfg.AutoDetectedAccounts)
 	cfg.Dashboard.Providers = normalizeDashboardProviders(cfg.Dashboard.Providers)
 	cfg.Dashboard.View = normalizeDashboardView(cfg.Dashboard.View)
+	cfg.Dashboard.WidgetSections = normalizeDashboardWidgetSections(cfg.Dashboard.WidgetSections)
 
 	return cfg, nil
 }
@@ -247,6 +273,39 @@ func normalizeDashboardView(view string) string {
 	}
 }
 
+func normalizeDashboardWidgetSections(in []DashboardWidgetSection) []DashboardWidgetSection {
+	if len(in) == 0 {
+		return nil
+	}
+	return normalizeDashboardWidgetSectionEntries(in)
+}
+
+func normalizeDashboardWidgetSectionEntries(in []DashboardWidgetSection) []DashboardWidgetSection {
+	if len(in) == 0 {
+		return nil
+	}
+
+	normalized := make([]DashboardWidgetSection, 0, len(in))
+	seenSections := make(map[core.DashboardStandardSection]bool, len(in))
+
+	for _, section := range in {
+		sectionID := core.DashboardStandardSection(strings.ToLower(strings.TrimSpace(string(section.ID))))
+		if sectionID == core.DashboardSectionHeader || !core.IsKnownDashboardStandardSection(sectionID) || seenSections[sectionID] {
+			continue
+		}
+		normalized = append(normalized, DashboardWidgetSection{
+			ID:      sectionID,
+			Enabled: section.Enabled,
+		})
+		seenSections[sectionID] = true
+	}
+
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
 // saveMu guards read-modify-write cycles on the config file.
 var saveMu sync.Mutex
 
@@ -320,6 +379,24 @@ func SaveDashboardViewTo(path string, view string) error {
 		cfg = DefaultConfig()
 	}
 	cfg.Dashboard.View = normalizeDashboardView(view)
+	return SaveTo(path, cfg)
+}
+
+// SaveDashboardWidgetSections persists dashboard widget section preferences
+// into the config file (read-modify-write).
+func SaveDashboardWidgetSections(sections []DashboardWidgetSection) error {
+	return SaveDashboardWidgetSectionsTo(ConfigPath(), sections)
+}
+
+func SaveDashboardWidgetSectionsTo(path string, sections []DashboardWidgetSection) error {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		cfg = DefaultConfig()
+	}
+	cfg.Dashboard.WidgetSections = normalizeDashboardWidgetSections(sections)
 	return SaveTo(path, cfg)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -557,6 +557,92 @@ func TestSaveDashboardViewTo(t *testing.T) {
 	}
 }
 
+func TestLoadFrom_DashboardWidgetSections(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	content := `{
+  "dashboard": {
+    "widget_sections": [
+      {"id": "top_usage_progress"},
+      {"id": "unknown_section", "enabled": true},
+      {"id": "header", "enabled": true},
+      {"id": "top_usage_progress", "enabled": false},
+      {"id": "other_data", "enabled": false},
+      {"id": "daily_usage", "enabled": true}
+    ]
+  }
+}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.Dashboard.WidgetSections) != 3 {
+		t.Fatalf("widget_sections count = %d, want 3", len(cfg.Dashboard.WidgetSections))
+	}
+	if cfg.Dashboard.WidgetSections[0].ID != core.DashboardSectionTopUsageProgress || !cfg.Dashboard.WidgetSections[0].Enabled {
+		t.Fatalf("section[0] = %#v, want top_usage_progress enabled=true", cfg.Dashboard.WidgetSections[0])
+	}
+	if cfg.Dashboard.WidgetSections[1].ID != core.DashboardSectionOtherData || cfg.Dashboard.WidgetSections[1].Enabled {
+		t.Fatalf("section[1] = %#v, want other_data enabled=false", cfg.Dashboard.WidgetSections[1])
+	}
+	if cfg.Dashboard.WidgetSections[2].ID != core.DashboardSectionDailyUsage || !cfg.Dashboard.WidgetSections[2].Enabled {
+		t.Fatalf("section[2] = %#v, want daily_usage enabled=true", cfg.Dashboard.WidgetSections[2])
+	}
+}
+
+func TestSaveDashboardWidgetSectionsTo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+
+	cfg := DefaultConfig()
+	cfg.Theme = "Nord"
+	cfg.Dashboard.View = DashboardViewSplit
+	cfg.Dashboard.Providers = []DashboardProviderConfig{
+		{AccountID: "openai-personal", Enabled: true},
+	}
+	if err := SaveTo(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	sections := []DashboardWidgetSection{
+		{ID: core.DashboardSectionTopUsageProgress, Enabled: true},
+		{ID: core.DashboardSectionOtherData, Enabled: false},
+		{ID: core.DashboardStandardSection("unknown"), Enabled: true},
+		{ID: core.DashboardSectionHeader, Enabled: true},
+		{ID: core.DashboardSectionTopUsageProgress, Enabled: false},
+	}
+	if err := SaveDashboardWidgetSectionsTo(path, sections); err != nil {
+		t.Fatalf("SaveDashboardWidgetSectionsTo error: %v", err)
+	}
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if loaded.Theme != "Nord" {
+		t.Errorf("theme should be preserved, got %q", loaded.Theme)
+	}
+	if loaded.Dashboard.View != DashboardViewSplit {
+		t.Errorf("dashboard.view should be preserved, got %q", loaded.Dashboard.View)
+	}
+	if len(loaded.Dashboard.Providers) != 1 || loaded.Dashboard.Providers[0].AccountID != "openai-personal" {
+		t.Errorf("dashboard.providers should be preserved, got %#v", loaded.Dashboard.Providers)
+	}
+	if len(loaded.Dashboard.WidgetSections) != 2 {
+		t.Fatalf("widget_sections count = %d, want 2", len(loaded.Dashboard.WidgetSections))
+	}
+	if loaded.Dashboard.WidgetSections[0].ID != core.DashboardSectionTopUsageProgress || !loaded.Dashboard.WidgetSections[0].Enabled {
+		t.Fatalf("section[0] = %#v, want top_usage_progress enabled=true", loaded.Dashboard.WidgetSections[0])
+	}
+	if loaded.Dashboard.WidgetSections[1].ID != core.DashboardSectionOtherData || loaded.Dashboard.WidgetSections[1].Enabled {
+		t.Fatalf("section[1] = %#v, want other_data enabled=false", loaded.Dashboard.WidgetSections[1])
+	}
+}
+
 func TestLoadFrom_DashboardViewTabs(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	if err := os.WriteFile(path, []byte(`{"dashboard":{"view":"tabs"}}`), 0o644); err != nil {

--- a/internal/core/widget.go
+++ b/internal/core/widget.go
@@ -143,6 +143,18 @@ func isKnownDashboardSection(section DashboardStandardSection) bool {
 	}
 }
 
+// DashboardStandardSections returns the canonical dashboard section list
+// in the default render order.
+func DashboardStandardSections() []DashboardStandardSection {
+	return append([]DashboardStandardSection(nil), defaultDashboardSectionOrder()...)
+}
+
+// IsKnownDashboardStandardSection reports whether section is a supported
+// dashboard standard section identifier.
+func IsKnownDashboardStandardSection(section DashboardStandardSection) bool {
+	return isKnownDashboardSection(section)
+}
+
 type DashboardWidget struct {
 	DisplayStyle DashboardDisplayStyle
 	ResetStyle   DashboardResetStyle

--- a/internal/core/widget_test.go
+++ b/internal/core/widget_test.go
@@ -56,3 +56,32 @@ func TestDashboardWidget_EffectiveStandardSectionOrderFiltersUnknownAndDuplicate
 		}
 	}
 }
+
+func TestDashboardStandardSections_ReturnsCanonicalOrderedCopy(t *testing.T) {
+	got := DashboardStandardSections()
+	want := DefaultDashboardWidget().EffectiveStandardSectionOrder()
+
+	if len(got) != len(want) {
+		t.Fatalf("section count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("section[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	got[0] = DashboardSectionOtherData
+	again := DashboardStandardSections()
+	if again[0] != DashboardSectionHeader {
+		t.Fatalf("DashboardStandardSections should return a copy; first = %q", again[0])
+	}
+}
+
+func TestIsKnownDashboardStandardSection(t *testing.T) {
+	if !IsKnownDashboardStandardSection(DashboardSectionTopUsageProgress) {
+		t.Fatal("expected top_usage_progress to be known")
+	}
+	if IsKnownDashboardStandardSection(DashboardStandardSection("nope")) {
+		t.Fatal("unexpected unknown section marked as known")
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	defaultCodexSessionsDir     = "~/.codex/sessions"
+	defaultGeminiSessionsDir    = "~/.gemini/tmp"
 	defaultClaudeProjectsDir    = "~/.claude/projects"
 	defaultClaudeProjectsAltDir = "~/.config/claude/projects"
 	defaultOpenCodeDBPath       = "~/.local/share/opencode/opencode.db"
@@ -508,13 +509,22 @@ func (s *Service) runHookSpoolLoop(ctx context.Context) {
 		return
 	}
 
-	processTicker := time.NewTicker(5 * time.Second)
-	cleanupTicker := time.NewTicker(5 * time.Minute)
+	processInterval := 5 * time.Second
+	cleanupInterval := 5 * time.Minute
+	processTicker := time.NewTicker(processInterval)
+	cleanupTicker := time.NewTicker(cleanupInterval)
 	defer processTicker.Stop()
 	defer cleanupTicker.Stop()
 
-	s.infof("hook_spool_loop_start", "dir=%s", hookSpoolDir)
+	s.infof(
+		"hook_spool_loop_start",
+		"dir=%s process_interval=%s cleanup_interval=%s",
+		hookSpoolDir,
+		processInterval,
+		cleanupInterval,
+	)
 	s.processHookSpool(ctx, hookSpoolDir)
+	s.cleanupHookSpool(hookSpoolDir)
 
 	for {
 		select {
@@ -1173,6 +1183,7 @@ func defaultTelemetryOptionsForSource(sourceSystem string) shared.TelemetryColle
 	return telemetryOptionsForSource(
 		sourceSystem,
 		defaultCodexSessionsDir,
+		defaultGeminiSessionsDir,
 		defaultClaudeProjectsDir,
 		defaultClaudeProjectsAltDir,
 		nil,
@@ -1184,6 +1195,7 @@ func defaultTelemetryOptionsForSource(sourceSystem string) shared.TelemetryColle
 func telemetryOptionsForSource(
 	sourceSystem string,
 	codexSessions string,
+	geminiSessions string,
 	claudeProjects string,
 	claudeProjectsAlt string,
 	opencodeEventsDirs []string,
@@ -1198,6 +1210,8 @@ func telemetryOptionsForSource(
 	switch sourceSystem {
 	case "codex":
 		opts.Paths["sessions_dir"] = codexSessions
+	case "gemini_cli":
+		opts.Paths["sessions_dir"] = geminiSessions
 	case "claude_code":
 		opts.Paths["projects_dir"] = claudeProjects
 		opts.Paths["alt_projects_dir"] = claudeProjectsAlt

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -105,6 +105,9 @@ func startService(ctx context.Context, cfg Config) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open daemon telemetry store: %w", err)
 	}
+	if err := store.RunMigrations(ctx); err != nil {
+		log.Printf("[daemon] warning: migrations failed: %v", err)
+	}
 
 	svc := &Service{
 		cfg:               cfg,
@@ -311,16 +314,20 @@ func (s *Service) computeReadModel(
 	ctx context.Context,
 	req ReadModelRequest,
 ) (map[string]core.UsageSnapshot, error) {
+	start := time.Now()
 	templates := ReadModelTemplatesFromRequest(req, DisabledAccountsFromConfig())
 	if len(templates) == 0 {
 		return map[string]core.UsageSnapshot{}, nil
 	}
 	tw := core.ParseTimeWindow(req.TimeWindow)
-	return telemetry.ApplyCanonicalTelemetryViewWithOptions(ctx, s.cfg.DBPath, templates, telemetry.ReadModelOptions{
+	result, err := telemetry.ApplyCanonicalTelemetryViewWithOptions(ctx, s.cfg.DBPath, templates, telemetry.ReadModelOptions{
 		ProviderLinks:   req.ProviderLinks,
 		TimeWindowHours: tw.Hours(),
 		TimeWindow:      req.TimeWindow,
 	})
+	core.Tracef("[read_model_perf] computeReadModel TOTAL: %dms (window=%s, accounts=%d, results=%d)",
+		time.Since(start).Milliseconds(), req.TimeWindow, len(req.Accounts), len(result))
+	return result, err
 }
 
 func (s *Service) refreshReadModelCacheAsync(
@@ -730,6 +737,16 @@ func (s *Service) pruneTelemetryOrphans(ctx context.Context) {
 	if removed > 0 {
 		s.infof("prune_orphan_raw_events", "removed=%d batch_size=%d", removed, pruneBatchSize)
 	}
+
+	// Opportunistically prune raw payloads older than 1 hour during each
+	// orphan cleanup cycle. This keeps the DB compact without waiting for
+	// the 6-hour retention loop.
+	payloadCtx, payloadCancel := context.WithTimeout(ctx, 4*time.Second)
+	defer payloadCancel()
+	pruned, pruneErr := s.store.PruneRawEventPayloads(payloadCtx, 1, pruneBatchSize)
+	if pruneErr == nil && pruned > 0 {
+		s.infof("prune_raw_payloads", "pruned=%d", pruned)
+	}
 }
 
 // --- Retention loop ---
@@ -787,6 +804,8 @@ func (s *Service) pruneOldData(ctx context.Context) {
 			s.infof("retention_orphan_prune", "removed=%d", orphaned)
 		}
 	}
+
+	// Payload pruning is handled by pruneTelemetryOrphans (runs every ~45s).
 }
 
 // --- Poll loop ---
@@ -1127,7 +1146,7 @@ func (s *Service) handleReadModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	computeCtx, cancel := context.WithTimeout(r.Context(), 500*time.Millisecond)
+	computeCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	snapshots, err := s.computeReadModel(computeCtx, req)
 	cancel()
 	if err == nil && len(snapshots) > 0 {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -83,3 +83,26 @@ func TestEnsureSocketPathAvailable_RejectsRegularFile(t *testing.T) {
 		t.Fatalf("error = %q, want not a socket message", err)
 	}
 }
+
+func TestTelemetryOptionsForSource_GeminiSessionsPath(t *testing.T) {
+	opts := telemetryOptionsForSource(
+		"gemini_cli",
+		"/tmp/codex-sessions",
+		"/tmp/gemini-sessions",
+		"/tmp/claude-projects",
+		"/tmp/claude-projects-alt",
+		[]string{"/tmp/opencode-events"},
+		"/tmp/opencode-events.jsonl",
+		"/tmp/opencode.db",
+	)
+
+	if got := opts.Paths["sessions_dir"]; got != "/tmp/gemini-sessions" {
+		t.Fatalf("sessions_dir = %q, want /tmp/gemini-sessions", got)
+	}
+	if _, ok := opts.Paths["projects_dir"]; ok {
+		t.Fatalf("unexpected claude projects_dir for gemini source: %+v", opts.Paths)
+	}
+	if _, ok := opts.Paths["events_file"]; ok {
+		t.Fatalf("unexpected opencode events_file for gemini source: %+v", opts.Paths)
+	}
+}

--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -1078,6 +1078,25 @@ func inferToolCallOutcome(output string) int {
 		}
 		return 2
 	}
+	if idx := strings.Index(lower, "exit code "); idx >= 0 {
+		rest := lower[idx+len("exit code "):]
+		n := 0
+		foundDigit := false
+		for _, r := range rest {
+			if r < '0' || r > '9' {
+				if foundDigit {
+					break
+				}
+				continue
+			}
+			foundDigit = true
+			n = n*10 + int(r-'0')
+		}
+		if !foundDigit || n == 0 {
+			return 1
+		}
+		return 2
+	}
 	if strings.Contains(lower, `"exit_code":`) && !strings.Contains(lower, `"exit_code":0`) {
 		return 2
 	}
@@ -1670,6 +1689,8 @@ func classifyClient(source, originator string) string {
 	org := strings.ToLower(strings.TrimSpace(originator))
 
 	switch {
+	case src == "openusage" || src == "codex":
+		return "CLI"
 	case strings.Contains(org, "desktop"):
 		return "Desktop App"
 	case strings.Contains(org, "exec") || src == "exec":

--- a/internal/providers/codex/codex_test.go
+++ b/internal/providers/codex/codex_test.go
@@ -687,6 +687,15 @@ func TestFetchBuildsModelAndClientUsageSplits(t *testing.T) {
 	}
 }
 
+func TestClassifyClient_NormalizesCodexWrapperSources(t *testing.T) {
+	if got := classifyClient("openusage", ""); got != "CLI" {
+		t.Fatalf("classifyClient(openusage) = %q, want CLI", got)
+	}
+	if got := classifyClient("codex", ""); got != "CLI" {
+		t.Fatalf("classifyClient(codex) = %q, want CLI", got)
+	}
+}
+
 func TestFetchExtractsToolLanguageAndCodeStats(t *testing.T) {
 	tmpDir := t.TempDir()
 	sessionsRoot := filepath.Join(tmpDir, "sessions")

--- a/internal/providers/codex/telemetry_usage.go
+++ b/internal/providers/codex/telemetry_usage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -20,13 +21,18 @@ type telemetrySessionEvent struct {
 }
 
 type telemetrySessionMeta struct {
-	ID        string `json:"id"`
-	SessionID string `json:"session_id"`
-	Model     string `json:"model"`
+	ID            string `json:"id"`
+	SessionID     string `json:"session_id"`
+	Model         string `json:"model"`
+	CWD           string `json:"cwd"`
+	Source        string `json:"source"`
+	Originator    string `json:"originator"`
+	ModelProvider string `json:"model_provider"`
 }
 
 type telemetryTurnContext struct {
-	Model string `json:"model"`
+	Model  string `json:"model"`
+	TurnID string `json:"turn_id"`
 }
 
 type telemetryTokenInfo struct {
@@ -40,10 +46,16 @@ type telemetryEventPayload struct {
 	MessageID string              `json:"message_id,omitempty"`
 }
 
+const (
+	codexTelemetryProviderID    = "codex"
+	codexTelemetryUpstreamModel = "openai"
+)
+
 func (p *Provider) System() string { return p.ID() }
 
 func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOptions) ([]shared.TelemetryEvent, error) {
 	sessionsDir := shared.ExpandHome(opts.Path("sessions_dir", DefaultTelemetrySessionsDir()))
+	accountID := strings.TrimSpace(opts.Path("account_id", "codex-cli"))
 	files := shared.CollectFilesByExt([]string{sessionsDir}, map[string]bool{".jsonl": true})
 	if len(files) == 0 {
 		return nil, nil
@@ -57,6 +69,11 @@ func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOpti
 		events, err := ParseTelemetrySessionFile(path)
 		if err != nil {
 			continue
+		}
+		if accountID != "" {
+			for i := range events {
+				events[i].AccountID = accountID
+			}
 		}
 		out = append(out, events...)
 	}
@@ -86,9 +103,16 @@ func ParseTelemetrySessionFile(path string) ([]shared.TelemetryEvent, error) {
 
 	sessionID := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 	model := ""
+	upstreamProviderID := codexTelemetryUpstreamModel
+	workspaceID := ""
+	currentTurnID := ""
+	clientName := "Other"
+	clientSource := ""
+	clientOriginator := ""
 	var previous tokenUsage
 	hasPrevious := false
 	turnIndex := 0
+	toolByCallID := make(map[string]int)
 
 	var out []shared.TelemetryEvent
 	scanner := bufio.NewScanner(f)
@@ -113,11 +137,25 @@ func ParseTelemetrySessionFile(path string) ([]shared.TelemetryEvent, error) {
 				if strings.TrimSpace(meta.Model) != "" {
 					model = strings.TrimSpace(meta.Model)
 				}
+				if strings.TrimSpace(meta.ModelProvider) != "" {
+					upstreamProviderID = strings.TrimSpace(meta.ModelProvider)
+				}
+				if ws := shared.SanitizeWorkspace(meta.CWD); ws != "" {
+					workspaceID = ws
+				}
+				clientSource = strings.TrimSpace(meta.Source)
+				clientOriginator = strings.TrimSpace(meta.Originator)
+				clientName = classifyClient(clientSource, clientOriginator)
 			}
 		case "turn_context":
 			var tc telemetryTurnContext
-			if json.Unmarshal(ev.Payload, &tc) == nil && strings.TrimSpace(tc.Model) != "" {
-				model = strings.TrimSpace(tc.Model)
+			if json.Unmarshal(ev.Payload, &tc) == nil {
+				if strings.TrimSpace(tc.Model) != "" {
+					model = strings.TrimSpace(tc.Model)
+				}
+				if strings.TrimSpace(tc.TurnID) != "" {
+					currentTurnID = strings.TrimSpace(tc.TurnID)
+				}
 			}
 		case "event_msg":
 			var payload telemetryEventPayload
@@ -147,12 +185,15 @@ func ParseTelemetrySessionFile(path string) ([]shared.TelemetryEvent, error) {
 			}
 
 			turnID := fmt.Sprintf("%s:%d", sessionID, turnIndex)
+			if strings.TrimSpace(currentTurnID) != "" {
+				turnID = strings.TrimSpace(currentTurnID)
+			}
 			if strings.TrimSpace(payload.RequestID) != "" {
 				turnID = strings.TrimSpace(payload.RequestID)
 			}
 			messageID := strings.TrimSpace(payload.MessageID)
 			if messageID == "" {
-				messageID = fmt.Sprintf("%s:%d", sessionID, lineNumber)
+				messageID = turnID
 			}
 
 			out = append(out, shared.TelemetryEvent{
@@ -160,10 +201,11 @@ func ParseTelemetrySessionFile(path string) ([]shared.TelemetryEvent, error) {
 				Channel:         shared.TelemetryChannelJSONL,
 				OccurredAt:      occurredAt,
 				AccountID:       "codex",
+				WorkspaceID:     workspaceID,
 				SessionID:       sessionID,
 				TurnID:          turnID,
 				MessageID:       messageID,
-				ProviderID:      "openai",
+				ProviderID:      codexTelemetryProviderID,
 				AgentName:       "codex",
 				EventType:       shared.TelemetryEventTypeMessageUsage,
 				ModelRaw:        model,
@@ -174,10 +216,90 @@ func ParseTelemetrySessionFile(path string) ([]shared.TelemetryEvent, error) {
 				TotalTokens:     shared.Int64Ptr(int64(delta.TotalTokens)),
 				Status:          shared.TelemetryStatusOK,
 				Payload: map[string]any{
-					"source_file": path,
-					"line":        lineNumber,
+					"source_file":       path,
+					"line":              lineNumber,
+					"upstream_provider": upstreamProviderID,
+					"client":            clientName,
+					"client_source":     clientSource,
+					"client_originator": clientOriginator,
 				},
 			})
+		case "response_item":
+			var item responseItemPayload
+			if json.Unmarshal(ev.Payload, &item) != nil {
+				continue
+			}
+
+			occurredAt := time.Now().UTC()
+			if ts, err := shared.ParseTimestampString(ev.Timestamp); err == nil {
+				occurredAt = ts
+			}
+
+			switch item.Type {
+			case "function_call", "custom_tool_call", "web_search_call":
+				toolName := normalizeToolName(item.Name)
+				if item.Type == "web_search_call" {
+					toolName = "web_search"
+				}
+				if strings.TrimSpace(toolName) == "" {
+					toolName = "unknown"
+				}
+
+				turnID := fmt.Sprintf("%s:tool:%d", sessionID, lineNumber)
+				if strings.TrimSpace(currentTurnID) != "" {
+					turnID = strings.TrimSpace(currentTurnID)
+				}
+				callID := strings.TrimSpace(item.CallID)
+				messageID := shared.FirstNonEmpty(callID, turnID, fmt.Sprintf("%s:%d", sessionID, lineNumber))
+				eventPayload := codexBuildToolPayload(path, lineNumber, item)
+				if strings.TrimSpace(upstreamProviderID) != "" {
+					eventPayload["upstream_provider"] = strings.TrimSpace(upstreamProviderID)
+				}
+				eventPayload["client"] = clientName
+				if clientSource != "" {
+					eventPayload["client_source"] = clientSource
+				}
+				if clientOriginator != "" {
+					eventPayload["client_originator"] = clientOriginator
+				}
+
+				out = append(out, shared.TelemetryEvent{
+					SchemaVersion: "codex_session_v1",
+					Channel:       shared.TelemetryChannelJSONL,
+					OccurredAt:    occurredAt,
+					AccountID:     "codex",
+					WorkspaceID:   workspaceID,
+					SessionID:     sessionID,
+					TurnID:        turnID,
+					MessageID:     messageID,
+					ToolCallID:    callID,
+					ProviderID:    codexTelemetryProviderID,
+					AgentName:     "codex",
+					EventType:     shared.TelemetryEventTypeToolUsage,
+					ModelRaw:      model,
+					ToolName:      toolName,
+					Requests:      shared.Int64Ptr(1),
+					Status:        shared.TelemetryStatusOK,
+					Payload:       eventPayload,
+				})
+				if callID != "" {
+					toolByCallID[callID] = len(out) - 1
+				}
+			case "function_call_output", "custom_tool_call_output":
+				callID := strings.TrimSpace(item.CallID)
+				idx, ok := toolByCallID[callID]
+				if !ok || idx < 0 || idx >= len(out) {
+					continue
+				}
+				switch inferToolCallOutcome(item.Output) {
+				case 2:
+					out[idx].Status = shared.TelemetryStatusError
+				case 3:
+					out[idx].Status = shared.TelemetryStatusAborted
+				default:
+					out[idx].Status = shared.TelemetryStatusOK
+				}
+			}
 		}
 	}
 
@@ -230,9 +352,9 @@ func ParseTelemetryNotifyPayload(raw []byte, opts shared.TelemetryCollectOptions
 		[]string{"messageID"},
 		[]string{"last_assistant_message", "id"},
 	)
-	providerID := shared.FirstNonEmpty(
+	upstreamProviderID := shared.FirstNonEmpty(
 		codexFirstPathString(root, []string{"provider_id"}, []string{"providerID"}, []string{"provider"}),
-		"openai",
+		codexTelemetryUpstreamModel,
 	)
 	modelRaw := codexFirstPathString(root,
 		[]string{"model"},
@@ -248,12 +370,54 @@ func ParseTelemetryNotifyPayload(raw []byte, opts shared.TelemetryCollectOptions
 	accountID := shared.FirstNonEmpty(
 		strings.TrimSpace(opts.Path("account_id", "")),
 		codexFirstPathString(root, []string{"account_id"}, []string{"accountID"}),
-		"codex",
+		"codex-cli",
 	)
+	eventStatus := codexHookEventStatus(root)
+	hookSource := strings.TrimSpace(codexFirstPathString(root, []string{"source"}))
+	hookOriginator := strings.TrimSpace(codexFirstPathString(root, []string{"originator"}))
+	if hookSource != "" || hookOriginator != "" {
+		root["client"] = classifyClient(hookSource, hookOriginator)
+		if hookSource != "" {
+			root["client_source"] = hookSource
+		}
+		if hookOriginator != "" {
+			root["client_originator"] = hookOriginator
+		}
+	}
+	if strings.TrimSpace(upstreamProviderID) != "" {
+		root["upstream_provider"] = strings.TrimSpace(upstreamProviderID)
+	}
+
+	out := make([]shared.TelemetryEvent, 0, 2)
+
+	if toolName, toolCallID, hasTool := codexExtractHookTool(root); hasTool {
+		if paths := shared.ExtractFilePathsFromPayload(root); len(paths) > 0 {
+			root["file"] = paths[0]
+		}
+		out = append(out, shared.TelemetryEvent{
+			SchemaVersion: "codex_notify_v1",
+			Channel:       shared.TelemetryChannelHook,
+			OccurredAt:    occurredAt,
+			AccountID:     accountID,
+			WorkspaceID:   workspaceID,
+			SessionID:     sessionID,
+			TurnID:        turnID,
+			MessageID:     messageID,
+			ToolCallID:    toolCallID,
+			ProviderID:    codexTelemetryProviderID,
+			AgentName:     "codex",
+			EventType:     shared.TelemetryEventTypeToolUsage,
+			ModelRaw:      modelRaw,
+			ToolName:      toolName,
+			Requests:      shared.Int64Ptr(1),
+			Status:        eventStatus,
+			Payload:       root,
+		})
+	}
 
 	usage := codexExtractHookUsage(root)
 	if codexHasHookUsage(usage) {
-		return []shared.TelemetryEvent{{
+		out = append(out, shared.TelemetryEvent{
 			SchemaVersion:    "codex_notify_v1",
 			Channel:          shared.TelemetryChannelHook,
 			OccurredAt:       occurredAt,
@@ -262,7 +426,7 @@ func ParseTelemetryNotifyPayload(raw []byte, opts shared.TelemetryCollectOptions
 			SessionID:        sessionID,
 			TurnID:           turnID,
 			MessageID:        messageID,
-			ProviderID:       providerID,
+			ProviderID:       codexTelemetryProviderID,
 			AgentName:        "codex",
 			EventType:        shared.TelemetryEventTypeMessageUsage,
 			ModelRaw:         modelRaw,
@@ -276,15 +440,11 @@ func ParseTelemetryNotifyPayload(raw []byte, opts shared.TelemetryCollectOptions
 			Requests:         shared.Int64Ptr(1),
 			Status:           shared.TelemetryStatusOK,
 			Payload:          root,
-		}}, nil
+		})
 	}
 
-	eventStatus := shared.TelemetryStatusOK
-	switch strings.ToLower(strings.TrimSpace(codexFirstPathString(root, []string{"status"}, []string{"result"}, []string{"outcome"}))) {
-	case "error", "failed", "failure":
-		eventStatus = shared.TelemetryStatusError
-	case "aborted", "canceled", "cancelled":
-		eventStatus = shared.TelemetryStatusAborted
+	if len(out) > 0 {
+		return out, nil
 	}
 
 	return []shared.TelemetryEvent{{
@@ -296,7 +456,7 @@ func ParseTelemetryNotifyPayload(raw []byte, opts shared.TelemetryCollectOptions
 		SessionID:     sessionID,
 		TurnID:        turnID,
 		MessageID:     messageID,
-		ProviderID:    providerID,
+		ProviderID:    codexTelemetryProviderID,
 		AgentName:     "codex",
 		EventType:     shared.TelemetryEventTypeTurnCompleted,
 		ModelRaw:      modelRaw,
@@ -472,4 +632,146 @@ func codexNumberToFloat64Ptr(v *float64) *float64 {
 		return nil
 	}
 	return shared.Float64Ptr(*v)
+}
+
+func codexBuildToolPayload(sourcePath string, lineNumber int, item responseItemPayload) map[string]any {
+	payload := map[string]any{
+		"source_file": sourcePath,
+		"line":        lineNumber,
+	}
+
+	setFirstToolPath := func(value any) {
+		if _, exists := payload["file"]; exists {
+			return
+		}
+		paths := shared.ExtractFilePathsFromPayload(value)
+		if len(paths) > 0 {
+			payload["file"] = paths[0]
+		}
+	}
+
+	if parsed, ok := codexDecodeJSONValue(item.Arguments); ok {
+		setFirstToolPath(parsed)
+		if argsMap, ok := parsed.(map[string]any); ok {
+			if cmd, ok := argsMap["cmd"].(string); ok && strings.TrimSpace(cmd) != "" {
+				payload["command"] = cmd
+				setFirstToolPath(map[string]any{"path": cmd})
+			}
+		}
+	}
+	if parsed, ok := codexDecodeJSONValue(item.Input); ok {
+		setFirstToolPath(parsed)
+	} else if strings.TrimSpace(item.Input) != "" {
+		setFirstToolPath(map[string]any{"path": item.Input})
+	}
+
+	if strings.EqualFold(strings.TrimSpace(item.Name), "apply_patch") && strings.TrimSpace(item.Input) != "" {
+		stats := patchStats{
+			Files:   make(map[string]struct{}),
+			Deleted: make(map[string]struct{}),
+		}
+		accumulatePatchStats(item.Input, &stats, make(map[string]int))
+		if stats.Added > 0 {
+			payload["lines_added"] = stats.Added
+		}
+		if stats.Removed > 0 {
+			payload["lines_removed"] = stats.Removed
+		}
+		if _, exists := payload["file"]; !exists {
+			if first := codexFirstFileFromPatchStats(stats); first != "" {
+				payload["file"] = first
+			}
+		}
+	}
+
+	return payload
+}
+
+func codexDecodeJSONValue(raw any) (any, bool) {
+	var body string
+	switch v := raw.(type) {
+	case string:
+		body = strings.TrimSpace(v)
+	case json.RawMessage:
+		body = strings.TrimSpace(string(v))
+	case []byte:
+		body = strings.TrimSpace(string(v))
+	default:
+		return nil, false
+	}
+	if body == "" {
+		return nil, false
+	}
+
+	dec := json.NewDecoder(strings.NewReader(body))
+	dec.UseNumber()
+	var out any
+	if err := dec.Decode(&out); err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+func codexFirstFileFromPatchStats(stats patchStats) string {
+	files := make([]string, 0, len(stats.Files)+len(stats.Deleted))
+	for file := range stats.Files {
+		files = append(files, file)
+	}
+	for file := range stats.Deleted {
+		files = append(files, file)
+	}
+	if len(files) == 0 {
+		return ""
+	}
+	sort.Strings(files)
+	return files[0]
+}
+
+func codexHookEventStatus(root map[string]any) shared.TelemetryStatus {
+	switch strings.ToLower(strings.TrimSpace(codexFirstPathString(root,
+		[]string{"status"},
+		[]string{"result"},
+		[]string{"outcome"},
+		[]string{"tool", "status"},
+		[]string{"tool_result", "status"},
+	))) {
+	case "error", "failed", "failure":
+		return shared.TelemetryStatusError
+	case "aborted", "canceled", "cancelled":
+		return shared.TelemetryStatusAborted
+	default:
+		return shared.TelemetryStatusOK
+	}
+}
+
+func codexExtractHookTool(root map[string]any) (toolName, toolCallID string, ok bool) {
+	eventName := strings.ToLower(shared.FirstNonEmpty(
+		codexFirstPathString(root, []string{"hook_event_name"}),
+		codexFirstPathString(root, []string{"hook_event"}),
+		codexFirstPathString(root, []string{"event"}),
+		codexFirstPathString(root, []string{"type"}),
+	))
+	toolName = strings.TrimSpace(codexFirstPathString(root,
+		[]string{"tool_name"},
+		[]string{"toolName"},
+		[]string{"tool", "name"},
+		[]string{"tool"},
+	))
+	if toolName == "" && strings.Contains(eventName, "tool") {
+		toolName = strings.TrimSpace(codexFirstPathString(root, []string{"name"}))
+	}
+	if toolName == "" {
+		return "", "", false
+	}
+	toolCallID = strings.TrimSpace(codexFirstPathString(root,
+		[]string{"tool_call_id"},
+		[]string{"toolCallID"},
+		[]string{"tool_call", "id"},
+		[]string{"call_id"},
+		[]string{"callID"},
+	))
+	if strings.Contains(eventName, "tool") || strings.HasPrefix(strings.ToLower(toolName), "mcp__") || toolCallID != "" {
+		return normalizeToolName(toolName), toolCallID, true
+	}
+	return "", "", false
 }

--- a/internal/providers/codex/telemetry_usage_test.go
+++ b/internal/providers/codex/telemetry_usage_test.go
@@ -45,6 +45,37 @@ func TestParseTelemetrySessionFile_CollectsTokenDeltas(t *testing.T) {
 	}
 }
 
+func TestParseTelemetrySessionFile_UsesTurnIDAsMessageIDFallback(t *testing.T) {
+	sessionsDir := filepath.Join(t.TempDir(), "sessions", "2026", "03", "05")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions dir: %v", err)
+	}
+
+	path := filepath.Join(sessionsDir, "rollout-messageid.jsonl")
+	content := `{"timestamp":"2026-03-05T10:00:00Z","type":"session_meta","payload":{"id":"sess-msgid"}}
+{"timestamp":"2026-03-05T10:00:01Z","type":"turn_context","payload":{"model":"gpt-5-codex","turn_id":"turn-1"}}
+{"timestamp":"2026-03-05T10:00:02Z","type":"event_msg","payload":{"type":"token_count","request_id":"req-1","info":{"total_token_usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}}}
+{"timestamp":"2026-03-05T10:00:03Z","type":"event_msg","payload":{"type":"token_count","request_id":"req-1","info":{"total_token_usage":{"input_tokens":12,"output_tokens":7,"total_tokens":19}}}}
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+
+	events, err := ParseTelemetrySessionFile(path)
+	if err != nil {
+		t.Fatalf("parse telemetry file: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2", len(events))
+	}
+	if events[0].MessageID != "req-1" {
+		t.Fatalf("first message_id = %q, want req-1", events[0].MessageID)
+	}
+	if events[1].MessageID != "req-1" {
+		t.Fatalf("second message_id = %q, want req-1", events[1].MessageID)
+	}
+}
+
 func TestParseTelemetryNotifyPayload_ParsesUsagePayload(t *testing.T) {
 	payload := []byte(`{
 		"type":"agent-turn-complete",
@@ -69,8 +100,11 @@ func TestParseTelemetryNotifyPayload_ParsesUsagePayload(t *testing.T) {
 	if ev.EventType != shared.TelemetryEventTypeMessageUsage {
 		t.Fatalf("event_type = %q, want message_usage", ev.EventType)
 	}
-	if ev.ProviderID != "openai" {
-		t.Fatalf("provider_id = %q, want openai", ev.ProviderID)
+	if ev.ProviderID != "codex" {
+		t.Fatalf("provider_id = %q, want codex", ev.ProviderID)
+	}
+	if got, _ := ev.Payload["upstream_provider"].(string); got != "openai" {
+		t.Fatalf("payload.upstream_provider = %q, want openai", got)
 	}
 	if ev.ModelRaw != "gpt-5-codex" {
 		t.Fatalf("model_raw = %q, want gpt-5-codex", ev.ModelRaw)
@@ -99,5 +133,135 @@ func TestParseTelemetryNotifyPayload_FallsBackToTurnCompleted(t *testing.T) {
 	}
 	if events[0].EventType != shared.TelemetryEventTypeTurnCompleted {
 		t.Fatalf("event_type = %q, want turn_completed", events[0].EventType)
+	}
+}
+
+func TestParseTelemetrySessionFile_ParsesToolUsageAndPatchStats(t *testing.T) {
+	sessionsDir := filepath.Join(t.TempDir(), "sessions", "2026", "03", "05")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions dir: %v", err)
+	}
+
+	path := filepath.Join(sessionsDir, "rollout-tools.jsonl")
+	content := `{"timestamp":"2026-03-05T19:00:00Z","type":"session_meta","payload":{"id":"sess-tools","cwd":"/Users/janekbaraniewski/Workspace/priv/openusage","source":"vscode","originator":"Codex Desktop","model_provider":"openai"}}
+{"timestamp":"2026-03-05T19:00:01Z","type":"turn_context","payload":{"model":"gpt-5-codex","turn_id":"turn-abc"}}
+{"timestamp":"2026-03-05T19:00:02Z","type":"response_item","payload":{"type":"function_call","name":"mcp__gopls__go_workspace","arguments":"{}","call_id":"call-mcp-1"}}
+{"timestamp":"2026-03-05T19:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-mcp-1","output":"failed to list namespaces: exit code 255"}}
+{"timestamp":"2026-03-05T19:00:04Z","type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","call_id":"call-patch-1","input":"*** Begin Patch\n*** Update File: internal/providers/codex/telemetry_usage.go\n+added\n-removed\n*** End Patch\n"}}
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+
+	events, err := ParseTelemetrySessionFile(path)
+	if err != nil {
+		t.Fatalf("parse telemetry file: %v", err)
+	}
+
+	var mcpEvent, patchEvent *shared.TelemetryEvent
+	for i := range events {
+		ev := &events[i]
+		if ev.EventType != shared.TelemetryEventTypeToolUsage {
+			continue
+		}
+		if ev.ToolName == "mcp__gopls__go_workspace" {
+			mcpEvent = ev
+		}
+		if ev.ToolName == "apply_patch" {
+			patchEvent = ev
+		}
+	}
+
+	if mcpEvent == nil {
+		t.Fatal("missing mcp tool usage event")
+	}
+	if mcpEvent.Status != shared.TelemetryStatusError {
+		t.Fatalf("mcp status = %q, want error", mcpEvent.Status)
+	}
+	if mcpEvent.WorkspaceID != "openusage" {
+		t.Fatalf("workspace_id = %q, want openusage", mcpEvent.WorkspaceID)
+	}
+	if mcpEvent.ProviderID != "codex" {
+		t.Fatalf("provider_id = %q, want codex", mcpEvent.ProviderID)
+	}
+	if got, _ := mcpEvent.Payload["upstream_provider"].(string); got != "openai" {
+		t.Fatalf("payload.upstream_provider = %q, want openai", got)
+	}
+	if got, _ := mcpEvent.Payload["client"].(string); got != "Desktop App" {
+		t.Fatalf("payload.client = %q, want Desktop App", got)
+	}
+	if mcpEvent.TurnID != "turn-abc" {
+		t.Fatalf("turn_id = %q, want turn-abc", mcpEvent.TurnID)
+	}
+
+	if patchEvent == nil {
+		t.Fatal("missing apply_patch tool usage event")
+	}
+	if got, ok := patchEvent.Payload["lines_added"].(int); !ok || got != 1 {
+		t.Fatalf("patch lines_added = %#v, want 1", patchEvent.Payload["lines_added"])
+	}
+	if got, ok := patchEvent.Payload["lines_removed"].(int); !ok || got != 1 {
+		t.Fatalf("patch lines_removed = %#v, want 1", patchEvent.Payload["lines_removed"])
+	}
+	if got, ok := patchEvent.Payload["file"].(string); !ok || got == "" {
+		t.Fatalf("patch payload file = %#v, want non-empty", patchEvent.Payload["file"])
+	}
+}
+
+func TestParseTelemetryNotifyPayload_EmitsToolAndUsageEvents(t *testing.T) {
+	payload := []byte(`{
+		"type":"tool.execute.after",
+		"timestamp":"2026-03-05T19:00:00Z",
+		"session_id":"sess-hook-1",
+		"turn_id":"turn-hook-1",
+		"message_id":"msg-hook-1",
+		"provider":"openai",
+		"model":"gpt-5-codex",
+		"tool_name":"mcp__gopls__go_workspace",
+		"tool_call_id":"tool-hook-1",
+		"tool_input":{"path":"internal/providers/codex/telemetry_usage.go"},
+		"usage":{"input_tokens":12,"output_tokens":5,"total_tokens":17}
+	}`)
+
+	events, err := ParseTelemetryNotifyPayload(payload, shared.TelemetryCollectOptions{})
+	if err != nil {
+		t.Fatalf("parse notify payload: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2", len(events))
+	}
+
+	var toolEv, usageEv *shared.TelemetryEvent
+	for i := range events {
+		if events[i].EventType == shared.TelemetryEventTypeToolUsage {
+			toolEv = &events[i]
+		}
+		if events[i].EventType == shared.TelemetryEventTypeMessageUsage {
+			usageEv = &events[i]
+		}
+	}
+	if toolEv == nil {
+		t.Fatal("missing tool_usage event")
+	}
+	if usageEv == nil {
+		t.Fatal("missing message_usage event")
+	}
+	if toolEv.ToolName != "mcp__gopls__go_workspace" {
+		t.Fatalf("tool name = %q, want mcp__gopls__go_workspace", toolEv.ToolName)
+	}
+	if toolEv.ToolCallID != "tool-hook-1" {
+		t.Fatalf("tool_call_id = %q, want tool-hook-1", toolEv.ToolCallID)
+	}
+	if toolEv.ProviderID != "codex" {
+		t.Fatalf("provider_id = %q, want codex", toolEv.ProviderID)
+	}
+	if got, _ := toolEv.Payload["upstream_provider"].(string); got != "openai" {
+		t.Fatalf("payload.upstream_provider = %q, want openai", got)
+	}
+	if got, _ := toolEv.Payload["file"].(string); got == "" {
+		t.Fatalf("tool payload file = %#v, want non-empty", toolEv.Payload["file"])
+	}
+	if usageEv.TotalTokens == nil || *usageEv.TotalTokens != 17 {
+		t.Fatalf("usage total_tokens = %#v, want 17", usageEv.TotalTokens)
 	}
 }

--- a/internal/providers/copilot/telemetry.go
+++ b/internal/providers/copilot/telemetry.go
@@ -2,6 +2,7 @@ package copilot
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,12 +11,15 @@ import (
 	"strings"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
+
 	"github.com/janekbaraniewski/openusage/internal/providers/shared"
 )
 
 const (
 	telemetrySchemaVersion   = "copilot_v2"
 	defaultCopilotSessionDir = ".copilot/session-state"
+	defaultCopilotStoreDB    = ".copilot/session-store.db"
 )
 
 type copilotTelemetryAssistantMessageData struct {
@@ -69,6 +73,7 @@ func (p *Provider) System() string { return p.ID() }
 // extracts usage telemetry events from assistant.usage entries.
 func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOptions) ([]shared.TelemetryEvent, error) {
 	sessionDir := shared.ExpandHome(opts.Path("sessions_dir", defaultCopilotSessionsDir()))
+	storeDB := shared.ExpandHome(opts.Path("session_store_db", defaultCopilotSessionStoreDB()))
 	if sessionDir == "" {
 		return nil, nil
 	}
@@ -79,6 +84,7 @@ func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOpti
 	}
 
 	var out []shared.TelemetryEvent
+	seenSessions := make(map[string]bool, len(entries))
 	for _, entry := range entries {
 		if ctx.Err() != nil {
 			return out, ctx.Err()
@@ -86,12 +92,20 @@ func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOpti
 		if !entry.IsDir() {
 			continue
 		}
+		seenSessions[entry.Name()] = true
 		eventsPath := filepath.Join(sessionDir, entry.Name(), "events.jsonl")
 		events, err := parseCopilotTelemetrySessionFile(eventsPath, entry.Name())
 		if err != nil {
 			continue
 		}
 		out = append(out, events...)
+	}
+
+	// Fallback to durable session-store metadata for sessions that no longer have
+	// events.jsonl state (Copilot rotates session-state aggressively).
+	storeEvents, err := parseCopilotTelemetrySessionStore(ctx, storeDB, seenSessions)
+	if err == nil {
+		out = append(out, storeEvents...)
 	}
 	return out, nil
 }
@@ -108,6 +122,14 @@ func defaultCopilotSessionsDir() string {
 		return ""
 	}
 	return filepath.Join(home, defaultCopilotSessionDir)
+}
+
+func defaultCopilotSessionStoreDB() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, defaultCopilotStoreDB)
 }
 
 // parseCopilotTelemetrySessionFile parses a single session's events.jsonl and
@@ -813,6 +835,22 @@ func parseCopilotTelemetryMCPTool(raw string) (string, string, bool) {
 		return "", "", false
 	}
 
+	// Copilot-native MCP wrappers: github_mcp_server_list_issues.
+	if parts := strings.SplitN(normalized, "_mcp_server_", 2); len(parts) == 2 {
+		server := sanitizeCopilotMCPSegment(parts[0])
+		function := sanitizeCopilotMCPSegment(parts[1])
+		if server != "" && function != "" {
+			return server, function, true
+		}
+	}
+	if parts := strings.SplitN(normalized, "-mcp-server-", 2); len(parts) == 2 {
+		server := sanitizeCopilotMCPSegment(parts[0])
+		function := sanitizeCopilotMCPSegment(parts[1])
+		if server != "" && function != "" {
+			return server, function, true
+		}
+	}
+
 	if strings.HasPrefix(normalized, "mcp__") {
 		rest := strings.TrimPrefix(normalized, "mcp__")
 		parts := strings.SplitN(rest, "__", 2)
@@ -1235,4 +1273,226 @@ func truncate(input string, max int) string {
 		return input
 	}
 	return input[:max]
+}
+
+func parseCopilotTelemetrySessionStore(ctx context.Context, dbPath string, skipSessions map[string]bool) ([]shared.TelemetryEvent, error) {
+	if strings.TrimSpace(dbPath) == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil, nil
+	}
+
+	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro", dbPath))
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	if !copilotTelemetryTableExists(ctx, db, "sessions") || !copilotTelemetryTableExists(ctx, db, "turns") {
+		return nil, nil
+	}
+
+	query := `
+		SELECT
+			s.id,
+			COALESCE(s.cwd, ''),
+			COALESCE(s.repository, ''),
+			COALESCE(t.turn_index, 0),
+			COALESCE(t.user_message, ''),
+			COALESCE(t.assistant_response, ''),
+			COALESCE(t.timestamp, '')
+		FROM sessions s
+		JOIN turns t ON t.session_id = s.id
+		ORDER BY s.id ASC, t.turn_index ASC
+	`
+
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []shared.TelemetryEvent
+	for rows.Next() {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+
+		var (
+			sessionID string
+			cwd       string
+			repo      string
+			turnIndex int
+			userMsg   string
+			reply     string
+			tsRaw     string
+		)
+		if err := rows.Scan(&sessionID, &cwd, &repo, &turnIndex, &userMsg, &reply, &tsRaw); err != nil {
+			continue
+		}
+		sessionID = strings.TrimSpace(sessionID)
+		if sessionID == "" || skipSessions[sessionID] {
+			continue
+		}
+
+		workspaceID := shared.SanitizeWorkspace(cwd)
+		clientLabel := normalizeCopilotClient(repo, cwd)
+		occurredAt := time.Now().UTC()
+		if parsed := shared.FlexParseTime(tsRaw); !parsed.IsZero() {
+			occurredAt = parsed
+		}
+
+		messageID := fmt.Sprintf("%s:turn:%d", sessionID, turnIndex)
+		model := "unknown"
+
+		payload := map[string]any{
+			"source_file":            dbPath,
+			"event":                  "session_store.turn",
+			"client":                 clientLabel,
+			"upstream_provider":      "github",
+			"session_store_fallback": true,
+			"user_chars":             len(strings.TrimSpace(userMsg)),
+			"assistant_chars":        len(strings.TrimSpace(reply)),
+			"turn_index":             turnIndex,
+		}
+		if strings.TrimSpace(repo) != "" {
+			payload["repository"] = strings.TrimSpace(repo)
+		}
+		if strings.TrimSpace(cwd) != "" {
+			payload["cwd"] = strings.TrimSpace(cwd)
+		}
+
+		out = append(out, shared.TelemetryEvent{
+			SchemaVersion: telemetrySchemaVersion,
+			Channel:       shared.TelemetryChannelSQLite,
+			OccurredAt:    occurredAt,
+			AccountID:     "copilot",
+			WorkspaceID:   workspaceID,
+			SessionID:     sessionID,
+			TurnID:        messageID,
+			MessageID:     messageID,
+			ProviderID:    "copilot",
+			AgentName:     "copilot",
+			EventType:     shared.TelemetryEventTypeMessageUsage,
+			ModelRaw:      model,
+			Requests:      shared.Int64Ptr(1),
+			Status:        shared.TelemetryStatusOK,
+			Payload:       payload,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return out, err
+	}
+
+	// Add session_files fallback for language/code-stats even when JSONL tool
+	// execution events are unavailable.
+	if copilotTelemetryTableExists(ctx, db, "session_files") {
+		fileRows, err := db.QueryContext(ctx, `
+			SELECT
+				COALESCE(sf.session_id, ''),
+				COALESCE(sf.file_path, ''),
+				COALESCE(sf.tool_name, ''),
+				COALESCE(sf.turn_index, 0),
+				COALESCE(sf.first_seen_at, ''),
+				COALESCE(s.cwd, ''),
+				COALESCE(s.repository, '')
+			FROM session_files sf
+			LEFT JOIN sessions s ON s.id = sf.session_id
+			ORDER BY sf.session_id ASC, sf.turn_index ASC, sf.id ASC
+		`)
+		if err == nil {
+			defer fileRows.Close()
+			for fileRows.Next() {
+				if ctx.Err() != nil {
+					return out, ctx.Err()
+				}
+				var (
+					sessionID string
+					filePath  string
+					toolRaw   string
+					turnIndex int
+					tsRaw     string
+					cwd       string
+					repo      string
+				)
+				if err := fileRows.Scan(&sessionID, &filePath, &toolRaw, &turnIndex, &tsRaw, &cwd, &repo); err != nil {
+					continue
+				}
+				sessionID = strings.TrimSpace(sessionID)
+				filePath = strings.TrimSpace(filePath)
+				if sessionID == "" || filePath == "" || skipSessions[sessionID] {
+					continue
+				}
+
+				workspaceID := shared.SanitizeWorkspace(cwd)
+				clientLabel := normalizeCopilotClient(repo, cwd)
+				occurredAt := time.Now().UTC()
+				if parsed := shared.FlexParseTime(tsRaw); !parsed.IsZero() {
+					occurredAt = parsed
+				}
+
+				toolName, meta := normalizeCopilotTelemetryToolName(toolRaw)
+				if toolName == "" || toolName == "unknown" {
+					toolName = "workspace_file_changed"
+				}
+
+				toolCallID := fmt.Sprintf("store:%s:%d:%s", sessionID, turnIndex, sanitizeMetricName(filePath))
+				messageID := fmt.Sprintf("%s:turn:%d", sessionID, turnIndex)
+				payload := map[string]any{
+					"source_file":            dbPath,
+					"event":                  "session_store.file",
+					"client":                 clientLabel,
+					"upstream_provider":      "github",
+					"session_store_fallback": true,
+					"file":                   filePath,
+					"turn_index":             turnIndex,
+					"tool_name_raw":          strings.TrimSpace(toolRaw),
+				}
+				for key, value := range meta {
+					payload[key] = value
+				}
+				if lang := inferCopilotLanguageFromPath(filePath); lang != "" {
+					payload["language"] = lang
+				}
+				if strings.TrimSpace(repo) != "" {
+					payload["repository"] = strings.TrimSpace(repo)
+				}
+				if strings.TrimSpace(cwd) != "" {
+					payload["cwd"] = strings.TrimSpace(cwd)
+				}
+
+				out = append(out, shared.TelemetryEvent{
+					SchemaVersion: telemetrySchemaVersion,
+					Channel:       shared.TelemetryChannelSQLite,
+					OccurredAt:    occurredAt,
+					AccountID:     "copilot",
+					WorkspaceID:   workspaceID,
+					SessionID:     sessionID,
+					TurnID:        messageID,
+					MessageID:     messageID,
+					ToolCallID:    toolCallID,
+					ProviderID:    "copilot",
+					AgentName:     "copilot",
+					EventType:     shared.TelemetryEventTypeToolUsage,
+					ModelRaw:      "unknown",
+					ToolName:      toolName,
+					Requests:      shared.Int64Ptr(1),
+					Status:        shared.TelemetryStatusOK,
+					Payload:       payload,
+				})
+			}
+		}
+	}
+
+	return out, nil
+}
+
+func copilotTelemetryTableExists(ctx context.Context, db *sql.DB, table string) bool {
+	var exists int
+	err := db.QueryRowContext(ctx,
+		`SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1`,
+		strings.TrimSpace(table),
+	).Scan(&exists)
+	return err == nil && exists == 1
 }

--- a/internal/providers/copilot/telemetry.go
+++ b/internal/providers/copilot/telemetry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,9 +14,53 @@ import (
 )
 
 const (
-	telemetrySchemaVersion   = "copilot_v1"
+	telemetrySchemaVersion   = "copilot_v2"
 	defaultCopilotSessionDir = ".copilot/session-state"
 )
+
+type copilotTelemetryAssistantMessageData struct {
+	MessageID    string          `json:"messageId"`
+	ToolRequests json.RawMessage `json:"toolRequests"`
+}
+
+type copilotTelemetryToolRequest struct {
+	ToolCallID string `json:"toolCallId"`
+	RawName    string `json:"-"`
+	Input      any    `json:"-"`
+}
+
+type copilotTelemetryToolExecutionStartData struct {
+	ToolCallID string          `json:"toolCallId"`
+	ToolName   string          `json:"toolName"`
+	Arguments  json.RawMessage `json:"arguments"`
+}
+
+type copilotTelemetryToolExecutionCompleteData struct {
+	ToolCallID string          `json:"toolCallId"`
+	ToolName   string          `json:"toolName"`
+	Success    *bool           `json:"success"`
+	Status     string          `json:"status"`
+	Result     json.RawMessage `json:"result"`
+	Error      json.RawMessage `json:"error"`
+}
+
+type copilotTelemetrySessionContextChangedData struct {
+	CWD        string `json:"cwd"`
+	Repository string `json:"repository"`
+}
+
+type copilotTelemetryWorkspaceFileChangedData struct {
+	Path      string `json:"path"`
+	Operation string `json:"operation"`
+}
+
+type copilotTelemetryToolContext struct {
+	MessageID string
+	TurnID    string
+	Model     string
+	ToolName  string
+	Payload   map[string]any
+}
 
 // System returns the telemetry system identifier for the copilot provider.
 func (p *Provider) System() string { return p.ID() }
@@ -76,7 +121,12 @@ func parseCopilotTelemetrySessionFile(path, sessionID string) ([]shared.Telemetr
 	lines := strings.Split(string(data), "\n")
 	currentModel := ""
 	workspaceID := ""
+	repo := ""
+	cwd := ""
+	clientLabel := "cli"
 	turnIndex := 0
+	assistantUsageSeen := false
+	toolContexts := make(map[string]copilotTelemetryToolContext)
 
 	var out []shared.TelemetryEvent
 	for lineNum, line := range lines {
@@ -88,14 +138,36 @@ func parseCopilotTelemetrySessionFile(path, sessionID string) ([]shared.Telemetr
 		if json.Unmarshal([]byte(line), &evt) != nil {
 			continue
 		}
+		occurredAt := time.Now().UTC()
+		if ts := shared.FlexParseTime(evt.Timestamp); !ts.IsZero() {
+			occurredAt = ts
+		}
 
 		switch evt.Type {
 		case "session.start":
 			var start sessionStartData
 			if json.Unmarshal(evt.Data, &start) == nil {
+				if start.Context.Repository != "" {
+					repo = start.Context.Repository
+				}
 				if start.Context.CWD != "" {
+					cwd = start.Context.CWD
 					workspaceID = shared.SanitizeWorkspace(start.Context.CWD)
 				}
+				clientLabel = normalizeCopilotClient(repo, cwd)
+			}
+
+		case "session.context_changed":
+			var changed copilotTelemetrySessionContextChangedData
+			if json.Unmarshal(evt.Data, &changed) == nil {
+				if changed.Repository != "" {
+					repo = changed.Repository
+				}
+				if changed.CWD != "" {
+					cwd = changed.CWD
+					workspaceID = shared.SanitizeWorkspace(changed.CWD)
+				}
+				clientLabel = normalizeCopilotClient(repo, cwd)
 			}
 
 		case "session.model_change":
@@ -112,11 +184,379 @@ func parseCopilotTelemetrySessionFile(path, sessionID string) ([]shared.Telemetr
 				}
 			}
 
+		case "assistant.message":
+			var msg copilotTelemetryAssistantMessageData
+			if json.Unmarshal(evt.Data, &msg) != nil {
+				continue
+			}
+
+			var toolRequests []json.RawMessage
+			if json.Unmarshal(msg.ToolRequests, &toolRequests) != nil || len(toolRequests) == 0 {
+				continue
+			}
+
+			messageID := copilotTelemetryMessageID(sessionID, lineNum+1, msg.MessageID, evt.ID)
+			turnID := shared.FirstNonEmpty(messageID, fmt.Sprintf("%s:line:%d", sessionID, lineNum+1))
+
+			for reqIdx, rawReq := range toolRequests {
+				req, ok := parseCopilotTelemetryToolRequest(rawReq)
+				if !ok {
+					continue
+				}
+
+				explicitCallID := strings.TrimSpace(req.ToolCallID) != ""
+				toolCallID := strings.TrimSpace(req.ToolCallID)
+				if toolCallID == "" {
+					toolCallID = fmt.Sprintf("%s:%d:tool:%d", sessionID, lineNum+1, reqIdx+1)
+				}
+
+				toolName, toolMeta := normalizeCopilotTelemetryToolName(req.RawName)
+				if toolName == "" {
+					toolName = "unknown"
+				}
+
+				payload := copilotTelemetryBasePayload(path, lineNum+1, clientLabel, repo, cwd, "assistant.message.tool_request")
+				for key, value := range toolMeta {
+					payload[key] = value
+				}
+				payload["tool_call_id"] = toolCallID
+
+				if req.Input != nil {
+					payload["tool_input"] = req.Input
+					if cmd := extractCopilotTelemetryCommand(req.Input); cmd != "" {
+						payload["command"] = cmd
+					}
+					if paths := shared.ExtractFilePathsFromPayload(req.Input); len(paths) > 0 {
+						payload["file"] = paths[0]
+						if lang := inferCopilotLanguageFromPath(paths[0]); lang != "" {
+							payload["language"] = lang
+						}
+					}
+					if added, removed := estimateCopilotTelemetryLineDelta(req.Input); added > 0 || removed > 0 {
+						payload["lines_added"] = added
+						payload["lines_removed"] = removed
+					}
+				}
+
+				if _, ok := payload["command"]; !ok {
+					if cmd := extractCopilotToolCommand(rawReq); cmd != "" {
+						payload["command"] = cmd
+					}
+				}
+				if _, ok := payload["file"]; !ok {
+					if paths := extractCopilotToolPaths(rawReq); len(paths) > 0 {
+						payload["file"] = paths[0]
+						if lang := inferCopilotLanguageFromPath(paths[0]); lang != "" {
+							payload["language"] = lang
+						}
+					}
+				}
+				if _, ok := payload["lines_added"]; !ok {
+					added, removed := estimateCopilotToolLineDelta(rawReq)
+					if added > 0 || removed > 0 {
+						payload["lines_added"] = added
+						payload["lines_removed"] = removed
+					}
+				}
+
+				model := strings.TrimSpace(currentModel)
+				if model == "" {
+					model = "unknown"
+				}
+				if upstream := copilotUpstreamProviderForModel(model); upstream != "" {
+					payload["upstream_provider"] = upstream
+				}
+
+				out = append(out, shared.TelemetryEvent{
+					SchemaVersion: telemetrySchemaVersion,
+					Channel:       shared.TelemetryChannelJSONL,
+					OccurredAt:    occurredAt,
+					AccountID:     "copilot",
+					WorkspaceID:   workspaceID,
+					SessionID:     sessionID,
+					TurnID:        turnID,
+					MessageID:     messageID,
+					ToolCallID:    toolCallID,
+					ProviderID:    "copilot",
+					AgentName:     "copilot",
+					EventType:     shared.TelemetryEventTypeToolUsage,
+					ModelRaw:      model,
+					ToolName:      toolName,
+					Requests:      shared.Int64Ptr(1),
+					Status:        shared.TelemetryStatusUnknown,
+					Payload:       payload,
+				})
+
+				if explicitCallID {
+					toolContexts[toolCallID] = copilotTelemetryToolContext{
+						MessageID: messageID,
+						TurnID:    turnID,
+						Model:     model,
+						ToolName:  toolName,
+						Payload:   copyCopilotTelemetryPayload(payload),
+					}
+				}
+			}
+
+		case "tool.execution_start":
+			var start copilotTelemetryToolExecutionStartData
+			if json.Unmarshal(evt.Data, &start) != nil {
+				continue
+			}
+
+			explicitCallID := strings.TrimSpace(start.ToolCallID) != ""
+			toolCallID := strings.TrimSpace(start.ToolCallID)
+			if toolCallID == "" {
+				toolCallID = fmt.Sprintf("%s:%d:tool_start", sessionID, lineNum+1)
+			}
+
+			ctx := toolContexts[toolCallID]
+			payload := copyCopilotTelemetryPayload(ctx.Payload)
+			if len(payload) == 0 {
+				payload = copilotTelemetryBasePayload(path, lineNum+1, clientLabel, repo, cwd, "tool.execution_start")
+			} else {
+				payload["event"] = "tool.execution_start"
+				payload["line"] = lineNum + 1
+			}
+			payload["tool_call_id"] = toolCallID
+
+			toolName := strings.TrimSpace(ctx.ToolName)
+			if start.ToolName != "" {
+				normalized, meta := normalizeCopilotTelemetryToolName(start.ToolName)
+				toolName = normalized
+				for key, value := range meta {
+					payload[key] = value
+				}
+			}
+			if toolName == "" {
+				toolName = "unknown"
+			}
+
+			if args := decodeCopilotTelemetryJSONAny(start.Arguments); args != nil {
+				payload["tool_input"] = args
+				if _, ok := payload["command"]; !ok {
+					if cmd := extractCopilotTelemetryCommand(args); cmd != "" {
+						payload["command"] = cmd
+					}
+				}
+				if _, ok := payload["file"]; !ok {
+					if paths := shared.ExtractFilePathsFromPayload(args); len(paths) > 0 {
+						payload["file"] = paths[0]
+						if lang := inferCopilotLanguageFromPath(paths[0]); lang != "" {
+							payload["language"] = lang
+						}
+					}
+				}
+				if _, ok := payload["lines_added"]; !ok {
+					added, removed := estimateCopilotTelemetryLineDelta(args)
+					if added > 0 || removed > 0 {
+						payload["lines_added"] = added
+						payload["lines_removed"] = removed
+					}
+				}
+			}
+
+			model := strings.TrimSpace(ctx.Model)
+			if model == "" {
+				model = strings.TrimSpace(currentModel)
+			}
+			if model == "" {
+				model = "unknown"
+			}
+			if upstream := copilotUpstreamProviderForModel(model); upstream != "" {
+				payload["upstream_provider"] = upstream
+			}
+
+			messageID := shared.FirstNonEmpty(ctx.MessageID, fmt.Sprintf("%s:%d", sessionID, lineNum+1))
+			turnID := shared.FirstNonEmpty(ctx.TurnID, messageID)
+
+			out = append(out, shared.TelemetryEvent{
+				SchemaVersion: telemetrySchemaVersion,
+				Channel:       shared.TelemetryChannelJSONL,
+				OccurredAt:    occurredAt,
+				AccountID:     "copilot",
+				WorkspaceID:   workspaceID,
+				SessionID:     sessionID,
+				TurnID:        turnID,
+				MessageID:     messageID,
+				ToolCallID:    toolCallID,
+				ProviderID:    "copilot",
+				AgentName:     "copilot",
+				EventType:     shared.TelemetryEventTypeToolUsage,
+				ModelRaw:      model,
+				ToolName:      toolName,
+				Requests:      shared.Int64Ptr(1),
+				Status:        shared.TelemetryStatusUnknown,
+				Payload:       payload,
+			})
+
+			if explicitCallID {
+				toolContexts[toolCallID] = copilotTelemetryToolContext{
+					MessageID: messageID,
+					TurnID:    turnID,
+					Model:     model,
+					ToolName:  toolName,
+					Payload:   copyCopilotTelemetryPayload(payload),
+				}
+			}
+
+		case "tool.execution_complete":
+			var complete copilotTelemetryToolExecutionCompleteData
+			if json.Unmarshal(evt.Data, &complete) != nil {
+				continue
+			}
+
+			toolCallID := strings.TrimSpace(complete.ToolCallID)
+			explicitCallID := toolCallID != ""
+			if toolCallID == "" {
+				toolCallID = fmt.Sprintf("%s:%d:tool_complete", sessionID, lineNum+1)
+			}
+
+			ctx := toolContexts[toolCallID]
+			payload := copyCopilotTelemetryPayload(ctx.Payload)
+			if len(payload) == 0 {
+				payload = copilotTelemetryBasePayload(path, lineNum+1, clientLabel, repo, cwd, "tool.execution_complete")
+			} else {
+				payload["event"] = "tool.execution_complete"
+				payload["line"] = lineNum + 1
+			}
+			payload["tool_call_id"] = toolCallID
+
+			toolName := strings.TrimSpace(ctx.ToolName)
+			if complete.ToolName != "" {
+				normalized, meta := normalizeCopilotTelemetryToolName(complete.ToolName)
+				toolName = normalized
+				for key, value := range meta {
+					payload[key] = value
+				}
+			}
+			if toolName == "" {
+				toolName = "unknown"
+			}
+
+			if complete.Success != nil {
+				payload["success"] = *complete.Success
+			}
+			if strings.TrimSpace(complete.Status) != "" {
+				payload["status_raw"] = strings.TrimSpace(complete.Status)
+			}
+
+			if resultMeta := summarizeCopilotTelemetryResult(complete.Result); len(resultMeta) > 0 {
+				for key, value := range resultMeta {
+					if _, exists := payload[key]; !exists {
+						payload[key] = value
+					}
+				}
+			}
+
+			errorCode, errorMessage := summarizeCopilotTelemetryError(complete.Error)
+			if errorCode != "" {
+				payload["error_code"] = errorCode
+			}
+			if errorMessage != "" {
+				payload["error_message"] = truncate(errorMessage, 240)
+			}
+
+			model := strings.TrimSpace(ctx.Model)
+			if model == "" {
+				model = strings.TrimSpace(currentModel)
+			}
+			if model == "" {
+				model = "unknown"
+			}
+			if upstream := copilotUpstreamProviderForModel(model); upstream != "" {
+				payload["upstream_provider"] = upstream
+			}
+
+			status := copilotTelemetryToolStatus(complete.Success, complete.Status, errorCode, errorMessage)
+			messageID := shared.FirstNonEmpty(ctx.MessageID, fmt.Sprintf("%s:%d", sessionID, lineNum+1))
+			turnID := shared.FirstNonEmpty(ctx.TurnID, messageID)
+
+			out = append(out, shared.TelemetryEvent{
+				SchemaVersion: telemetrySchemaVersion,
+				Channel:       shared.TelemetryChannelJSONL,
+				OccurredAt:    occurredAt,
+				AccountID:     "copilot",
+				WorkspaceID:   workspaceID,
+				SessionID:     sessionID,
+				TurnID:        turnID,
+				MessageID:     messageID,
+				ToolCallID:    toolCallID,
+				ProviderID:    "copilot",
+				AgentName:     "copilot",
+				EventType:     shared.TelemetryEventTypeToolUsage,
+				ModelRaw:      model,
+				ToolName:      toolName,
+				Requests:      shared.Int64Ptr(1),
+				Status:        status,
+				Payload:       payload,
+			})
+
+			if explicitCallID {
+				toolContexts[toolCallID] = copilotTelemetryToolContext{
+					MessageID: messageID,
+					TurnID:    turnID,
+					Model:     model,
+					ToolName:  toolName,
+					Payload:   copyCopilotTelemetryPayload(payload),
+				}
+			}
+
+		case "session.workspace_file_changed":
+			var changed copilotTelemetryWorkspaceFileChangedData
+			if json.Unmarshal(evt.Data, &changed) != nil {
+				continue
+			}
+			filePath := strings.TrimSpace(changed.Path)
+			if filePath == "" {
+				continue
+			}
+
+			op := sanitizeMetricName(changed.Operation)
+			if op == "" || op == "unknown" {
+				op = "change"
+			}
+
+			payload := copilotTelemetryBasePayload(path, lineNum+1, clientLabel, repo, cwd, "session.workspace_file_changed")
+			payload["file"] = filePath
+			payload["operation"] = strings.TrimSpace(changed.Operation)
+			if lang := inferCopilotLanguageFromPath(filePath); lang != "" {
+				payload["language"] = lang
+			}
+
+			model := strings.TrimSpace(currentModel)
+			if model == "" {
+				model = "unknown"
+			}
+			if upstream := copilotUpstreamProviderForModel(model); upstream != "" {
+				payload["upstream_provider"] = upstream
+			}
+
+			out = append(out, shared.TelemetryEvent{
+				SchemaVersion: telemetrySchemaVersion,
+				Channel:       shared.TelemetryChannelJSONL,
+				OccurredAt:    occurredAt,
+				AccountID:     "copilot",
+				WorkspaceID:   workspaceID,
+				SessionID:     sessionID,
+				TurnID:        fmt.Sprintf("%s:file:%d", sessionID, lineNum+1),
+				MessageID:     fmt.Sprintf("%s:%d", sessionID, lineNum+1),
+				ProviderID:    "copilot",
+				AgentName:     "copilot",
+				EventType:     shared.TelemetryEventTypeToolUsage,
+				ModelRaw:      model,
+				ToolName:      "workspace_file_" + op,
+				Requests:      shared.Int64Ptr(0),
+				Status:        shared.TelemetryStatusOK,
+				Payload:       payload,
+			})
+
 		case "assistant.usage":
 			var usage assistantUsageData
 			if json.Unmarshal(evt.Data, &usage) != nil {
 				continue
 			}
+			assistantUsageSeen = true
 
 			model := usage.Model
 			if model == "" {
@@ -127,18 +567,22 @@ func parseCopilotTelemetrySessionFile(path, sessionID string) ([]shared.Telemetr
 			}
 
 			turnIndex++
-			occurredAt := time.Now().UTC()
-			if ts := shared.FlexParseTime(evt.Timestamp); !ts.IsZero() {
-				occurredAt = ts
-			}
 
-			turnID := fmt.Sprintf("%s:%d", sessionID, turnIndex)
-			if strings.TrimSpace(evt.ID) != "" {
-				turnID = strings.TrimSpace(evt.ID)
-			}
+			turnID := shared.FirstNonEmpty(strings.TrimSpace(evt.ID), fmt.Sprintf("%s:usage:%d", sessionID, turnIndex))
 			messageID := fmt.Sprintf("%s:%d", sessionID, lineNum+1)
 
 			totalTokens := int64(usage.InputTokens + usage.OutputTokens)
+			payload := copilotTelemetryBasePayload(path, lineNum+1, clientLabel, repo, cwd, "assistant.usage")
+			payload["source_file"] = path
+			payload["line"] = lineNum + 1
+			payload["client"] = clientLabel
+			payload["upstream_provider"] = copilotUpstreamProviderForModel(model)
+			if usage.Duration > 0 {
+				payload["duration_ms"] = usage.Duration
+			}
+			if len(usage.QuotaSnapshots) > 0 {
+				payload["quota_snapshot_count"] = len(usage.QuotaSnapshots)
+			}
 
 			te := shared.TelemetryEvent{
 				SchemaVersion: telemetrySchemaVersion,
@@ -158,11 +602,7 @@ func parseCopilotTelemetrySessionFile(path, sessionID string) ([]shared.Telemetr
 				TotalTokens:   shared.Int64Ptr(totalTokens),
 				Requests:      shared.Int64Ptr(1),
 				Status:        shared.TelemetryStatusOK,
-				Payload: map[string]any{
-					"source_file":       path,
-					"line":              lineNum + 1,
-					"upstream_provider": "github",
-				},
+				Payload:       payload,
 			}
 
 			if usage.CacheReadTokens > 0 {
@@ -176,8 +616,623 @@ func parseCopilotTelemetrySessionFile(path, sessionID string) ([]shared.Telemetr
 			}
 
 			out = append(out, te)
+
+		case "session.shutdown":
+			var shutdown sessionShutdownData
+			if json.Unmarshal(evt.Data, &shutdown) != nil {
+				continue
+			}
+
+			shutdownTurnID := shared.FirstNonEmpty(strings.TrimSpace(evt.ID), fmt.Sprintf("%s:shutdown", sessionID))
+			shutdownMessageID := fmt.Sprintf("%s:shutdown:%d", sessionID, lineNum+1)
+
+			shutdownPayload := copilotTelemetryBasePayload(path, lineNum+1, clientLabel, repo, cwd, "session.shutdown")
+			shutdownPayload["shutdown_type"] = strings.TrimSpace(shutdown.ShutdownType)
+			shutdownPayload["total_premium_requests"] = shutdown.TotalPremiumRequests
+			shutdownPayload["total_api_duration_ms"] = shutdown.TotalAPIDurationMs
+			shutdownPayload["session_start_time"] = strings.TrimSpace(shutdown.SessionStartTime)
+			shutdownPayload["lines_added"] = shutdown.CodeChanges.LinesAdded
+			shutdownPayload["lines_removed"] = shutdown.CodeChanges.LinesRemoved
+			shutdownPayload["files_modified"] = shutdown.CodeChanges.FilesModified
+			shutdownPayload["model_metrics_count"] = len(shutdown.ModelMetrics)
+			if model := strings.TrimSpace(currentModel); model != "" {
+				shutdownPayload["upstream_provider"] = copilotUpstreamProviderForModel(model)
+			}
+
+			out = append(out, shared.TelemetryEvent{
+				SchemaVersion: telemetrySchemaVersion,
+				Channel:       shared.TelemetryChannelJSONL,
+				OccurredAt:    occurredAt,
+				AccountID:     "copilot",
+				WorkspaceID:   workspaceID,
+				SessionID:     sessionID,
+				TurnID:        shutdownTurnID,
+				MessageID:     shutdownMessageID,
+				ProviderID:    "copilot",
+				AgentName:     "copilot",
+				EventType:     shared.TelemetryEventTypeTurnCompleted,
+				ModelRaw:      shared.FirstNonEmpty(strings.TrimSpace(currentModel), "unknown"),
+				Status:        shared.TelemetryStatusOK,
+				Payload:       shutdownPayload,
+			})
+
+			if assistantUsageSeen {
+				continue
+			}
+
+			models := make([]string, 0, len(shutdown.ModelMetrics))
+			for model := range shutdown.ModelMetrics {
+				models = append(models, model)
+			}
+			sort.Strings(models)
+
+			for idx, model := range models {
+				modelMetric := shutdown.ModelMetrics[model]
+				model = strings.TrimSpace(model)
+				if model == "" {
+					model = shared.FirstNonEmpty(strings.TrimSpace(currentModel), "unknown")
+				}
+
+				inputTokens := int64(modelMetric.Usage.InputTokens)
+				outputTokens := int64(modelMetric.Usage.OutputTokens)
+				cacheReadTokens := int64(modelMetric.Usage.CacheReadTokens)
+				cacheWriteTokens := int64(modelMetric.Usage.CacheWriteTokens)
+				totalTokens := inputTokens + outputTokens
+				requests := int64(modelMetric.Requests.Count)
+				cost := modelMetric.Requests.Cost
+
+				if totalTokens <= 0 && requests <= 0 && cost <= 0 {
+					continue
+				}
+
+				messageID := fmt.Sprintf("%s:shutdown:%s", sessionID, sanitizeMetricName(model))
+				if idx > 0 {
+					messageID = fmt.Sprintf("%s:%d", messageID, idx+1)
+				}
+				turnID := messageID
+
+				payload := copilotTelemetryBasePayload(path, lineNum+1, clientLabel, repo, cwd, "session.shutdown.model_metric")
+				payload["model_metrics_source"] = "session.shutdown"
+				payload["upstream_provider"] = copilotUpstreamProviderForModel(model)
+				if idx == 0 {
+					payload["lines_added"] = shutdown.CodeChanges.LinesAdded
+					payload["lines_removed"] = shutdown.CodeChanges.LinesRemoved
+					payload["files_modified"] = shutdown.CodeChanges.FilesModified
+				}
+
+				usageEvent := shared.TelemetryEvent{
+					SchemaVersion: telemetrySchemaVersion,
+					Channel:       shared.TelemetryChannelJSONL,
+					OccurredAt:    occurredAt,
+					AccountID:     "copilot",
+					WorkspaceID:   workspaceID,
+					SessionID:     sessionID,
+					TurnID:        turnID,
+					MessageID:     messageID,
+					ProviderID:    "copilot",
+					AgentName:     "copilot",
+					EventType:     shared.TelemetryEventTypeMessageUsage,
+					ModelRaw:      model,
+					InputTokens:   shared.Int64Ptr(inputTokens),
+					OutputTokens:  shared.Int64Ptr(outputTokens),
+					TotalTokens:   shared.Int64Ptr(totalTokens),
+					Status:        shared.TelemetryStatusOK,
+					Payload:       payload,
+				}
+				if requests > 0 {
+					usageEvent.Requests = shared.Int64Ptr(requests)
+				}
+				if cacheReadTokens > 0 {
+					usageEvent.CacheReadTokens = shared.Int64Ptr(cacheReadTokens)
+				}
+				if cacheWriteTokens > 0 {
+					usageEvent.CacheWriteTokens = shared.Int64Ptr(cacheWriteTokens)
+				}
+				if cost > 0 {
+					usageEvent.CostUSD = shared.Float64Ptr(cost)
+				}
+
+				out = append(out, usageEvent)
+			}
 		}
 	}
 
 	return out, nil
+}
+
+func copilotTelemetryMessageID(sessionID string, lineNum int, messageID, fallbackID string) string {
+	messageID = strings.TrimSpace(messageID)
+	if messageID != "" {
+		if strings.Contains(messageID, ":") {
+			return messageID
+		}
+		return fmt.Sprintf("%s:%s", sessionID, messageID)
+	}
+
+	fallbackID = strings.TrimSpace(fallbackID)
+	if fallbackID != "" {
+		return fmt.Sprintf("%s:%s", sessionID, fallbackID)
+	}
+	return fmt.Sprintf("%s:%d", sessionID, lineNum)
+}
+
+func parseCopilotTelemetryToolRequest(raw json.RawMessage) (copilotTelemetryToolRequest, bool) {
+	var reqMap map[string]any
+	if json.Unmarshal(raw, &reqMap) != nil {
+		return copilotTelemetryToolRequest{}, false
+	}
+
+	out := copilotTelemetryToolRequest{
+		ToolCallID: strings.TrimSpace(anyToString(reqMap["toolCallId"])),
+		RawName:    shared.FirstNonEmpty(anyToString(reqMap["name"]), anyToString(reqMap["toolName"]), anyToString(reqMap["tool"])),
+	}
+	if out.RawName == "" {
+		out.RawName = extractCopilotToolName(raw)
+	}
+
+	if value, ok := reqMap["arguments"]; ok {
+		out.Input = decodeCopilotTelemetryJSONAny(value)
+	}
+	if out.Input == nil {
+		if value, ok := reqMap["args"]; ok {
+			out.Input = decodeCopilotTelemetryJSONAny(value)
+		}
+	}
+	if out.Input == nil {
+		if value, ok := reqMap["input"]; ok {
+			out.Input = decodeCopilotTelemetryJSONAny(value)
+		}
+	}
+
+	return out, true
+}
+
+func normalizeCopilotTelemetryToolName(raw string) (string, map[string]any) {
+	meta := make(map[string]any)
+	name := strings.TrimSpace(raw)
+	if name == "" {
+		return "unknown", meta
+	}
+
+	meta["tool_name_raw"] = name
+
+	if server, function, ok := parseCopilotTelemetryMCPTool(name); ok {
+		canonical := "mcp__" + server + "__" + function
+		meta["tool_type"] = "mcp"
+		meta["mcp_server"] = server
+		meta["mcp_function"] = function
+		return canonical, meta
+	}
+
+	return sanitizeMetricName(name), meta
+}
+
+func parseCopilotTelemetryMCPTool(raw string) (string, string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if normalized == "" {
+		return "", "", false
+	}
+
+	if strings.HasPrefix(normalized, "mcp__") {
+		rest := strings.TrimPrefix(normalized, "mcp__")
+		parts := strings.SplitN(rest, "__", 2)
+		if len(parts) != 2 {
+			return sanitizeCopilotMCPSegment(rest), "", false
+		}
+		server := sanitizeCopilotMCPSegment(parts[0])
+		function := sanitizeCopilotMCPSegment(parts[1])
+		if server == "" || function == "" {
+			return "", "", false
+		}
+		return server, function, true
+	}
+
+	if strings.HasPrefix(normalized, "mcp-") || strings.HasPrefix(normalized, "mcp_") {
+		canonical := normalizeCopilotCursorStyleMCPName(normalized)
+		if strings.HasPrefix(canonical, "mcp__") {
+			parts := strings.SplitN(strings.TrimPrefix(canonical, "mcp__"), "__", 2)
+			if len(parts) == 2 {
+				server := sanitizeCopilotMCPSegment(parts[0])
+				function := sanitizeCopilotMCPSegment(parts[1])
+				if server != "" && function != "" {
+					return server, function, true
+				}
+			}
+		}
+	}
+
+	// Legacy suffix format from earlier tool adapters: "server-function (mcp)".
+	if strings.HasSuffix(normalized, " (mcp)") {
+		body := strings.TrimSpace(strings.TrimSuffix(normalized, " (mcp)"))
+		body = strings.TrimPrefix(body, "user-")
+		if body == "" {
+			return "", "", false
+		}
+		if idx := findCopilotTelemetryServerFunctionSplit(body); idx > 0 {
+			server := sanitizeCopilotMCPSegment(body[:idx])
+			function := sanitizeCopilotMCPSegment(body[idx+1:])
+			if server != "" && function != "" {
+				return server, function, true
+			}
+		}
+		return "other", sanitizeCopilotMCPSegment(body), true
+	}
+
+	return "", "", false
+}
+
+func normalizeCopilotCursorStyleMCPName(name string) string {
+	if strings.HasPrefix(name, "mcp-") {
+		rest := name[4:]
+		parts := strings.SplitN(rest, "-user-", 2)
+		if len(parts) == 2 {
+			server := parts[0]
+			afterUser := parts[1]
+			serverDash := server + "-"
+			if strings.HasPrefix(afterUser, serverDash) {
+				return "mcp__" + server + "__" + afterUser[len(serverDash):]
+			}
+			if idx := strings.LastIndex(afterUser, "-"); idx > 0 {
+				return "mcp__" + server + "__" + afterUser[idx+1:]
+			}
+			return "mcp__" + server + "__" + afterUser
+		}
+		if idx := strings.Index(rest, "-"); idx > 0 {
+			return "mcp__" + rest[:idx] + "__" + rest[idx+1:]
+		}
+		return "mcp__" + rest + "__"
+	}
+
+	if strings.HasPrefix(name, "mcp_") {
+		rest := name[4:]
+		if idx := strings.Index(rest, "_"); idx > 0 {
+			return "mcp__" + rest[:idx] + "__" + rest[idx+1:]
+		}
+		return "mcp__" + rest + "__"
+	}
+
+	return name
+}
+
+func findCopilotTelemetryServerFunctionSplit(s string) int {
+	best := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] != '-' {
+			continue
+		}
+		rest := s[i+1:]
+		if strings.Contains(rest, "_") {
+			best = i
+		}
+	}
+	return best
+}
+
+func sanitizeCopilotMCPSegment(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if raw == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range raw {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			lastUnderscore = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastUnderscore = false
+		case r == '_' || r == '-':
+			b.WriteRune(r)
+			lastUnderscore = false
+		default:
+			if !lastUnderscore {
+				b.WriteByte('_')
+				lastUnderscore = true
+			}
+		}
+	}
+
+	return strings.Trim(b.String(), "_")
+}
+
+func copilotTelemetryToolStatus(success *bool, statusRaw, errorCode, errorMessage string) shared.TelemetryStatus {
+	if success != nil {
+		if *success {
+			return shared.TelemetryStatusOK
+		}
+		if copilotTelemetryLooksAborted(errorCode, errorMessage, statusRaw) {
+			return shared.TelemetryStatusAborted
+		}
+		return shared.TelemetryStatusError
+	}
+
+	switch strings.ToLower(strings.TrimSpace(statusRaw)) {
+	case "ok", "success", "succeeded", "completed", "complete":
+		return shared.TelemetryStatusOK
+	case "aborted", "cancelled", "canceled", "denied":
+		return shared.TelemetryStatusAborted
+	case "error", "failed", "failure":
+		return shared.TelemetryStatusError
+	}
+
+	if errorCode != "" || errorMessage != "" {
+		if copilotTelemetryLooksAborted(errorCode, errorMessage, statusRaw) {
+			return shared.TelemetryStatusAborted
+		}
+		return shared.TelemetryStatusError
+	}
+	return shared.TelemetryStatusUnknown
+}
+
+func copilotTelemetryLooksAborted(parts ...string) bool {
+	for _, part := range parts {
+		lower := strings.ToLower(strings.TrimSpace(part))
+		if lower == "" {
+			continue
+		}
+		if strings.Contains(lower, "denied") ||
+			strings.Contains(lower, "cancel") ||
+			strings.Contains(lower, "abort") ||
+			strings.Contains(lower, "rejected") ||
+			strings.Contains(lower, "user initiated") {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeCopilotTelemetryResult(raw json.RawMessage) map[string]any {
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return nil
+	}
+	decoded := decodeCopilotTelemetryJSONAny(raw)
+	if decoded == nil {
+		return nil
+	}
+
+	payload := make(map[string]any)
+
+	if paths := shared.ExtractFilePathsFromPayload(decoded); len(paths) > 0 {
+		payload["result_file"] = paths[0]
+	}
+
+	switch value := decoded.(type) {
+	case map[string]any:
+		if content := anyToString(value["content"]); content != "" {
+			payload["result_chars"] = len(content)
+			if added, removed := countCopilotTelemetryUnifiedDiff(content); added > 0 || removed > 0 {
+				payload["lines_added"] = added
+				payload["lines_removed"] = removed
+			}
+		}
+		if detailed := anyToString(value["detailedContent"]); detailed != "" {
+			payload["result_detailed_chars"] = len(detailed)
+			if _, hasLines := payload["lines_added"]; !hasLines {
+				if added, removed := countCopilotTelemetryUnifiedDiff(detailed); added > 0 || removed > 0 {
+					payload["lines_added"] = added
+					payload["lines_removed"] = removed
+				}
+			}
+		}
+		if msg := anyToString(value["message"]); msg != "" {
+			payload["result_message"] = truncate(msg, 240)
+		}
+	case string:
+		if value != "" {
+			payload["result_chars"] = len(value)
+			if added, removed := countCopilotTelemetryUnifiedDiff(value); added > 0 || removed > 0 {
+				payload["lines_added"] = added
+				payload["lines_removed"] = removed
+			}
+		}
+	}
+
+	if len(payload) == 0 {
+		return nil
+	}
+	return payload
+}
+
+func countCopilotTelemetryUnifiedDiff(raw string) (int, int) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, 0
+	}
+	if !strings.Contains(raw, "diff --git") && !strings.Contains(raw, "\n@@") {
+		return 0, 0
+	}
+
+	added := 0
+	removed := 0
+	for _, line := range strings.Split(raw, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++"), strings.HasPrefix(line, "---"), strings.HasPrefix(line, "@@"):
+			continue
+		case strings.HasPrefix(line, "+"):
+			added++
+		case strings.HasPrefix(line, "-"):
+			removed++
+		}
+	}
+	return added, removed
+}
+
+func summarizeCopilotTelemetryError(raw json.RawMessage) (string, string) {
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return "", ""
+	}
+	decoded := decodeCopilotTelemetryJSONAny(raw)
+	if decoded == nil {
+		return "", ""
+	}
+
+	switch value := decoded.(type) {
+	case map[string]any:
+		return strings.TrimSpace(anyToString(value["code"])), strings.TrimSpace(anyToString(value["message"]))
+	case string:
+		return "", strings.TrimSpace(value)
+	default:
+		return "", strings.TrimSpace(anyToString(decoded))
+	}
+}
+
+func copilotTelemetryBasePayload(path string, line int, client, repo, cwd, event string) map[string]any {
+	payload := map[string]any{
+		"source_file":       path,
+		"line":              line,
+		"event":             event,
+		"client":            client,
+		"upstream_provider": "github",
+	}
+	if strings.TrimSpace(repo) != "" {
+		payload["repository"] = strings.TrimSpace(repo)
+	}
+	if strings.TrimSpace(cwd) != "" {
+		payload["cwd"] = strings.TrimSpace(cwd)
+	}
+	return payload
+}
+
+func copyCopilotTelemetryPayload(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func decodeCopilotTelemetryJSONAny(raw any) any {
+	switch value := raw.(type) {
+	case nil:
+		return nil
+	case map[string]any:
+		return value
+	case []any:
+		return value
+	case json.RawMessage:
+		var out any
+		if json.Unmarshal(value, &out) == nil {
+			return out
+		}
+		return strings.TrimSpace(string(value))
+	case []byte:
+		var out any
+		if json.Unmarshal(value, &out) == nil {
+			return out
+		}
+		return strings.TrimSpace(string(value))
+	case string:
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return nil
+		}
+		var out any
+		if json.Unmarshal([]byte(trimmed), &out) == nil {
+			return out
+		}
+		return trimmed
+	default:
+		return value
+	}
+}
+
+func extractCopilotTelemetryCommand(input any) string {
+	var command string
+	var walk func(value any)
+	walk = func(value any) {
+		if command != "" || value == nil {
+			return
+		}
+		switch v := value.(type) {
+		case map[string]any:
+			for key, child := range v {
+				k := strings.ToLower(strings.TrimSpace(key))
+				if k == "command" || k == "cmd" || k == "script" || k == "shell_command" {
+					if s, ok := child.(string); ok {
+						command = strings.TrimSpace(s)
+						return
+					}
+				}
+			}
+			for _, child := range v {
+				walk(child)
+				if command != "" {
+					return
+				}
+			}
+		case []any:
+			for _, child := range v {
+				walk(child)
+				if command != "" {
+					return
+				}
+			}
+		}
+	}
+	walk(input)
+	return command
+}
+
+func estimateCopilotTelemetryLineDelta(input any) (int, int) {
+	if input == nil {
+		return 0, 0
+	}
+	encoded, err := json.Marshal(map[string]any{"arguments": input})
+	if err != nil {
+		return 0, 0
+	}
+	return estimateCopilotToolLineDelta(encoded)
+}
+
+func copilotUpstreamProviderForModel(model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" || model == "unknown" {
+		return "github"
+	}
+	switch {
+	case strings.Contains(model, "claude"):
+		return "anthropic"
+	case strings.Contains(model, "gpt"), strings.HasPrefix(model, "o1"), strings.HasPrefix(model, "o3"), strings.HasPrefix(model, "o4"):
+		return "openai"
+	case strings.Contains(model, "gemini"):
+		return "google"
+	case strings.Contains(model, "qwen"):
+		return "alibaba_cloud"
+	case strings.Contains(model, "deepseek"):
+		return "deepseek"
+	case strings.Contains(model, "llama"):
+		return "meta"
+	case strings.Contains(model, "mistral"):
+		return "mistral"
+	default:
+		return "github"
+	}
+}
+
+func anyToString(v any) string {
+	switch value := v.(type) {
+	case string:
+		return value
+	case fmt.Stringer:
+		return value.String()
+	default:
+		if value == nil {
+			return ""
+		}
+		return fmt.Sprintf("%v", value)
+	}
+}
+
+func truncate(input string, max int) string {
+	input = strings.TrimSpace(input)
+	if max <= 0 || len(input) <= max {
+		return input
+	}
+	return input[:max]
 }

--- a/internal/providers/copilot/telemetry_test.go
+++ b/internal/providers/copilot/telemetry_test.go
@@ -1,11 +1,15 @@
 package copilot
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/janekbaraniewski/openusage/internal/providers/shared"
 )
@@ -381,6 +385,113 @@ func TestParseCopilotTelemetrySessionFile_ShutdownDoesNotDuplicateWhenUsageExist
 	}
 	if messageUsageCount != 1 {
 		t.Fatalf("message usage count = %d, want 1 (assistant.usage only)", messageUsageCount)
+	}
+}
+
+func TestNormalizeCopilotTelemetryToolName_CopilotMCPPattern(t *testing.T) {
+	tool, meta := normalizeCopilotTelemetryToolName("github_mcp_server_list_issues")
+	if tool != "mcp__github__list_issues" {
+		t.Fatalf("tool = %q, want mcp__github__list_issues", tool)
+	}
+	if got, _ := meta["mcp_server"].(string); got != "github" {
+		t.Fatalf("meta.mcp_server = %q, want github", got)
+	}
+	if got, _ := meta["mcp_function"].(string); got != "list_issues" {
+		t.Fatalf("meta.mcp_function = %q, want list_issues", got)
+	}
+}
+
+func TestParseCopilotTelemetrySessionStore_Fallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "session-store.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	for _, stmt := range []string{
+		`CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			cwd TEXT,
+			repository TEXT,
+			branch TEXT,
+			summary TEXT,
+			created_at TEXT,
+			updated_at TEXT
+		)`,
+		`CREATE TABLE turns (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			turn_index INTEGER NOT NULL,
+			user_message TEXT,
+			assistant_response TEXT,
+			timestamp TEXT
+		)`,
+		`CREATE TABLE session_files (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			file_path TEXT NOT NULL,
+			tool_name TEXT,
+			turn_index INTEGER,
+			first_seen_at TEXT
+		)`,
+		`INSERT INTO sessions (id, cwd, repository) VALUES
+			('sess-missing-jsonl', '/Users/test/openusage', 'janek/openusage'),
+			('sess-has-jsonl', '/Users/test/other', 'janek/other')`,
+		`INSERT INTO turns (session_id, turn_index, user_message, assistant_response, timestamp) VALUES
+			('sess-missing-jsonl', 0, 'hello', 'world', '2026-03-01T10:00:00Z'),
+			('sess-has-jsonl', 1, 'skip', 'skip', '2026-03-01T10:01:00Z')`,
+		`INSERT INTO session_files (session_id, file_path, tool_name, turn_index, first_seen_at) VALUES
+			('sess-missing-jsonl', 'internal/providers/copilot/telemetry.go', 'edit', 0, '2026-03-01T10:00:10Z'),
+			('sess-has-jsonl', 'internal/providers/copilot/copilot.go', 'view', 1, '2026-03-01T10:01:10Z')`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+
+	events, err := parseCopilotTelemetrySessionStore(context.Background(), dbPath, map[string]bool{
+		"sess-has-jsonl": true,
+	})
+	if err != nil {
+		t.Fatalf("parseCopilotTelemetrySessionStore() error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("event count = %d, want 2 (turn + session_file for fallback session)", len(events))
+	}
+
+	var hasMessageUsage bool
+	var hasFileTool bool
+	for _, ev := range events {
+		if ev.SessionID != "sess-missing-jsonl" {
+			t.Fatalf("unexpected session id %q, expected fallback-only session", ev.SessionID)
+		}
+		switch ev.EventType {
+		case shared.TelemetryEventTypeMessageUsage:
+			hasMessageUsage = true
+			if ev.Requests == nil || *ev.Requests != 1 {
+				t.Fatalf("message usage requests = %v, want 1", ev.Requests)
+			}
+			if got, _ := ev.Payload["session_store_fallback"].(bool); !got {
+				t.Fatalf("missing payload.session_store_fallback=true")
+			}
+		case shared.TelemetryEventTypeToolUsage:
+			hasFileTool = true
+			if ev.ToolName != "edit" {
+				t.Fatalf("tool fallback name = %q, want edit", ev.ToolName)
+			}
+			if got, _ := ev.Payload["file"].(string); got != "internal/providers/copilot/telemetry.go" {
+				t.Fatalf("tool fallback payload.file = %q, want internal/providers/copilot/telemetry.go", got)
+			}
+		}
+	}
+	if !hasMessageUsage {
+		t.Fatal("missing message usage fallback event")
+	}
+	if !hasFileTool {
+		t.Fatal("missing session file fallback tool event")
 	}
 }
 

--- a/internal/providers/copilot/telemetry_test.go
+++ b/internal/providers/copilot/telemetry_test.go
@@ -1,0 +1,424 @@
+package copilot
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/providers/shared"
+)
+
+func TestParseCopilotTelemetrySessionFile_ToolLifecycleAndMCP(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "session-telemetry-1"
+	eventsPath := filepath.Join(tmpDir, "events.jsonl")
+
+	events := []map[string]any{
+		{
+			"type":      "session.start",
+			"timestamp": "2026-03-01T10:00:00Z",
+			"data": map[string]any{
+				"sessionId":      sessionID,
+				"copilotVersion": "0.0.500",
+				"startTime":      "2026-03-01T10:00:00Z",
+				"context": map[string]any{
+					"cwd":        "/Users/test/openusage",
+					"repository": "janekbaraniewski/openusage",
+					"branch":     "main",
+				},
+			},
+		},
+		{
+			"type":      "session.model_change",
+			"timestamp": "2026-03-01T10:00:01Z",
+			"data": map[string]any{
+				"newModel": "claude-sonnet-4.5",
+			},
+		},
+		{
+			"type":      "assistant.message",
+			"timestamp": "2026-03-01T10:00:02Z",
+			"id":        "assistant-msg-1",
+			"data": map[string]any{
+				"messageId": "msg-1",
+				"toolRequests": []map[string]any{
+					{
+						"toolCallId": "call-mcp-1",
+						"name":       "mcp-kubernetes-user-kubernetes-pods_list",
+						"arguments": map[string]any{
+							"path": "internal/providers/copilot/copilot.go",
+						},
+					},
+					{
+						"toolCallId": "call-edit-1",
+						"name":       "edit",
+						"arguments": map[string]any{
+							"filePath":   "internal/providers/copilot/telemetry.go",
+							"old_string": "a\nb",
+							"new_string": "a\nb\nc",
+							"command":    "git commit -m \"copilot telemetry\"",
+						},
+					},
+				},
+			},
+		},
+		{
+			"type":      "tool.execution_complete",
+			"timestamp": "2026-03-01T10:00:03Z",
+			"data": map[string]any{
+				"toolCallId": "call-mcp-1",
+				"success":    false,
+				"error": map[string]any{
+					"code":    "denied",
+					"message": "user rejected this tool call",
+				},
+			},
+		},
+		{
+			"type":      "tool.execution_complete",
+			"timestamp": "2026-03-01T10:00:04Z",
+			"data": map[string]any{
+				"toolCallId": "call-edit-1",
+				"success":    true,
+				"result": map[string]any{
+					"content": "ok",
+				},
+			},
+		},
+		{
+			"type":      "session.workspace_file_changed",
+			"timestamp": "2026-03-01T10:00:05Z",
+			"data": map[string]any{
+				"path":      "docs/NEW.md",
+				"operation": "create",
+			},
+		},
+	}
+	writeCopilotTelemetryEvents(t, eventsPath, events)
+
+	out, err := parseCopilotTelemetrySessionFile(eventsPath, sessionID)
+	if err != nil {
+		t.Fatalf("parseCopilotTelemetrySessionFile() error: %v", err)
+	}
+
+	mcpEvent, ok := findToolEventByCallIDAndStatus(out, "call-mcp-1", shared.TelemetryStatusAborted)
+	if !ok {
+		t.Fatal("missing MCP tool completion event with aborted status")
+	}
+	if mcpEvent.ToolName != "mcp__kubernetes__pods_list" {
+		t.Fatalf("mcp tool name = %q, want canonical mcp__kubernetes__pods_list", mcpEvent.ToolName)
+	}
+	if got, _ := mcpEvent.Payload["mcp_server"].(string); got != "kubernetes" {
+		t.Fatalf("payload.mcp_server = %q, want kubernetes", got)
+	}
+	if got, _ := mcpEvent.Payload["mcp_function"].(string); got != "pods_list" {
+		t.Fatalf("payload.mcp_function = %q, want pods_list", got)
+	}
+	if got, _ := mcpEvent.Payload["client"].(string); got != "janekbaraniewski/openusage" {
+		t.Fatalf("payload.client = %q, want janekbaraniewski/openusage", got)
+	}
+	if got, _ := mcpEvent.Payload["file"].(string); got != "internal/providers/copilot/copilot.go" {
+		t.Fatalf("payload.file = %q, want internal/providers/copilot/copilot.go", got)
+	}
+
+	editEvent, ok := findToolEventByCallIDAndStatus(out, "call-edit-1", shared.TelemetryStatusOK)
+	if !ok {
+		t.Fatal("missing edit tool completion event with ok status")
+	}
+	if editEvent.ToolName != "edit" {
+		t.Fatalf("edit tool name = %q, want edit", editEvent.ToolName)
+	}
+	if got, _ := editEvent.Payload["command"].(string); got == "" {
+		t.Fatal("payload.command should be populated from tool args")
+	}
+	if got, ok := editEvent.Payload["lines_added"].(int); !ok || got != 3 {
+		t.Fatalf("payload.lines_added = %#v, want 3", editEvent.Payload["lines_added"])
+	}
+	if got, ok := editEvent.Payload["lines_removed"].(int); !ok || got != 2 {
+		t.Fatalf("payload.lines_removed = %#v, want 2", editEvent.Payload["lines_removed"])
+	}
+
+	workspaceEvent, ok := findToolEventByName(out, "workspace_file_create")
+	if !ok {
+		t.Fatal("missing session.workspace_file_changed tool_usage event")
+	}
+	if workspaceEvent.Requests == nil || *workspaceEvent.Requests != 0 {
+		t.Fatalf("workspace file event requests = %v, want 0", workspaceEvent.Requests)
+	}
+	if got, _ := workspaceEvent.Payload["file"].(string); got != "docs/NEW.md" {
+		t.Fatalf("workspace payload.file = %q, want docs/NEW.md", got)
+	}
+}
+
+func TestParseCopilotTelemetrySessionFile_AssistantUsageFallbackModel(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "session-telemetry-usage"
+	eventsPath := filepath.Join(tmpDir, "events.jsonl")
+
+	events := []map[string]any{
+		{
+			"type":      "session.start",
+			"timestamp": "2026-03-01T11:00:00Z",
+			"data": map[string]any{
+				"sessionId": sessionID,
+				"context": map[string]any{
+					"cwd":        "/Users/test/openusage",
+					"repository": "janekbaraniewski/openusage",
+				},
+			},
+		},
+		{
+			"type":      "session.model_change",
+			"timestamp": "2026-03-01T11:00:01Z",
+			"data": map[string]any{
+				"newModel": "claude-sonnet-4.5",
+			},
+		},
+		{
+			"type":      "assistant.usage",
+			"id":        "usage-evt-1",
+			"timestamp": "2026-03-01T11:00:02Z",
+			"data": map[string]any{
+				"model":            "",
+				"inputTokens":      120,
+				"outputTokens":     30,
+				"cacheReadTokens":  10,
+				"cacheWriteTokens": 2,
+				"cost":             1.25,
+				"duration":         3250,
+			},
+		},
+	}
+	writeCopilotTelemetryEvents(t, eventsPath, events)
+
+	out, err := parseCopilotTelemetrySessionFile(eventsPath, sessionID)
+	if err != nil {
+		t.Fatalf("parseCopilotTelemetrySessionFile() error: %v", err)
+	}
+
+	var usageEvent *shared.TelemetryEvent
+	for i := range out {
+		if out[i].EventType == shared.TelemetryEventTypeMessageUsage {
+			usageEvent = &out[i]
+			break
+		}
+	}
+	if usageEvent == nil {
+		t.Fatal("missing message_usage event")
+	}
+	if usageEvent.ModelRaw != "claude-sonnet-4.5" {
+		t.Fatalf("model_raw = %q, want claude-sonnet-4.5", usageEvent.ModelRaw)
+	}
+	if usageEvent.TotalTokens == nil || *usageEvent.TotalTokens != 150 {
+		t.Fatalf("total_tokens = %v, want 150", usageEvent.TotalTokens)
+	}
+	if usageEvent.CacheReadTokens == nil || *usageEvent.CacheReadTokens != 10 {
+		t.Fatalf("cache_read_tokens = %v, want 10", usageEvent.CacheReadTokens)
+	}
+	if usageEvent.CacheWriteTokens == nil || *usageEvent.CacheWriteTokens != 2 {
+		t.Fatalf("cache_write_tokens = %v, want 2", usageEvent.CacheWriteTokens)
+	}
+	if usageEvent.CostUSD == nil || *usageEvent.CostUSD != 1.25 {
+		t.Fatalf("cost_usd = %v, want 1.25", usageEvent.CostUSD)
+	}
+	if got, _ := usageEvent.Payload["client"].(string); got != "janekbaraniewski/openusage" {
+		t.Fatalf("payload.client = %q, want janekbaraniewski/openusage", got)
+	}
+}
+
+func TestParseCopilotTelemetrySessionFile_ShutdownFallbackUsage(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "session-telemetry-shutdown"
+	eventsPath := filepath.Join(tmpDir, "events.jsonl")
+
+	events := []map[string]any{
+		{
+			"type":      "session.start",
+			"timestamp": "2026-03-01T12:00:00Z",
+			"data": map[string]any{
+				"sessionId": sessionID,
+				"context": map[string]any{
+					"cwd":        "/Users/test/openusage",
+					"repository": "janekbaraniewski/openusage",
+				},
+			},
+		},
+		{
+			"type":      "session.shutdown",
+			"id":        "shutdown-evt-1",
+			"timestamp": "2026-03-01T12:05:00Z",
+			"data": map[string]any{
+				"shutdownType":         "normal",
+				"totalPremiumRequests": 4,
+				"totalApiDurationMs":   9000,
+				"sessionStartTime":     "2026-03-01T12:00:00Z",
+				"codeChanges": map[string]any{
+					"linesAdded":    12,
+					"linesRemoved":  3,
+					"filesModified": 2,
+				},
+				"modelMetrics": map[string]any{
+					"gpt-5": map[string]any{
+						"requests": map[string]any{
+							"count": 4,
+							"cost":  0.88,
+						},
+						"usage": map[string]any{
+							"inputTokens":      100,
+							"outputTokens":     40,
+							"cacheReadTokens":  10,
+							"cacheWriteTokens": 2,
+						},
+					},
+				},
+			},
+		},
+	}
+	writeCopilotTelemetryEvents(t, eventsPath, events)
+
+	out, err := parseCopilotTelemetrySessionFile(eventsPath, sessionID)
+	if err != nil {
+		t.Fatalf("parseCopilotTelemetrySessionFile() error: %v", err)
+	}
+
+	var turnCompleted *shared.TelemetryEvent
+	var usageEvent *shared.TelemetryEvent
+	for i := range out {
+		switch out[i].EventType {
+		case shared.TelemetryEventTypeTurnCompleted:
+			turnCompleted = &out[i]
+		case shared.TelemetryEventTypeMessageUsage:
+			if strings.Contains(out[i].MessageID, "shutdown:gpt_5") {
+				usageEvent = &out[i]
+			}
+		}
+	}
+
+	if turnCompleted == nil {
+		t.Fatal("missing turn_completed event from session.shutdown")
+	}
+	if got, ok := turnCompleted.Payload["lines_added"].(int); !ok || got != 12 {
+		t.Fatalf("turn_completed lines_added = %#v, want 12", turnCompleted.Payload["lines_added"])
+	}
+	if got, ok := turnCompleted.Payload["lines_removed"].(int); !ok || got != 3 {
+		t.Fatalf("turn_completed lines_removed = %#v, want 3", turnCompleted.Payload["lines_removed"])
+	}
+
+	if usageEvent == nil {
+		t.Fatal("missing shutdown fallback message_usage event")
+	}
+	if usageEvent.ModelRaw != "gpt-5" {
+		t.Fatalf("fallback model_raw = %q, want gpt-5", usageEvent.ModelRaw)
+	}
+	if usageEvent.TotalTokens == nil || *usageEvent.TotalTokens != 140 {
+		t.Fatalf("fallback total_tokens = %v, want 140", usageEvent.TotalTokens)
+	}
+	if usageEvent.Requests == nil || *usageEvent.Requests != 4 {
+		t.Fatalf("fallback requests = %v, want 4", usageEvent.Requests)
+	}
+	if usageEvent.CostUSD == nil || *usageEvent.CostUSD != 0.88 {
+		t.Fatalf("fallback cost = %v, want 0.88", usageEvent.CostUSD)
+	}
+	if got, ok := usageEvent.Payload["lines_added"].(int); !ok || got != 12 {
+		t.Fatalf("fallback payload.lines_added = %#v, want 12", usageEvent.Payload["lines_added"])
+	}
+}
+
+func TestParseCopilotTelemetrySessionFile_ShutdownDoesNotDuplicateWhenUsageExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "session-telemetry-no-duplicate"
+	eventsPath := filepath.Join(tmpDir, "events.jsonl")
+
+	events := []map[string]any{
+		{
+			"type":      "session.start",
+			"timestamp": "2026-03-01T13:00:00Z",
+			"data": map[string]any{
+				"sessionId": sessionID,
+			},
+		},
+		{
+			"type":      "assistant.usage",
+			"timestamp": "2026-03-01T13:00:01Z",
+			"data": map[string]any{
+				"model":        "gpt-5",
+				"inputTokens":  50,
+				"outputTokens": 10,
+			},
+		},
+		{
+			"type":      "session.shutdown",
+			"timestamp": "2026-03-01T13:00:02Z",
+			"data": map[string]any{
+				"codeChanges": map[string]any{
+					"linesAdded":    2,
+					"linesRemoved":  1,
+					"filesModified": 1,
+				},
+				"modelMetrics": map[string]any{
+					"gpt-5": map[string]any{
+						"requests": map[string]any{"count": 2, "cost": 0.2},
+						"usage":    map[string]any{"inputTokens": 20, "outputTokens": 5},
+					},
+				},
+			},
+		},
+	}
+	writeCopilotTelemetryEvents(t, eventsPath, events)
+
+	out, err := parseCopilotTelemetrySessionFile(eventsPath, sessionID)
+	if err != nil {
+		t.Fatalf("parseCopilotTelemetrySessionFile() error: %v", err)
+	}
+
+	messageUsageCount := 0
+	for _, ev := range out {
+		if ev.EventType == shared.TelemetryEventTypeMessageUsage {
+			messageUsageCount++
+		}
+	}
+	if messageUsageCount != 1 {
+		t.Fatalf("message usage count = %d, want 1 (assistant.usage only)", messageUsageCount)
+	}
+}
+
+func writeCopilotTelemetryEvents(t *testing.T, path string, events []map[string]any) {
+	t.Helper()
+
+	lines := make([]string, 0, len(events))
+	for _, event := range events {
+		raw, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		lines = append(lines, string(raw))
+	}
+
+	body := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+}
+
+func findToolEventByCallIDAndStatus(events []shared.TelemetryEvent, callID string, status shared.TelemetryStatus) (shared.TelemetryEvent, bool) {
+	for _, ev := range events {
+		if ev.EventType == shared.TelemetryEventTypeToolUsage &&
+			ev.ToolCallID == callID &&
+			ev.Status == status {
+			return ev, true
+		}
+	}
+	return shared.TelemetryEvent{}, false
+}
+
+func findToolEventByName(events []shared.TelemetryEvent, toolName string) (shared.TelemetryEvent, bool) {
+	for _, ev := range events {
+		if ev.EventType == shared.TelemetryEventTypeToolUsage &&
+			ev.ToolName == toolName {
+			return ev, true
+		}
+	}
+	return shared.TelemetryEvent{}, false
+}

--- a/internal/providers/cursor/telemetry.go
+++ b/internal/providers/cursor/telemetry.go
@@ -34,11 +34,12 @@ func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOpti
 	seenTools := make(map[string]bool)
 	var out []shared.TelemetryEvent
 
-	// Collect from the tracking DB (ai_code_hashes table).
+	// Collect from the tracking DB (ai_code_hashes + scored_commits).
 	if trackingDBPath != "" {
-		events, err := collectTrackingDBEvents(ctx, trackingDBPath)
+		events, commitEvents, err := collectTrackingDBEvents(ctx, trackingDBPath)
 		if err == nil {
 			appendCursorDedupEvents(&out, events, seenMessages, seenTools)
+			appendCursorDedupEvents(&out, commitEvents, seenMessages, seenTools)
 		}
 	}
 
@@ -92,24 +93,27 @@ func defaultStateDBPath() string {
 	}
 }
 
-// collectTrackingDBEvents reads the ai_code_hashes table from the Cursor
-// tracking database and produces message usage events.
-func collectTrackingDBEvents(ctx context.Context, dbPath string) ([]shared.TelemetryEvent, error) {
+// collectTrackingDBEvents reads the ai_code_hashes and scored_commits tables
+// from the Cursor tracking database. Returns (usage events, commit events, error).
+func collectTrackingDBEvents(ctx context.Context, dbPath string) ([]shared.TelemetryEvent, []shared.TelemetryEvent, error) {
 	if strings.TrimSpace(dbPath) == "" {
-		return nil, nil
-	}
-	if _, err := os.Stat(dbPath); err != nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro", dbPath))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer db.Close()
 
+	// Collect scored commits from the same DB connection.
+	var commitEvents []shared.TelemetryEvent
+	if cursorTableExists(ctx, db, "scored_commits") {
+		commitEvents, _ = queryScoredCommits(ctx, db, dbPath)
+	}
+
 	if !cursorTableExists(ctx, db, "ai_code_hashes") {
-		return nil, nil
+		return nil, commitEvents, nil
 	}
 
 	timeExpr := chooseTrackingTimeExpr(ctx, db)
@@ -118,29 +122,35 @@ func collectTrackingDBEvents(ctx context.Context, dbPath string) ([]shared.Telem
 		SELECT COALESCE(source, ''),
 		       COALESCE(model, ''),
 		       COALESCE(fileExtension, ''),
+		       COALESCE(fileName, ''),
+		       COALESCE(requestId, ''),
+		       COALESCE(conversationId, ''),
 		       COALESCE(%s, 0),
 		       rowid
 		FROM ai_code_hashes
 		ORDER BY %s ASC`, timeExpr, timeExpr))
 	if err != nil {
-		return nil, fmt.Errorf("cursor: querying ai_code_hashes: %w", err)
+		return nil, commitEvents, fmt.Errorf("cursor: querying ai_code_hashes: %w", err)
 	}
 	defer rows.Close()
 
 	var out []shared.TelemetryEvent
 	for rows.Next() {
 		if ctx.Err() != nil {
-			return out, ctx.Err()
+			return out, commitEvents, ctx.Err()
 		}
 
 		var (
-			source    string
-			model     string
-			fileExt   string
-			timestamp int64
-			rowID     int64
+			source         string
+			model          string
+			fileExt        string
+			fileName       string
+			requestID      string
+			conversationID string
+			timestamp      int64
+			rowID          int64
 		)
-		if err := rows.Scan(&source, &model, &fileExt, &timestamp, &rowID); err != nil {
+		if err := rows.Scan(&source, &model, &fileExt, &fileName, &requestID, &conversationID, &timestamp, &rowID); err != nil {
 			continue
 		}
 
@@ -151,22 +161,33 @@ func collectTrackingDBEvents(ctx context.Context, dbPath string) ([]shared.Telem
 
 		messageID := fmt.Sprintf("cursor-tracking:%d", rowID)
 
+		clientBucket := cursorSourceToClientBucket(source)
+
+		// Use conversationId as session ID to link tracking events to composer sessions.
+		sessionID := strings.TrimSpace(conversationID)
+
 		payload := map[string]any{
 			"source": map[string]any{
 				"db_path": dbPath,
 				"table":   "ai_code_hashes",
 				"row_id":  rowID,
 			},
+			"client":        clientBucket,
+			"cursor_source": source,
 		}
 		if fileExt != "" {
 			payload["file_extension"] = fileExt
-			payload["file"] = "example" + normalizeFileExtension(fileExt)
 		}
-		if source != "" {
-			payload["cursor_source"] = source
+		if fileName != "" {
+			payload["file"] = fileName
+		} else if fileExt != "" {
+			payload["file"] = "example" + normalizeFileExtension(fileExt)
 		}
 		if upstream := inferProviderFromModel(model); upstream != "cursor" {
 			payload["upstream_provider"] = upstream
+		}
+		if requestID != "" {
+			payload["request_id"] = requestID
 		}
 
 		out = append(out, shared.TelemetryEvent{
@@ -174,7 +195,7 @@ func collectTrackingDBEvents(ctx context.Context, dbPath string) ([]shared.Telem
 			Channel:       shared.TelemetryChannelSQLite,
 			OccurredAt:    occurredAt,
 			AccountID:     "",
-			SessionID:     "",
+			SessionID:     sessionID,
 			MessageID:     messageID,
 			ProviderID:    "cursor",
 			AgentName:     cursorAgentName(source),
@@ -186,7 +207,7 @@ func collectTrackingDBEvents(ctx context.Context, dbPath string) ([]shared.Telem
 		})
 	}
 
-	return out, rows.Err()
+	return out, commitEvents, rows.Err()
 }
 
 // collectStateDBEvents reads composerData and bubbleId entries from the
@@ -223,20 +244,43 @@ func collectStateDBEvents(ctx context.Context, dbPath string) ([]shared.Telemetr
 		out = append(out, toolEvents...)
 	}
 
+	// Collect token counts from bubble entries and attach to composer sessions.
+	tokenEvents, err := collectBubbleTokenEvents(ctx, db, dbPath)
+	if err == nil {
+		out = append(out, tokenEvents...)
+	}
+
+	// Collect daily stats (tab/composer suggested/accepted lines).
+	if cursorTableExists(ctx, db, "ItemTable") {
+		dailyEvents, err := collectDailyStatsEvents(ctx, db, dbPath)
+		if err == nil {
+			out = append(out, dailyEvents...)
+		}
+	}
+
 	return out, nil
 }
 
 // collectComposerEvents extracts usage data from composerData entries.
-// Each composer session has a usageData map with per-model cost and request counts.
+// Each composer session has a usageData map with per-model cost and request counts,
+// plus session metadata like mode, model config, and file changes.
 func collectComposerEvents(ctx context.Context, db *sql.DB, dbPath string) ([]shared.TelemetryEvent, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT key,
 		       json_extract(value, '$.usageData'),
 		       json_extract(value, '$.createdAt'),
 		       json_extract(value, '$.unifiedMode'),
+		       json_extract(value, '$.forceMode'),
 		       json_extract(value, '$.isAgentic'),
 		       json_extract(value, '$.totalLinesAdded'),
-		       json_extract(value, '$.totalLinesRemoved')
+		       json_extract(value, '$.totalLinesRemoved'),
+		       json_extract(value, '$.modelConfig.modelName'),
+		       json_extract(value, '$.newlyCreatedFiles'),
+		       json_extract(value, '$.addedFiles'),
+		       json_extract(value, '$.removedFiles'),
+		       json_extract(value, '$.contextTokensUsed'),
+		       json_extract(value, '$.contextTokenLimit'),
+		       json_extract(value, '$.filesChangedCount')
 		FROM cursorDiskKV
 		WHERE key LIKE 'composerData:%'
 		  AND json_extract(value, '$.usageData') IS NOT NULL
@@ -253,15 +297,25 @@ func collectComposerEvents(ctx context.Context, db *sql.DB, dbPath string) ([]sh
 		}
 
 		var (
-			key          string
-			usageJSON    sql.NullString
-			createdAt    sql.NullInt64
-			mode         sql.NullString
-			isAgentic    sql.NullBool
-			linesAdded   sql.NullInt64
-			linesRemoved sql.NullInt64
+			key             string
+			usageJSON       sql.NullString
+			createdAt       sql.NullInt64
+			mode            sql.NullString
+			forceMode       sql.NullString
+			isAgentic       sql.NullBool
+			linesAdded      sql.NullInt64
+			linesRemoved    sql.NullInt64
+			modelConfigName sql.NullString
+			newlyCreated    sql.NullString
+			addedFiles      sql.NullString
+			removedFiles    sql.NullString
+			ctxTokensUsed   sql.NullInt64
+			ctxTokenLimit   sql.NullInt64
+			filesChangedCnt sql.NullInt64
 		)
-		if err := rows.Scan(&key, &usageJSON, &createdAt, &mode, &isAgentic, &linesAdded, &linesRemoved); err != nil {
+		if err := rows.Scan(&key, &usageJSON, &createdAt, &mode, &forceMode, &isAgentic,
+			&linesAdded, &linesRemoved, &modelConfigName, &newlyCreated, &addedFiles, &removedFiles,
+			&ctxTokensUsed, &ctxTokenLimit, &filesChangedCnt); err != nil {
 			continue
 		}
 		if !usageJSON.Valid || usageJSON.String == "" || usageJSON.String == "{}" {
@@ -294,6 +348,7 @@ func collectComposerEvents(ctx context.Context, db *sql.DB, dbPath string) ([]sh
 					"table":   "cursorDiskKV",
 					"key":     key,
 				},
+				"client":        "IDE",
 				"cursor_source": "composer",
 			}
 			if upstream := inferProviderFromModel(model); upstream != "cursor" {
@@ -301,6 +356,9 @@ func collectComposerEvents(ctx context.Context, db *sql.DB, dbPath string) ([]sh
 			}
 			if mode.Valid && mode.String != "" {
 				payload["mode"] = mode.String
+			}
+			if forceMode.Valid && forceMode.String != "" {
+				payload["force_mode"] = forceMode.String
 			}
 			if isAgentic.Valid {
 				payload["is_agentic"] = isAgentic.Bool
@@ -310,6 +368,30 @@ func collectComposerEvents(ctx context.Context, db *sql.DB, dbPath string) ([]sh
 			}
 			if linesRemoved.Valid && linesRemoved.Int64 > 0 {
 				payload["lines_removed"] = linesRemoved.Int64
+			}
+			if modelConfigName.Valid && modelConfigName.String != "" {
+				payload["model_config"] = modelConfigName.String
+			}
+			newFileCount := countJSONArrayItems(newlyCreated)
+			addedCount := countNullableInt(addedFiles)
+			removedCount := countNullableInt(removedFiles)
+			if newFileCount > 0 {
+				payload["newly_created_files"] = newFileCount
+			}
+			if addedCount > 0 {
+				payload["added_files"] = addedCount
+			}
+			if removedCount > 0 {
+				payload["removed_files"] = removedCount
+			}
+			if ctxTokensUsed.Valid && ctxTokensUsed.Int64 > 0 {
+				payload["context_tokens_used"] = ctxTokensUsed.Int64
+			}
+			if ctxTokenLimit.Valid && ctxTokenLimit.Int64 > 0 {
+				payload["context_token_limit"] = ctxTokenLimit.Int64
+			}
+			if filesChangedCnt.Valid && filesChangedCnt.Int64 > 0 {
+				payload["files_changed"] = filesChangedCnt.Int64
 			}
 
 			out = append(out, shared.TelemetryEvent{
@@ -417,6 +499,7 @@ func collectToolEvents(ctx context.Context, db *sql.DB, dbPath string) ([]shared
 					"table":   "cursorDiskKV",
 					"key":     key,
 				},
+				"client":          "IDE",
 				"raw_tool_name":   toolNameRaw.String,
 				"raw_tool_status": toolStatusRaw.String,
 			},
@@ -533,6 +616,15 @@ func inferProviderFromModel(model string) string {
 	}
 }
 
+// cursorSourceToClientBucket maps a Cursor source column value to a client
+// bucket name suitable for the clientDimensionExpr "$.client" field.
+func cursorSourceToClientBucket(source string) string {
+	if strings.ToLower(strings.TrimSpace(source)) == "cli" {
+		return "CLI"
+	}
+	return "IDE"
+}
+
 // cursorAgentName maps a Cursor source identifier to an agent name for
 // telemetry classification.
 func cursorAgentName(source string) string {
@@ -576,4 +668,302 @@ func normalizeFileExtension(ext string) string {
 		return "." + ext
 	}
 	return ext
+}
+
+// collectBubbleTokenEvents extracts token counts from bubbleId entries in the
+// state DB. Each AI response bubble (type=2) may have a tokenCount with
+// inputTokens/outputTokens. These are emitted as message_usage events linked
+// to their parent composer session via conversationId.
+func collectBubbleTokenEvents(ctx context.Context, db *sql.DB, dbPath string) ([]shared.TelemetryEvent, error) {
+	sessionTimestamps := buildSessionTimestampMap(ctx, db)
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT key,
+		       json_extract(value, '$.tokenCount.inputTokens'),
+		       json_extract(value, '$.tokenCount.outputTokens'),
+		       json_extract(value, '$.conversationId'),
+		       json_extract(value, '$.model')
+		FROM cursorDiskKV
+		WHERE key LIKE 'bubbleId:%'
+		  AND json_extract(value, '$.type') = 2
+		  AND json_extract(value, '$.tokenCount') IS NOT NULL
+		  AND json_extract(value, '$.tokenCount.inputTokens') > 0`)
+	if err != nil {
+		return nil, fmt.Errorf("cursor: querying bubbleId tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var out []shared.TelemetryEvent
+	for rows.Next() {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+
+		var (
+			key            string
+			inputTokens    sql.NullInt64
+			outputTokens   sql.NullInt64
+			conversationID sql.NullString
+			model          sql.NullString
+		)
+		if err := rows.Scan(&key, &inputTokens, &outputTokens, &conversationID, &model); err != nil {
+			continue
+		}
+		if !inputTokens.Valid || inputTokens.Int64 <= 0 {
+			continue
+		}
+
+		bubbleID := strings.TrimPrefix(key, "bubbleId:")
+		messageID := fmt.Sprintf("cursor-bubble-tokens:%s", bubbleID)
+
+		sessionID := ""
+		if conversationID.Valid && conversationID.String != "" {
+			sessionID = conversationID.String
+		}
+
+		var occurredAt time.Time
+		if sessionID != "" {
+			if ts, ok := sessionTimestamps[sessionID]; ok {
+				occurredAt = ts
+			}
+		}
+
+		modelRaw := ""
+		if model.Valid {
+			modelRaw = model.String
+		}
+
+		var inTok, outTok *int64
+		if inputTokens.Valid && inputTokens.Int64 > 0 {
+			inTok = shared.Int64Ptr(inputTokens.Int64)
+		}
+		if outputTokens.Valid && outputTokens.Int64 > 0 {
+			outTok = shared.Int64Ptr(outputTokens.Int64)
+		}
+
+		out = append(out, shared.TelemetryEvent{
+			SchemaVersion: telemetryCursorSQLiteSchema,
+			Channel:       shared.TelemetryChannelSQLite,
+			OccurredAt:    occurredAt,
+			SessionID:     sessionID,
+			MessageID:     messageID,
+			ProviderID:    "cursor",
+			AgentName:     "cursor",
+			EventType:     shared.TelemetryEventTypeMessageUsage,
+			ModelRaw:      modelRaw,
+			InputTokens:   inTok,
+			OutputTokens:  outTok,
+			Requests:      shared.Int64Ptr(1),
+			Status:        shared.TelemetryStatusOK,
+			Payload: map[string]any{
+				"source": map[string]any{
+					"db_path": dbPath,
+					"table":   "cursorDiskKV",
+					"key":     key,
+				},
+				"client":        "IDE",
+				"cursor_source": "composer",
+			},
+		})
+	}
+
+	return out, rows.Err()
+}
+
+// collectDailyStatsEvents extracts daily code tracking stats from ItemTable.
+// Keys like "aiCodeTracking.dailyStats.v1.5.2025-11-23" contain tab/composer
+// suggested/accepted line counts per day.
+func collectDailyStatsEvents(ctx context.Context, db *sql.DB, dbPath string) ([]shared.TelemetryEvent, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT key, value FROM ItemTable
+		WHERE key LIKE 'aiCodeTracking.dailyStats.%'`)
+	if err != nil {
+		return nil, fmt.Errorf("cursor: querying dailyStats: %w", err)
+	}
+	defer rows.Close()
+
+	var out []shared.TelemetryEvent
+	for rows.Next() {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+
+		var key, rawJSON string
+		if err := rows.Scan(&key, &rawJSON); err != nil {
+			continue
+		}
+
+		var stats cursorDailyStats
+		if json.Unmarshal([]byte(rawJSON), &stats) != nil {
+			continue
+		}
+		if stats.Date == "" {
+			continue
+		}
+
+		dayTime, err := time.Parse("2006-01-02", stats.Date)
+		if err != nil {
+			continue
+		}
+
+		messageID := fmt.Sprintf("cursor-daily-stats:%s", stats.Date)
+
+		out = append(out, shared.TelemetryEvent{
+			SchemaVersion: telemetryCursorSQLiteSchema,
+			Channel:       shared.TelemetryChannelSQLite,
+			OccurredAt:    dayTime,
+			MessageID:     messageID,
+			ProviderID:    "cursor",
+			AgentName:     "cursor",
+			EventType:     shared.TelemetryEventTypeRawEnvelope,
+			Requests:      shared.Int64Ptr(1),
+			Status:        shared.TelemetryStatusOK,
+			Payload: map[string]any{
+				"source": map[string]any{
+					"db_path": dbPath,
+					"table":   "ItemTable",
+					"key":     key,
+				},
+				"daily_stats": map[string]any{
+					"date":                     stats.Date,
+					"tab_suggested_lines":      stats.TabSuggestedLines,
+					"tab_accepted_lines":       stats.TabAcceptedLines,
+					"composer_suggested_lines": stats.ComposerSuggestedLines,
+					"composer_accepted_lines":  stats.ComposerAcceptedLines,
+				},
+			},
+		})
+	}
+
+	return out, rows.Err()
+}
+
+// queryScoredCommits reads scored_commits from an already-open tracking DB
+// and produces telemetry events with AI contribution percentages per commit.
+func queryScoredCommits(ctx context.Context, db *sql.DB, dbPath string) ([]shared.TelemetryEvent, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT commitHash, branchName, scoredAt,
+		       COALESCE(linesAdded, 0), COALESCE(linesDeleted, 0),
+		       COALESCE(tabLinesAdded, 0), COALESCE(tabLinesDeleted, 0),
+		       COALESCE(composerLinesAdded, 0), COALESCE(composerLinesDeleted, 0),
+		       COALESCE(humanLinesAdded, 0), COALESCE(humanLinesDeleted, 0),
+		       COALESCE(commitMessage, ''),
+		       COALESCE(v1AiPercentage, ''), COALESCE(v2AiPercentage, '')
+		FROM scored_commits
+		ORDER BY scoredAt ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("cursor: querying scored_commits: %w", err)
+	}
+	defer rows.Close()
+
+	var out []shared.TelemetryEvent
+	for rows.Next() {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+
+		var (
+			commitHash       string
+			branchName       string
+			scoredAt         int64
+			linesAdded       int64
+			linesDeleted     int64
+			tabAdded         int64
+			tabDeleted       int64
+			composerAdded    int64
+			composerDeleted  int64
+			humanAdded       int64
+			humanDeleted     int64
+			commitMessage    string
+			v1AiPct, v2AiPct string
+		)
+		if err := rows.Scan(&commitHash, &branchName, &scoredAt,
+			&linesAdded, &linesDeleted, &tabAdded, &tabDeleted,
+			&composerAdded, &composerDeleted, &humanAdded, &humanDeleted,
+			&commitMessage, &v1AiPct, &v2AiPct); err != nil {
+			continue
+		}
+
+		occurredAt := time.Now().UTC()
+		if scoredAt > 0 {
+			occurredAt = shared.UnixAuto(scoredAt)
+		}
+
+		messageID := fmt.Sprintf("cursor-scored-commit:%s", commitHash)
+
+		out = append(out, shared.TelemetryEvent{
+			SchemaVersion: telemetryCursorSQLiteSchema,
+			Channel:       shared.TelemetryChannelSQLite,
+			OccurredAt:    occurredAt,
+			MessageID:     messageID,
+			ProviderID:    "cursor",
+			AgentName:     "cursor",
+			EventType:     shared.TelemetryEventTypeRawEnvelope,
+			Requests:      shared.Int64Ptr(1),
+			Status:        shared.TelemetryStatusOK,
+			Payload: map[string]any{
+				"source": map[string]any{
+					"db_path": dbPath,
+					"table":   "scored_commits",
+				},
+				"scored_commit": map[string]any{
+					"commit_hash":            commitHash,
+					"branch":                 branchName,
+					"message":                truncateString(commitMessage, 200),
+					"lines_added":            linesAdded,
+					"lines_deleted":          linesDeleted,
+					"tab_lines_added":        tabAdded,
+					"tab_lines_deleted":      tabDeleted,
+					"composer_lines_added":   composerAdded,
+					"composer_lines_deleted": composerDeleted,
+					"human_lines_added":      humanAdded,
+					"human_lines_deleted":    humanDeleted,
+					"v1_ai_percentage":       v1AiPct,
+					"v2_ai_percentage":       v2AiPct,
+				},
+			},
+		})
+	}
+
+	return out, rows.Err()
+}
+
+type cursorDailyStats struct {
+	Date                   string `json:"date"`
+	TabSuggestedLines      int    `json:"tabSuggestedLines"`
+	TabAcceptedLines       int    `json:"tabAcceptedLines"`
+	ComposerSuggestedLines int    `json:"composerSuggestedLines"`
+	ComposerAcceptedLines  int    `json:"composerAcceptedLines"`
+}
+
+// countJSONArrayItems parses a nullable string as a JSON array and returns its length.
+func countJSONArrayItems(s sql.NullString) int {
+	if !s.Valid || s.String == "" || s.String == "[]" {
+		return 0
+	}
+	var arr []any
+	if json.Unmarshal([]byte(s.String), &arr) != nil {
+		return 0
+	}
+	return len(arr)
+}
+
+// countNullableInt parses a nullable string as an integer count.
+// Handles both integer values and JSON array strings.
+func countNullableInt(s sql.NullString) int {
+	if !s.Valid || s.String == "" {
+		return 0
+	}
+	var n int
+	if _, err := fmt.Sscanf(s.String, "%d", &n); err == nil {
+		return n
+	}
+	return countJSONArrayItems(s)
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
 }

--- a/internal/providers/gemini_cli/gemini_cli.go
+++ b/internal/providers/gemini_cli/gemini_cli.go
@@ -49,7 +49,7 @@ func New() *Provider {
 			ID: "gemini_cli",
 			Info: core.ProviderInfo{
 				Name:         "Gemini CLI",
-				Capabilities: []string{"local_config", "oauth_status", "conversation_count", "local_sessions", "token_usage", "by_model", "by_client", "quota_api"},
+				Capabilities: []string{"local_config", "oauth_status", "conversation_count", "local_sessions", "token_usage", "by_model", "by_client", "mcp_config", "code_generation", "quota_api"},
 				DocURL:       "https://github.com/google-gemini/gemini-cli",
 			},
 			Auth: core.ProviderAuthSpec{
@@ -108,6 +108,17 @@ type geminiSettings struct {
 	Experimental struct {
 		Plan bool `json:"plan"`
 	} `json:"experimental"`
+	MCPServers map[string]geminiMCPServer `json:"mcpServers,omitempty"`
+}
+
+type geminiMCPServer struct {
+	Command string   `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
+	URL     string   `json:"url,omitempty"`
+}
+
+type geminiMCPEnablement struct {
+	Enabled bool `json:"enabled"`
 }
 
 type tokenRefreshResponse struct {
@@ -182,6 +193,7 @@ type geminiChatFile struct {
 }
 
 type geminiChatMessage struct {
+	ID        string              `json:"id,omitempty"`
 	Type      string              `json:"type"`
 	Timestamp string              `json:"timestamp"`
 	Model     string              `json:"model"`
@@ -191,9 +203,27 @@ type geminiChatMessage struct {
 }
 
 type geminiToolCall struct {
-	Name   string          `json:"name"`
-	Status string          `json:"status,omitempty"`
-	Args   json.RawMessage `json:"args,omitempty"`
+	ID                     string          `json:"id,omitempty"`
+	Name                   string          `json:"name"`
+	Status                 string          `json:"status,omitempty"`
+	Timestamp              string          `json:"timestamp,omitempty"`
+	DisplayName            string          `json:"displayName,omitempty"`
+	Description            string          `json:"description,omitempty"`
+	RenderOutputAsMarkdown *bool           `json:"renderOutputAsMarkdown,omitempty"`
+	Result                 json.RawMessage `json:"result,omitempty"`
+	ResultDisplay          json.RawMessage `json:"resultDisplay,omitempty"`
+	Args                   json.RawMessage `json:"args,omitempty"`
+}
+
+type geminiDiffStat struct {
+	ModelAddedLines   int `json:"model_added_lines"`
+	ModelRemovedLines int `json:"model_removed_lines"`
+	ModelAddedChars   int `json:"model_added_chars"`
+	ModelRemovedChars int `json:"model_removed_chars"`
+	UserAddedLines    int `json:"user_added_lines"`
+	UserRemovedLines  int `json:"user_removed_lines"`
+	UserAddedChars    int `json:"user_added_chars"`
+	UserRemovedChars  int `json:"user_removed_chars"`
 }
 
 type geminiMessageToken struct {
@@ -301,6 +331,7 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 			if settings.General.PreviewFeatures {
 				snap.Raw["preview_features"] = "enabled"
 			}
+			applyGeminiMCPMetadata(&snap, settings, filepath.Join(configDir, "mcp-server-enablement.json"))
 		}
 	}
 
@@ -946,6 +977,99 @@ func applyQuotaStatus(snap *core.UsageSnapshot, worstFraction float64) {
 	}
 }
 
+func applyGeminiMCPMetadata(snap *core.UsageSnapshot, settings geminiSettings, enablementPath string) {
+	configured := make(map[string]bool)
+	for name := range settings.MCPServers {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		configured[name] = true
+	}
+
+	enabled := make(map[string]bool)
+	disabled := make(map[string]bool)
+	if data, err := os.ReadFile(enablementPath); err == nil {
+		var state map[string]geminiMCPEnablement
+		if json.Unmarshal(data, &state) == nil {
+			for name, cfg := range state {
+				name = strings.TrimSpace(name)
+				if name == "" {
+					continue
+				}
+				configured[name] = true
+				if cfg.Enabled {
+					enabled[name] = true
+					delete(disabled, name)
+					continue
+				}
+				if !enabled[name] {
+					disabled[name] = true
+				}
+			}
+		}
+	}
+
+	configuredNames := mapKeysSorted(configured)
+	enabledNames := mapKeysSorted(enabled)
+	disabledNames := mapKeysSorted(disabled)
+
+	if len(configuredNames) == 0 {
+		return
+	}
+
+	setUsedMetric(snap, "mcp_servers_configured", float64(len(configuredNames)), "servers", defaultUsageWindowLabel)
+	if len(enabledNames) > 0 {
+		setUsedMetric(snap, "mcp_servers_enabled", float64(len(enabledNames)), "servers", defaultUsageWindowLabel)
+	}
+	if len(disabledNames) > 0 {
+		setUsedMetric(snap, "mcp_servers_disabled", float64(len(disabledNames)), "servers", defaultUsageWindowLabel)
+	}
+	if len(enabledNames)+len(disabledNames) > 0 {
+		setUsedMetric(snap, "mcp_servers_tracked", float64(len(enabledNames)+len(disabledNames)), "servers", defaultUsageWindowLabel)
+	}
+
+	if summary := formatGeminiNameList(configuredNames, maxBreakdownRaw); summary != "" {
+		snap.Raw["mcp_servers"] = summary
+	}
+	if summary := formatGeminiNameList(enabledNames, maxBreakdownRaw); summary != "" {
+		snap.Raw["mcp_servers_enabled"] = summary
+	}
+	if summary := formatGeminiNameList(disabledNames, maxBreakdownRaw); summary != "" {
+		snap.Raw["mcp_servers_disabled"] = summary
+	}
+}
+
+func mapKeysSorted(values map[string]bool) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for key := range values {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func formatGeminiNameList(values []string, max int) string {
+	if len(values) == 0 {
+		return ""
+	}
+	limit := max
+	if limit <= 0 || limit > len(values) {
+		limit = len(values)
+	}
+	out := strings.Join(values[:limit], ", ")
+	if len(values) > limit {
+		out += fmt.Sprintf(", +%d more", len(values)-limit)
+	}
+	return out
+}
+
 func (t geminiMessageToken) toUsage() tokenUsage {
 	total := t.Total
 	if total <= 0 {
@@ -1005,8 +1129,15 @@ func (p *Provider) readSessionUsageBreakdowns(tmpDir string, snap *core.UsageSna
 	totalToolErrored := 0
 	totalToolCancelled := 0
 	quotaLimitEvents := 0
-	inferredLinesAdded := 0
-	inferredLinesRemoved := 0
+	modelLinesAdded := 0
+	modelLinesRemoved := 0
+	modelCharsAdded := 0
+	modelCharsRemoved := 0
+	userLinesAdded := 0
+	userLinesRemoved := 0
+	userCharsAdded := 0
+	userCharsRemoved := 0
+	diffStatEvents := 0
 	inferredCommitCount := 0
 
 	var lastModelName string
@@ -1105,9 +1236,21 @@ func (p *Provider) readSessionUsageBreakdowns(tmpDir string, snap *core.UsageSna
 					}
 
 					if successfulToolCall && isGeminiMutatingTool(toolLower) {
-						added, removed := estimateGeminiToolLineDelta(tc.Args)
-						inferredLinesAdded += added
-						inferredLinesRemoved += removed
+						if diff, ok := extractGeminiToolDiffStat(tc.ResultDisplay); ok {
+							modelLinesAdded += diff.ModelAddedLines
+							modelLinesRemoved += diff.ModelRemovedLines
+							modelCharsAdded += diff.ModelAddedChars
+							modelCharsRemoved += diff.ModelRemovedChars
+							userLinesAdded += diff.UserAddedLines
+							userLinesRemoved += diff.UserRemovedLines
+							userCharsAdded += diff.UserAddedChars
+							userCharsRemoved += diff.UserRemovedChars
+							diffStatEvents++
+						} else {
+							added, removed := estimateGeminiToolLineDelta(tc.Args)
+							modelLinesAdded += added
+							modelLinesRemoved += removed
+						}
 					}
 
 					if !successfulToolCall {
@@ -1323,11 +1466,11 @@ func (p *Provider) readSessionUsageBreakdowns(tmpDir string, snap *core.UsageSna
 	setUsedMetric(snap, "7d_reasoning_tokens", sumLastNDays(dailyReasoningTokens, 7), "tokens", "7d")
 	setUsedMetric(snap, "7d_tool_tokens", sumLastNDays(dailyToolTokens, 7), "tokens", "7d")
 
-	if inferredLinesAdded > 0 {
-		setUsedMetric(snap, "composer_lines_added", float64(inferredLinesAdded), "lines", defaultUsageWindowLabel)
+	if modelLinesAdded > 0 {
+		setUsedMetric(snap, "composer_lines_added", float64(modelLinesAdded), "lines", defaultUsageWindowLabel)
 	}
-	if inferredLinesRemoved > 0 {
-		setUsedMetric(snap, "composer_lines_removed", float64(inferredLinesRemoved), "lines", defaultUsageWindowLabel)
+	if modelLinesRemoved > 0 {
+		setUsedMetric(snap, "composer_lines_removed", float64(modelLinesRemoved), "lines", defaultUsageWindowLabel)
 	}
 	if len(changedFiles) > 0 {
 		setUsedMetric(snap, "composer_files_changed", float64(len(changedFiles)), "files", defaultUsageWindowLabel)
@@ -1335,8 +1478,35 @@ func (p *Provider) readSessionUsageBreakdowns(tmpDir string, snap *core.UsageSna
 	if inferredCommitCount > 0 {
 		setUsedMetric(snap, "scored_commits", float64(inferredCommitCount), "commits", defaultUsageWindowLabel)
 	}
-	if inferredLinesAdded > 0 || inferredLinesRemoved > 0 {
-		setPercentMetric(snap, "ai_code_percentage", 100, defaultUsageWindowLabel)
+	if userLinesAdded > 0 {
+		setUsedMetric(snap, "composer_user_lines_added", float64(userLinesAdded), "lines", defaultUsageWindowLabel)
+	}
+	if userLinesRemoved > 0 {
+		setUsedMetric(snap, "composer_user_lines_removed", float64(userLinesRemoved), "lines", defaultUsageWindowLabel)
+	}
+	if modelCharsAdded > 0 {
+		setUsedMetric(snap, "composer_model_chars_added", float64(modelCharsAdded), "chars", defaultUsageWindowLabel)
+	}
+	if modelCharsRemoved > 0 {
+		setUsedMetric(snap, "composer_model_chars_removed", float64(modelCharsRemoved), "chars", defaultUsageWindowLabel)
+	}
+	if userCharsAdded > 0 {
+		setUsedMetric(snap, "composer_user_chars_added", float64(userCharsAdded), "chars", defaultUsageWindowLabel)
+	}
+	if userCharsRemoved > 0 {
+		setUsedMetric(snap, "composer_user_chars_removed", float64(userCharsRemoved), "chars", defaultUsageWindowLabel)
+	}
+	if diffStatEvents > 0 {
+		setUsedMetric(snap, "composer_diffstat_events", float64(diffStatEvents), "calls", defaultUsageWindowLabel)
+	}
+	totalModelLineDelta := modelLinesAdded + modelLinesRemoved
+	totalUserLineDelta := userLinesAdded + userLinesRemoved
+	if totalModelLineDelta > 0 || totalUserLineDelta > 0 {
+		totalLineDelta := totalModelLineDelta + totalUserLineDelta
+		if totalLineDelta > 0 {
+			aiPct := float64(totalModelLineDelta) / float64(totalLineDelta) * 100
+			setPercentMetric(snap, "ai_code_percentage", aiPct, defaultUsageWindowLabel)
+		}
 	}
 
 	if quotaLimitEvents > 0 {
@@ -1877,6 +2047,50 @@ func estimateGeminiToolLineDelta(raw json.RawMessage) (added int, removed int) {
 	}
 	walk(payload)
 	return added, removed
+}
+
+func extractGeminiToolDiffStat(raw json.RawMessage) (geminiDiffStat, bool) {
+	var empty geminiDiffStat
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return empty, false
+	}
+
+	var root map[string]json.RawMessage
+	if json.Unmarshal(raw, &root) != nil {
+		return empty, false
+	}
+	diffRaw, ok := root["diffStat"]
+	if !ok {
+		return empty, false
+	}
+
+	var stat geminiDiffStat
+	if json.Unmarshal(diffRaw, &stat) != nil {
+		return empty, false
+	}
+
+	stat.ModelAddedLines = max(0, stat.ModelAddedLines)
+	stat.ModelRemovedLines = max(0, stat.ModelRemovedLines)
+	stat.ModelAddedChars = max(0, stat.ModelAddedChars)
+	stat.ModelRemovedChars = max(0, stat.ModelRemovedChars)
+	stat.UserAddedLines = max(0, stat.UserAddedLines)
+	stat.UserRemovedLines = max(0, stat.UserRemovedLines)
+	stat.UserAddedChars = max(0, stat.UserAddedChars)
+	stat.UserRemovedChars = max(0, stat.UserRemovedChars)
+
+	if stat.ModelAddedLines == 0 &&
+		stat.ModelRemovedLines == 0 &&
+		stat.ModelAddedChars == 0 &&
+		stat.ModelRemovedChars == 0 &&
+		stat.UserAddedLines == 0 &&
+		stat.UserRemovedLines == 0 &&
+		stat.UserAddedChars == 0 &&
+		stat.UserRemovedChars == 0 {
+		return empty, false
+	}
+
+	return stat, true
 }
 
 func inferGeminiLanguageFromPath(path string) string {

--- a/internal/providers/gemini_cli/gemini_cli_test.go
+++ b/internal/providers/gemini_cli/gemini_cli_test.go
@@ -38,8 +38,20 @@ func TestFetch_ReadsLocalData(t *testing.T) {
 				"selectedType": "oauth-personal",
 			},
 		},
+		"mcpServers": map[string]any{
+			"gopls": map[string]any{"command": "gopls"},
+			"linear": map[string]any{
+				"command": "linear-mcp",
+			},
+			"kubernetes": map[string]any{"url": "http://localhost:8080"},
+		},
 	}
 	writeJSON(t, filepath.Join(tmpDir, "settings.json"), settings)
+	writeJSON(t, filepath.Join(tmpDir, "mcp-server-enablement.json"), map[string]any{
+		"gopls":      map[string]any{"enabled": true},
+		"linear":     map[string]any{"enabled": false},
+		"kubernetes": map[string]any{"enabled": true},
+	})
 
 	os.WriteFile(filepath.Join(tmpDir, "installation_id"), []byte("test-uuid-1234"), 0644)
 
@@ -87,6 +99,22 @@ func TestFetch_ReadsLocalData(t *testing.T) {
 	}
 	if conv.Used == nil || *conv.Used != 3 {
 		t.Errorf("total_conversations = %v, want 3", conv.Used)
+	}
+
+	configured, ok := snap.Metrics["mcp_servers_configured"]
+	if !ok || configured.Used == nil || *configured.Used != 3 {
+		t.Fatalf("mcp_servers_configured = %+v, want 3", configured)
+	}
+	enabled, ok := snap.Metrics["mcp_servers_enabled"]
+	if !ok || enabled.Used == nil || *enabled.Used != 2 {
+		t.Fatalf("mcp_servers_enabled = %+v, want 2", enabled)
+	}
+	disabled, ok := snap.Metrics["mcp_servers_disabled"]
+	if !ok || disabled.Used == nil || *disabled.Used != 1 {
+		t.Fatalf("mcp_servers_disabled = %+v, want 1", disabled)
+	}
+	if !strings.Contains(snap.Raw["mcp_servers"], "gopls") {
+		t.Fatalf("mcp_servers raw missing gopls: %q", snap.Raw["mcp_servers"])
 	}
 }
 
@@ -458,6 +486,18 @@ func TestReadSessionUsageBreakdowns_ExtractsLanguageAndCodeStatsMetrics(t *testi
 							"new_string":  "one\ntwo\nthree",
 							"instruction": "append line",
 						},
+						"resultDisplay": map[string]any{
+							"diffStat": map[string]any{
+								"model_added_lines":   7,
+								"model_removed_lines": 3,
+								"model_added_chars":   210,
+								"model_removed_chars": 72,
+								"user_added_lines":    2,
+								"user_removed_lines":  1,
+								"user_added_chars":    48,
+								"user_removed_chars":  16,
+							},
+						},
 					},
 					{
 						"name":   "write_file",
@@ -465,6 +505,18 @@ func TestReadSessionUsageBreakdowns_ExtractsLanguageAndCodeStatsMetrics(t *testi
 						"args": map[string]any{
 							"file_path": "internal/providers/gemini_cli/widget.go",
 							"content":   "a\nb\n",
+						},
+						"resultDisplay": map[string]any{
+							"diffStat": map[string]any{
+								"model_added_lines":   10,
+								"model_removed_lines": 0,
+								"model_added_chars":   300,
+								"model_removed_chars": 0,
+								"user_added_lines":    0,
+								"user_removed_lines":  0,
+								"user_added_chars":    0,
+								"user_removed_chars":  0,
+							},
 						},
 					},
 					{
@@ -514,11 +566,20 @@ func TestReadSessionUsageBreakdowns_ExtractsLanguageAndCodeStatsMetrics(t *testi
 	if m, ok := snap.Metrics["lang_go"]; !ok || m.Used == nil || *m.Used != 3 {
 		t.Fatalf("lang_go = %v, want 3", m.Used)
 	}
-	if m, ok := snap.Metrics["composer_lines_added"]; !ok || m.Used == nil || *m.Used != 5 {
-		t.Fatalf("composer_lines_added = %v, want 5", m.Used)
+	if m, ok := snap.Metrics["composer_lines_added"]; !ok || m.Used == nil || *m.Used != 17 {
+		t.Fatalf("composer_lines_added = %v, want 17", m.Used)
 	}
-	if m, ok := snap.Metrics["composer_lines_removed"]; !ok || m.Used == nil || *m.Used != 2 {
-		t.Fatalf("composer_lines_removed = %v, want 2", m.Used)
+	if m, ok := snap.Metrics["composer_lines_removed"]; !ok || m.Used == nil || *m.Used != 3 {
+		t.Fatalf("composer_lines_removed = %v, want 3", m.Used)
+	}
+	if m, ok := snap.Metrics["composer_user_lines_added"]; !ok || m.Used == nil || *m.Used != 2 {
+		t.Fatalf("composer_user_lines_added = %v, want 2", m.Used)
+	}
+	if m, ok := snap.Metrics["composer_user_lines_removed"]; !ok || m.Used == nil || *m.Used != 1 {
+		t.Fatalf("composer_user_lines_removed = %v, want 1", m.Used)
+	}
+	if m, ok := snap.Metrics["composer_diffstat_events"]; !ok || m.Used == nil || *m.Used != 2 {
+		t.Fatalf("composer_diffstat_events = %v, want 2", m.Used)
 	}
 	if m, ok := snap.Metrics["composer_files_changed"]; !ok || m.Used == nil || *m.Used != 2 {
 		t.Fatalf("composer_files_changed = %v, want 2", m.Used)
@@ -544,8 +605,8 @@ func TestReadSessionUsageBreakdowns_ExtractsLanguageAndCodeStatsMetrics(t *testi
 	if m, ok := snap.Metrics["total_prompts"]; !ok || m.Used == nil || *m.Used != 1 {
 		t.Fatalf("total_prompts = %v, want 1", m.Used)
 	}
-	if m, ok := snap.Metrics["ai_code_percentage"]; !ok || m.Used == nil || *m.Used != 100 {
-		t.Fatalf("ai_code_percentage = %v, want 100", m.Used)
+	if m, ok := snap.Metrics["ai_code_percentage"]; !ok || m.Used == nil || *m.Used < 86 || *m.Used > 87 {
+		t.Fatalf("ai_code_percentage = %v, want ~86.96", m.Used)
 	}
 	if !strings.Contains(snap.Raw["language_usage"], "go: 3 req") {
 		t.Fatalf("language_usage = %q, want go usage summary", snap.Raw["language_usage"])

--- a/internal/providers/gemini_cli/telemetry.go
+++ b/internal/providers/gemini_cli/telemetry.go
@@ -1,10 +1,13 @@
 package gemini_cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -12,7 +15,7 @@ import (
 )
 
 const (
-	telemetrySchemaVersion = "gemini_cli_v1"
+	telemetrySchemaVersion = "gemini_cli_v2"
 )
 
 // System implements shared.TelemetrySource.
@@ -92,27 +95,58 @@ func parseGeminiTelemetrySessionFile(path string) ([]shared.TelemetryEvent, erro
 	var out []shared.TelemetryEvent
 
 	for msgIdx, msg := range chat.Messages {
-		occurredAt := parseMessageTime(msg.Timestamp, chat.StartTime, chat.LastUpdated)
+		messageOccurredAt := parseMessageTime(msg.Timestamp, chat.StartTime, chat.LastUpdated)
+		messageID := geminiTelemetryMessageID(sessionID, msg, msgIdx)
+		turnID := fmt.Sprintf("%s:msg%d", sessionID, msgIdx)
+		if messageID != "" {
+			turnID = messageID
+		}
 
 		// Emit tool usage events for each tool call.
 		for tcIdx, tc := range msg.ToolCalls {
-			toolName := strings.TrimSpace(tc.Name)
-			if toolName == "" {
+			toolName, payloadToolMeta := normalizeGeminiTelemetryToolName(tc)
+			if strings.TrimSpace(toolName) == "" {
 				continue
 			}
 
 			status := telemetryStatusFromToolCall(tc.Status)
-			toolCallID := fmt.Sprintf("%s:msg%d:tc%d", sessionID, msgIdx, tcIdx)
+			toolCallID := strings.TrimSpace(tc.ID)
+			if toolCallID == "" {
+				toolCallID = fmt.Sprintf("%s:msg%d:tc%d", sessionID, msgIdx, tcIdx)
+			}
+			occurredAt := parseToolCallTime(tc.Timestamp, msg.Timestamp, chat.StartTime, chat.LastUpdated)
 
 			payload := map[string]any{
-				"file":              path,
+				"source_file":       path,
 				"upstream_provider": "google",
+				"client":            "CLI",
+				"tool_type":         "native",
+			}
+			for key, value := range payloadToolMeta {
+				payload[key] = value
 			}
 			if tc.Args != nil {
 				for _, fp := range extractGeminiToolPaths(tc.Args) {
 					payload["file"] = fp
 					break
 				}
+			}
+			if _, ok := payload["file"]; !ok {
+				if resultFile := extractGeminiResultDisplayFile(tc.ResultDisplay); resultFile != "" {
+					payload["file"] = resultFile
+				}
+			}
+			if diff, ok := extractGeminiToolDiffStat(tc.ResultDisplay); ok {
+				payload["model_added_lines"] = diff.ModelAddedLines
+				payload["model_removed_lines"] = diff.ModelRemovedLines
+				payload["user_added_lines"] = diff.UserAddedLines
+				payload["user_removed_lines"] = diff.UserRemovedLines
+				payload["model_added_chars"] = diff.ModelAddedChars
+				payload["model_removed_chars"] = diff.ModelRemovedChars
+				payload["user_added_chars"] = diff.UserAddedChars
+				payload["user_removed_chars"] = diff.UserRemovedChars
+				payload["lines_added"] = diff.ModelAddedLines + diff.UserAddedLines
+				payload["lines_removed"] = diff.ModelRemovedLines + diff.UserRemovedLines
 			}
 
 			out = append(out, shared.TelemetryEvent{
@@ -121,7 +155,8 @@ func parseGeminiTelemetrySessionFile(path string) ([]shared.TelemetryEvent, erro
 				OccurredAt:    occurredAt,
 				AccountID:     "gemini_cli",
 				SessionID:     sessionID,
-				TurnID:        fmt.Sprintf("%s:msg%d", sessionID, msgIdx),
+				TurnID:        turnID,
+				MessageID:     messageID,
 				ToolCallID:    toolCallID,
 				ProviderID:    "gemini_cli",
 				AgentName:     "gemini_cli",
@@ -155,16 +190,18 @@ func parseGeminiTelemetrySessionFile(path string) ([]shared.TelemetryEvent, erro
 		}
 
 		turnIndex++
-		turnID := fmt.Sprintf("%s:%d", sessionID, turnIndex)
-		messageID := fmt.Sprintf("%s:msg%d", sessionID, msgIdx)
+		tokenTurnID := fmt.Sprintf("%s:%d", sessionID, turnIndex)
+		if strings.TrimSpace(messageID) != "" {
+			tokenTurnID = messageID
+		}
 
 		out = append(out, shared.TelemetryEvent{
 			SchemaVersion:   telemetrySchemaVersion,
 			Channel:         shared.TelemetryChannelJSONL,
-			OccurredAt:      occurredAt,
+			OccurredAt:      messageOccurredAt,
 			AccountID:       "gemini_cli",
 			SessionID:       sessionID,
-			TurnID:          turnID,
+			TurnID:          tokenTurnID,
 			MessageID:       messageID,
 			ProviderID:      "gemini_cli",
 			AgentName:       "gemini_cli",
@@ -177,8 +214,9 @@ func parseGeminiTelemetrySessionFile(path string) ([]shared.TelemetryEvent, erro
 			TotalTokens:     shared.Int64Ptr(int64(delta.TotalTokens)),
 			Status:          shared.TelemetryStatusOK,
 			Payload: map[string]any{
-				"file":              path,
+				"source_file":       path,
 				"tool_tokens":       delta.ToolTokens,
+				"client":            "CLI",
 				"upstream_provider": "google",
 			},
 		})
@@ -200,6 +238,153 @@ func parseMessageTime(msgTimestamp, sessionStart, sessionLastUpdated string) tim
 		return ts
 	}
 	return time.Now().UTC()
+}
+
+func parseToolCallTime(toolTimestamp, msgTimestamp, sessionStart, sessionLastUpdated string) time.Time {
+	if ts, err := shared.ParseTimestampString(toolTimestamp); err == nil {
+		return ts
+	}
+	if ts, err := shared.ParseTimestampString(msgTimestamp); err == nil {
+		return ts
+	}
+	if ts, err := shared.ParseTimestampString(sessionLastUpdated); err == nil {
+		return ts
+	}
+	if ts, err := shared.ParseTimestampString(sessionStart); err == nil {
+		return ts
+	}
+	return time.Now().UTC()
+}
+
+func geminiTelemetryMessageID(sessionID string, msg geminiChatMessage, msgIdx int) string {
+	msgID := strings.TrimSpace(msg.ID)
+	if msgID == "" {
+		return fmt.Sprintf("%s:msg%d", sessionID, msgIdx)
+	}
+	if strings.Contains(msgID, ":") {
+		return msgID
+	}
+	return fmt.Sprintf("%s:%s", sessionID, msgID)
+}
+
+func normalizeGeminiTelemetryToolName(tc geminiToolCall) (string, map[string]any) {
+	toolName := strings.TrimSpace(tc.Name)
+	displayName := strings.TrimSpace(tc.DisplayName)
+	description := strings.TrimSpace(tc.Description)
+
+	payload := make(map[string]any)
+	if toolName == "" && displayName == "" {
+		return "", payload
+	}
+	if displayName != "" {
+		payload["tool_display_name"] = displayName
+	}
+	if description != "" {
+		payload["tool_description"] = truncate(description, 240)
+	}
+	if tc.RenderOutputAsMarkdown != nil {
+		payload["render_output_markdown"] = *tc.RenderOutputAsMarkdown
+	}
+	if strings.TrimSpace(toolName) != "" {
+		payload["tool_name_raw"] = strings.TrimSpace(toolName)
+	}
+
+	if strings.HasPrefix(strings.ToLower(toolName), "mcp__") {
+		canonical := strings.ToLower(strings.TrimSpace(toolName))
+		payload["tool_type"] = "mcp"
+		if parts := strings.SplitN(strings.TrimPrefix(canonical, "mcp__"), "__", 2); len(parts) == 2 {
+			payload["mcp_server"] = parts[0]
+			payload["mcp_function"] = parts[1]
+		}
+		return canonical, payload
+	}
+
+	if mcpServer, mcpFunction, ok := extractGeminiMCPTool(displayName, toolName); ok {
+		payload["tool_type"] = "mcp"
+		payload["mcp_server"] = mcpServer
+		payload["mcp_function"] = mcpFunction
+		return "mcp__" + mcpServer + "__" + mcpFunction, payload
+	}
+
+	return sanitizeMetricName(toolName), payload
+}
+
+var geminiMCPDisplayPattern = regexp.MustCompile(`(?i)\(([^()]+?)\s+mcp server\)\s*$`)
+
+func extractGeminiMCPTool(displayName, fallbackToolName string) (server, function string, ok bool) {
+	displayName = strings.TrimSpace(displayName)
+	if displayName == "" {
+		return "", "", false
+	}
+	matches := geminiMCPDisplayPattern.FindStringSubmatch(displayName)
+	if len(matches) != 2 {
+		return "", "", false
+	}
+
+	server = normalizeGeminiMCPToken(matches[1])
+	function = normalizeGeminiMCPToken(fallbackToolName)
+	if function == "" {
+		withoutSuffix := strings.TrimSpace(geminiMCPDisplayPattern.ReplaceAllString(displayName, ""))
+		function = normalizeGeminiMCPToken(withoutSuffix)
+	}
+	if server == "" || function == "" {
+		return "", "", false
+	}
+	return server, function, true
+}
+
+func normalizeGeminiMCPToken(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if raw == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	underscore := false
+	for _, r := range raw {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			underscore = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			underscore = false
+		case r == '-' || r == '_':
+			if !underscore {
+				b.WriteRune(r)
+				underscore = true
+			}
+		default:
+			if !underscore {
+				b.WriteByte('_')
+				underscore = true
+			}
+		}
+	}
+
+	return strings.Trim(b.String(), "_-")
+}
+
+func extractGeminiResultDisplayFile(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) || raw[0] != '{' {
+		return ""
+	}
+
+	var root map[string]any
+	if json.Unmarshal(raw, &root) != nil {
+		return ""
+	}
+	for _, key := range []string{"filePath", "file_path", "path", "file"} {
+		if value, ok := root[key].(string); ok {
+			for _, token := range extractGeminiPathTokens(value) {
+				if token != "" {
+					return token
+				}
+			}
+		}
+	}
+	return ""
 }
 
 // telemetryStatusFromToolCall maps a Gemini CLI tool call status string to a

--- a/internal/providers/gemini_cli/telemetry_test.go
+++ b/internal/providers/gemini_cli/telemetry_test.go
@@ -1,0 +1,151 @@
+package gemini_cli
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/providers/shared"
+)
+
+func TestParseGeminiTelemetrySessionFile_NormalizesMCPToolsAndDiffStats(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionPath := filepath.Join(tmpDir, "session-telemetry.json")
+
+	writeJSON(t, sessionPath, map[string]any{
+		"sessionId":   "sess-1",
+		"startTime":   "2026-02-17T09:43:00Z",
+		"lastUpdated": "2026-02-17T09:44:00Z",
+		"messages": []map[string]any{
+			{
+				"id":        "msg-1",
+				"type":      "gemini",
+				"timestamp": "2026-02-17T09:43:20Z",
+				"model":     "gemini-2.5-pro-preview",
+				"tokens": map[string]any{
+					"input":    90,
+					"output":   20,
+					"cached":   0,
+					"thoughts": 5,
+					"tool":     5,
+					"total":    120,
+				},
+				"toolCalls": []map[string]any{
+					{
+						"id":                     "run_gcloud_command-1771321394695-e36bfb60d36d08",
+						"name":                   "run_gcloud_command",
+						"displayName":            "run_gcloud_command (gcp-gcloud MCP Server)",
+						"description":            "Execute gcloud command via MCP",
+						"status":                 "success",
+						"timestamp":              "2026-02-17T09:43:24.124Z",
+						"renderOutputAsMarkdown": true,
+						"args": map[string]any{
+							"command":   "gcloud compute instances list",
+							"file_path": "infra/main.tf",
+						},
+						"resultDisplay": map[string]any{
+							"filePath": "infra/main.tf",
+							"diffStat": map[string]any{
+								"model_added_lines":   4,
+								"model_removed_lines": 1,
+								"model_added_chars":   120,
+								"model_removed_chars": 30,
+								"user_added_lines":    2,
+								"user_removed_lines":  0,
+								"user_added_chars":    40,
+								"user_removed_chars":  0,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	events, err := parseGeminiTelemetrySessionFile(sessionPath)
+	if err != nil {
+		t.Fatalf("parseGeminiTelemetrySessionFile() error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("event count = %d, want 2", len(events))
+	}
+
+	var toolEvent *shared.TelemetryEvent
+	var usageEvent *shared.TelemetryEvent
+	for i := range events {
+		ev := &events[i]
+		switch ev.EventType {
+		case shared.TelemetryEventTypeToolUsage:
+			toolEvent = ev
+		case shared.TelemetryEventTypeMessageUsage:
+			usageEvent = ev
+		}
+	}
+	if toolEvent == nil {
+		t.Fatal("missing tool usage event")
+	}
+	if usageEvent == nil {
+		t.Fatal("missing message usage event")
+	}
+
+	if toolEvent.ToolName != "mcp__gcp-gcloud__run_gcloud_command" {
+		t.Fatalf("tool_name = %q, want canonical MCP name", toolEvent.ToolName)
+	}
+	if toolEvent.ToolCallID != "run_gcloud_command-1771321394695-e36bfb60d36d08" {
+		t.Fatalf("tool_call_id = %q, want upstream id", toolEvent.ToolCallID)
+	}
+	if toolEvent.MessageID != "sess-1:msg-1" {
+		t.Fatalf("message_id = %q, want sess-1:msg-1", toolEvent.MessageID)
+	}
+	if toolEvent.Status != shared.TelemetryStatusOK {
+		t.Fatalf("status = %q, want ok", toolEvent.Status)
+	}
+
+	wantToolTime, err := shared.ParseTimestampString("2026-02-17T09:43:24.124Z")
+	if err != nil {
+		t.Fatalf("parse want timestamp: %v", err)
+	}
+	if !toolEvent.OccurredAt.Equal(wantToolTime) {
+		t.Fatalf("tool occurred_at = %s, want %s", toolEvent.OccurredAt.Format(time.RFC3339Nano), wantToolTime.Format(time.RFC3339Nano))
+	}
+
+	if got, _ := toolEvent.Payload["tool_type"].(string); got != "mcp" {
+		t.Fatalf("payload.tool_type = %q, want mcp", got)
+	}
+	if got, _ := toolEvent.Payload["mcp_server"].(string); got != "gcp-gcloud" {
+		t.Fatalf("payload.mcp_server = %q, want gcp-gcloud", got)
+	}
+	if got, _ := toolEvent.Payload["mcp_function"].(string); got != "run_gcloud_command" {
+		t.Fatalf("payload.mcp_function = %q, want run_gcloud_command", got)
+	}
+	if got, _ := toolEvent.Payload["file"].(string); got != "infra/main.tf" {
+		t.Fatalf("payload.file = %q, want infra/main.tf", got)
+	}
+	if got, ok := toolEvent.Payload["lines_added"].(int); !ok || got != 6 {
+		t.Fatalf("payload.lines_added = %#v, want 6", toolEvent.Payload["lines_added"])
+	}
+	if got, ok := toolEvent.Payload["lines_removed"].(int); !ok || got != 1 {
+		t.Fatalf("payload.lines_removed = %#v, want 1", toolEvent.Payload["lines_removed"])
+	}
+
+	if usageEvent.TotalTokens == nil || *usageEvent.TotalTokens != 120 {
+		t.Fatalf("total_tokens = %+v, want 120", usageEvent.TotalTokens)
+	}
+	if got, _ := usageEvent.Payload["client"].(string); got != "CLI" {
+		t.Fatalf("payload.client = %q, want CLI", got)
+	}
+}
+
+func TestExtractGeminiMCPTool(t *testing.T) {
+	server, function, ok := extractGeminiMCPTool("go_workspace (gopls MCP Server)", "go_workspace")
+	if !ok {
+		t.Fatal("expected MCP extraction to succeed")
+	}
+	if server != "gopls" || function != "go_workspace" {
+		t.Fatalf("server/function = %q/%q, want gopls/go_workspace", server, function)
+	}
+
+	if _, _, ok := extractGeminiMCPTool("ReadFile", "read_file"); ok {
+		t.Fatal("expected non-MCP display name to return ok=false")
+	}
+}

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -1,6 +1,10 @@
 package providers
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
 
 func TestAllProviders_ContainsOpenCode(t *testing.T) {
 	all := AllProviders()
@@ -40,5 +44,41 @@ func TestTelemetrySourceBySystem_CaseInsensitive(t *testing.T) {
 	}
 	if source.System() != "codex" {
 		t.Fatalf("source.system = %q, want codex", source.System())
+	}
+}
+
+func TestAllProviders_HaveUniqueAndConsistentIDs(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, p := range AllProviders() {
+		id := p.ID()
+		if id == "" {
+			t.Fatalf("provider %T has empty ID", p)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate provider ID %q", id)
+		}
+		seen[id] = true
+
+		spec := p.Spec()
+		if spec.ID != "" && spec.ID != id {
+			t.Fatalf("provider %q spec.ID = %q, want %q", id, spec.ID, id)
+		}
+	}
+}
+
+func TestAllProviders_DashboardSectionsAreKnownAndUnique(t *testing.T) {
+	for _, p := range AllProviders() {
+		id := p.ID()
+		sections := p.DashboardWidget().EffectiveStandardSectionOrder()
+		seen := make(map[core.DashboardStandardSection]bool, len(sections))
+		for _, section := range sections {
+			if !core.IsKnownDashboardStandardSection(section) {
+				t.Fatalf("provider %q has unknown dashboard section %q", id, section)
+			}
+			if seen[section] {
+				t.Fatalf("provider %q has duplicate dashboard section %q", id, section)
+			}
+			seen[section] = true
+		}
 	}
 }

--- a/internal/telemetry/read_model.go
+++ b/internal/telemetry/read_model.go
@@ -53,6 +53,12 @@ func ApplyCanonicalTelemetryViewWithOptions(
 	snaps map[string]core.UsageSnapshot,
 	options ReadModelOptions,
 ) (map[string]core.UsageSnapshot, error) {
+	totalStart := time.Now()
+	defer func() {
+		core.Tracef("[read_model_perf] TOTAL ApplyCanonicalTelemetryView: %dms (window=%s, windowHours=%d, accounts=%d)",
+			time.Since(totalStart).Milliseconds(), options.TimeWindow, options.TimeWindowHours, len(snaps))
+	}()
+
 	dbPath = strings.TrimSpace(dbPath)
 	if dbPath == "" {
 		var err error
@@ -65,6 +71,12 @@ func ApplyCanonicalTelemetryViewWithOptions(
 		return snaps, nil
 	}
 
+	trace := func(label string) func() {
+		start := time.Now()
+		return func() { core.Tracef("[read_model_perf] %s: %dms", label, time.Since(start).Milliseconds()) }
+	}
+
+	done := trace("db open+configure")
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
 		return snaps, fmt.Errorf("open telemetry read model db: %w", err)
@@ -73,53 +85,28 @@ func ApplyCanonicalTelemetryViewWithOptions(
 	if err := configureSQLiteConnection(db); err != nil {
 		return snaps, fmt.Errorf("configure telemetry read model db: %w", err)
 	}
-	if err := repairLegacyProviderIDs(ctx, db); err != nil {
-		return snaps, fmt.Errorf("repair telemetry provider ids: %w", err)
-	}
+	done()
 
+	done = trace("hydrateRootsFromLimitSnapshots")
 	merged, err := hydrateRootsFromLimitSnapshots(ctx, db, snaps)
 	if err != nil {
 		return snaps, err
 	}
+	done()
+
 	links := normalizeProviderLinks(options.ProviderLinks)
+
+	done = trace("annotateUnmappedTelemetryProviders")
 	merged, err = annotateUnmappedTelemetryProviders(ctx, db, merged, links)
 	if err != nil {
 		return snaps, err
 	}
-	return applyCanonicalUsageViewWithDB(ctx, db, merged, links, options.TimeWindowHours, options.TimeWindow)
-}
+	done()
 
-func repairLegacyProviderIDs(ctx context.Context, db *sql.DB) error {
-	if db == nil {
-		return nil
-	}
-	_, err := db.ExecContext(ctx, `
-		UPDATE usage_events
-		SET provider_id = 'codex'
-		WHERE LOWER(TRIM(provider_id)) = 'openai'
-		  AND LOWER(TRIM(agent_name)) = 'codex'
-		  AND raw_event_id IN (
-			SELECT raw_event_id
-			FROM usage_raw_events
-			WHERE LOWER(TRIM(source_system)) = 'codex'
-		  )
-	`)
-	if err != nil {
-		return err
-	}
-	_, err = db.ExecContext(ctx, `
-		UPDATE usage_events
-		SET account_id = 'codex-cli'
-		WHERE LOWER(TRIM(provider_id)) = 'codex'
-		  AND LOWER(TRIM(account_id)) = 'codex'
-		  AND LOWER(TRIM(agent_name)) = 'codex'
-		  AND raw_event_id IN (
-			SELECT raw_event_id
-			FROM usage_raw_events
-			WHERE LOWER(TRIM(source_system)) = 'codex'
-		  )
-	`)
-	return err
+	done = trace("applyCanonicalUsageViewWithDB")
+	result, err := applyCanonicalUsageViewWithDB(ctx, db, merged, links, options.TimeWindowHours, options.TimeWindow)
+	done()
+	return result, err
 }
 
 func hydrateRootsFromLimitSnapshots(ctx context.Context, db *sql.DB, snaps map[string]core.UsageSnapshot) (map[string]core.UsageSnapshot, error) {

--- a/internal/telemetry/read_model.go
+++ b/internal/telemetry/read_model.go
@@ -73,6 +73,9 @@ func ApplyCanonicalTelemetryViewWithOptions(
 	if err := configureSQLiteConnection(db); err != nil {
 		return snaps, fmt.Errorf("configure telemetry read model db: %w", err)
 	}
+	if err := repairLegacyProviderIDs(ctx, db); err != nil {
+		return snaps, fmt.Errorf("repair telemetry provider ids: %w", err)
+	}
 
 	merged, err := hydrateRootsFromLimitSnapshots(ctx, db, snaps)
 	if err != nil {
@@ -84,6 +87,39 @@ func ApplyCanonicalTelemetryViewWithOptions(
 		return snaps, err
 	}
 	return applyCanonicalUsageViewWithDB(ctx, db, merged, links, options.TimeWindowHours, options.TimeWindow)
+}
+
+func repairLegacyProviderIDs(ctx context.Context, db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+	_, err := db.ExecContext(ctx, `
+		UPDATE usage_events
+		SET provider_id = 'codex'
+		WHERE LOWER(TRIM(provider_id)) = 'openai'
+		  AND LOWER(TRIM(agent_name)) = 'codex'
+		  AND raw_event_id IN (
+			SELECT raw_event_id
+			FROM usage_raw_events
+			WHERE LOWER(TRIM(source_system)) = 'codex'
+		  )
+	`)
+	if err != nil {
+		return err
+	}
+	_, err = db.ExecContext(ctx, `
+		UPDATE usage_events
+		SET account_id = 'codex-cli'
+		WHERE LOWER(TRIM(provider_id)) = 'codex'
+		  AND LOWER(TRIM(account_id)) = 'codex'
+		  AND LOWER(TRIM(agent_name)) = 'codex'
+		  AND raw_event_id IN (
+			SELECT raw_event_id
+			FROM usage_raw_events
+			WHERE LOWER(TRIM(source_system)) = 'codex'
+		  )
+	`)
+	return err
 }
 
 func hydrateRootsFromLimitSnapshots(ctx context.Context, db *sql.DB, snaps map[string]core.UsageSnapshot) (map[string]core.UsageSnapshot, error) {

--- a/internal/telemetry/read_model_test.go
+++ b/internal/telemetry/read_model_test.go
@@ -307,3 +307,69 @@ func TestApplyCanonicalTelemetryView_UsesProviderLinksForCanonicalUsage(t *testi
 		t.Fatalf("unexpected telemetry_unmapped_providers = %q", gotDiag)
 	}
 }
+
+func TestApplyCanonicalTelemetryView_RepairsLegacyCodexProviderID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telemetry.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	input := int64(21)
+	total := int64(21)
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    time.Now().UTC(),
+		ProviderID:    "openai", // legacy misattribution from codex parser
+		AccountID:     "codex-cli",
+		AgentName:     "codex",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-codex-fix-1",
+		MessageID:     "msg-codex-fix-1",
+		ModelRaw:      "gpt-5-codex",
+		InputTokens:   &input,
+		TotalTokens:   &total,
+		Requests:      int64Ptr(1),
+	}); err != nil {
+		t.Fatalf("ingest legacy codex usage: %v", err)
+	}
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    time.Now().UTC(),
+		ProviderID:    "codex",
+		AccountID:     "codex", // legacy account id before codex-cli normalization
+		AgentName:     "codex",
+		EventType:     EventTypeToolUsage,
+		SessionID:     "sess-codex-fix-1",
+		ToolCallID:    "tool-codex-fix-1",
+		ToolName:      "mcp__gopls__go_workspace",
+		Requests:      int64Ptr(1),
+		Status:        EventStatusOK,
+	}); err != nil {
+		t.Fatalf("ingest legacy codex tool usage: %v", err)
+	}
+
+	base := map[string]core.UsageSnapshot{
+		"codex-cli": {
+			ProviderID: "codex",
+			AccountID:  "codex-cli",
+			Status:     core.StatusOK,
+			Metrics:    map[string]core.Metric{},
+		},
+	}
+	got, err := applyCanonicalTelemetryViewForTest(context.Background(), dbPath, base)
+	if err != nil {
+		t.Fatalf("apply canonical telemetry view: %v", err)
+	}
+
+	snap := got["codex-cli"]
+	if modelMetric, ok := snap.Metrics["model_gpt_5_codex_input_tokens"]; !ok || modelMetric.Used == nil || *modelMetric.Used != 21 {
+		t.Fatalf("missing codex usage metric after provider repair: %+v", modelMetric)
+	}
+	if toolMetric, ok := snap.Metrics["tool_mcp_gopls_go_workspace"]; !ok || toolMetric.Used == nil || *toolMetric.Used != 1 {
+		t.Fatalf("missing codex tool metric after account repair: %+v", toolMetric)
+	}
+}

--- a/internal/telemetry/read_model_test.go
+++ b/internal/telemetry/read_model_test.go
@@ -352,6 +352,11 @@ func TestApplyCanonicalTelemetryView_RepairsLegacyCodexProviderID(t *testing.T) 
 		t.Fatalf("ingest legacy codex tool usage: %v", err)
 	}
 
+	// RunMigrations applies the one-shot repairs that were previously inline in the read path.
+	if err := store.RunMigrations(context.Background()); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
 	base := map[string]core.UsageSnapshot{
 		"codex-cli": {
 			ProviderID: "codex",

--- a/internal/telemetry/store.go
+++ b/internal/telemetry/store.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,6 +106,7 @@ func (s *Store) Init(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_usage_events_provider_window ON usage_events(provider_id, account_id, occurred_at);`,
 		`CREATE INDEX IF NOT EXISTS idx_usage_events_provider_account_type_occurred ON usage_events(provider_id, account_id, event_type, occurred_at DESC);`,
 		`CREATE INDEX IF NOT EXISTS idx_usage_events_type_provider ON usage_events(event_type, provider_id);`,
+		`CREATE INDEX IF NOT EXISTS idx_usage_raw_events_source_system ON usage_raw_events(source_system);`,
 		`CREATE TABLE IF NOT EXISTS usage_reconciliation_windows (
 			recon_id TEXT PRIMARY KEY,
 			provider_id TEXT NOT NULL,
@@ -130,6 +132,69 @@ func (s *Store) Init(ctx context.Context) error {
 		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("telemetry: init schema: %w", err)
 		}
+	}
+	return nil
+}
+
+// RunMigrations runs one-shot data repair migrations. Called at daemon startup.
+func (s *Store) RunMigrations(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS _migrations (name TEXT PRIMARY KEY, applied_at TEXT NOT NULL)`); err != nil {
+		return fmt.Errorf("create migrations table: %w", err)
+	}
+
+	repairs := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "repair_codex_provider_id",
+			sql: `UPDATE usage_events
+				SET provider_id = 'codex'
+				WHERE LOWER(TRIM(provider_id)) = 'openai'
+				  AND LOWER(TRIM(agent_name)) = 'codex'
+				  AND raw_event_id IN (
+					SELECT raw_event_id FROM usage_raw_events WHERE LOWER(TRIM(source_system)) = 'codex'
+				  )`,
+		},
+		{
+			name: "repair_codex_account_id",
+			sql: `UPDATE usage_events
+				SET account_id = 'codex-cli'
+				WHERE LOWER(TRIM(provider_id)) = 'codex'
+				  AND LOWER(TRIM(account_id)) = 'codex'
+				  AND LOWER(TRIM(agent_name)) = 'codex'
+				  AND raw_event_id IN (
+					SELECT raw_event_id FROM usage_raw_events WHERE LOWER(TRIM(source_system)) = 'codex'
+				  )`,
+		},
+		{
+			name: "repair_cursor_provider_id",
+			sql: `UPDATE usage_events
+				SET provider_id = 'cursor'
+				WHERE LOWER(TRIM(provider_id)) != 'cursor'
+				  AND raw_event_id IN (
+					SELECT raw_event_id FROM usage_raw_events WHERE LOWER(TRIM(source_system)) = 'cursor'
+				  )`,
+		},
+	}
+
+	for _, r := range repairs {
+		var exists int
+		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM _migrations WHERE name = ?`, r.name).Scan(&exists); err != nil {
+			return fmt.Errorf("check migration %s: %w", r.name, err)
+		}
+		if exists > 0 {
+			continue
+		}
+		log.Printf("[migrations] running: %s", r.name)
+		start := time.Now()
+		if _, err := s.db.ExecContext(ctx, r.sql); err != nil {
+			return fmt.Errorf("run migration %s: %w", r.name, err)
+		}
+		if _, err := s.db.ExecContext(ctx, `INSERT INTO _migrations (name, applied_at) VALUES (?, datetime('now'))`, r.name); err != nil {
+			return fmt.Errorf("record migration %s: %w", r.name, err)
+		}
+		log.Printf("[migrations] completed: %s (%dms)", r.name, time.Since(start).Milliseconds())
 	}
 	return nil
 }

--- a/internal/telemetry/store.go
+++ b/internal/telemetry/store.go
@@ -394,7 +394,7 @@ func enrichEventByDedupKey(ctx context.Context, tx *sql.Tx, dedupKey string, nor
 	modelRaw := chooseString(current.ModelRaw, norm.ModelRaw, override)
 	modelCanonical := chooseString(current.ModelCanonical, norm.ModelCanonical, override)
 	modelLineage := chooseString(current.ModelLineageID, norm.ModelLineageID, override)
-	toolName := chooseString(current.ToolName, norm.ToolName, override)
+	toolName := chooseToolName(current.ToolName, norm.ToolName, override)
 
 	inputTokens := chooseInt64(current.InputTokens, norm.InputTokens, override)
 	outputTokens := chooseInt64(current.OutputTokens, norm.OutputTokens, override)
@@ -480,6 +480,43 @@ func chooseString(current sql.NullString, incoming string, override bool) string
 		return trimmedIncoming
 	}
 	return strings.TrimSpace(current.String)
+}
+
+func chooseToolName(current sql.NullString, incoming string, override bool) string {
+	currentName := strings.ToLower(strings.TrimSpace(current.String))
+	incomingName := strings.ToLower(strings.TrimSpace(incoming))
+
+	if !current.Valid || currentName == "" {
+		return incomingName
+	}
+	if override && incomingName != "" {
+		return incomingName
+	}
+	if incomingName == "" {
+		return currentName
+	}
+	if currentName == "unknown" && incomingName != "unknown" {
+		return incomingName
+	}
+	// When parsers improve MCP normalization over time, prefer canonical
+	// mcp__server__function labels so existing deduped rows self-heal.
+	if isCanonicalMCPToolName(incomingName) && !isCanonicalMCPToolName(currentName) {
+		return incomingName
+	}
+	return currentName
+}
+
+func isCanonicalMCPToolName(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if !strings.HasPrefix(normalized, "mcp__") {
+		return false
+	}
+	rest := strings.TrimPrefix(normalized, "mcp__")
+	parts := strings.SplitN(rest, "__", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	return strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != ""
 }
 
 func chooseInt64(current sql.NullInt64, incoming *int64, override bool) *int64 {
@@ -599,6 +636,36 @@ func (s *Store) PruneOrphanRawEvents(ctx context.Context, limit int) (int64, err
 	n, err := res.RowsAffected()
 	if err != nil {
 		return 0, fmt.Errorf("telemetry: prune orphan raw events rows affected: %w", err)
+	}
+	return n, nil
+}
+
+// PruneRawEventPayloads clears source_payload from old raw events to reclaim
+// disk space. All useful data has already been extracted into usage_events.
+// Keeps payloads for events newer than retentionHours.
+func (s *Store) PruneRawEventPayloads(ctx context.Context, retentionHours int, limit int) (int64, error) {
+	if s == nil || s.db == nil || retentionHours < 0 || limit <= 0 {
+		return 0, nil
+	}
+	cutoff := fmt.Sprintf("-%d hours", retentionHours)
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE usage_raw_events
+		SET source_payload = '{}'
+		WHERE raw_event_id IN (
+			SELECT raw_event_id
+			FROM usage_raw_events
+			WHERE ingested_at < datetime('now', ?)
+			  AND LENGTH(source_payload) > 2
+			ORDER BY ingested_at ASC
+			LIMIT ?
+		)
+	`, cutoff, limit)
+	if err != nil {
+		return 0, fmt.Errorf("telemetry: prune raw event payloads: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("telemetry: prune raw event payloads rows affected: %w", err)
 	}
 	return n, nil
 }

--- a/internal/telemetry/store_test.go
+++ b/internal/telemetry/store_test.go
@@ -338,6 +338,57 @@ func TestStoreIngest_DedupStableIDIgnoresAccountProviderAgentDrift(t *testing.T)
 	}
 }
 
+func TestStoreIngest_DedupCanonicalMCPToolNameWins(t *testing.T) {
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "telemetry.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	if err := store.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	firstReq := IngestRequest{
+		SourceSystem:  SourceSystem("copilot"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    time.Date(2026, time.March, 5, 11, 0, 0, 0, time.UTC),
+		ProviderID:    "copilot",
+		AccountID:     "copilot",
+		SessionID:     "sess-copilot-1",
+		ToolCallID:    "tool-call-1",
+		EventType:     EventTypeToolUsage,
+		ToolName:      "github_mcp_server_list_issues",
+		Requests:      int64Ptr(1),
+	}
+	if _, err := store.Ingest(context.Background(), firstReq); err != nil {
+		t.Fatalf("first ingest: %v", err)
+	}
+
+	secondReq := firstReq
+	secondReq.OccurredAt = secondReq.OccurredAt.Add(1 * time.Second)
+	secondReq.ToolName = "mcp__github__list_issues"
+	second, err := store.Ingest(context.Background(), secondReq)
+	if err != nil {
+		t.Fatalf("second ingest: %v", err)
+	}
+	if !second.Deduped {
+		t.Fatalf("second ingest should be deduped")
+	}
+
+	var toolName sql.NullString
+	if err := db.QueryRow(
+		`SELECT tool_name FROM usage_events WHERE dedup_key = ?`,
+		BuildDedupKey(firstReq),
+	).Scan(&toolName); err != nil {
+		t.Fatalf("query canonical tool_name: %v", err)
+	}
+	if !toolName.Valid || toolName.String != "mcp__github__list_issues" {
+		t.Fatalf("tool_name = %#v, want mcp__github__list_issues", toolName)
+	}
+}
+
 func TestStorePruneOldEvents_DeletesExpiredEventsOnly(t *testing.T) {
 	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "telemetry.db"))
 	if err != nil {

--- a/internal/telemetry/usage_view.go
+++ b/internal/telemetry/usage_view.go
@@ -255,6 +255,7 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 			strings.HasPrefix(key, "model_") ||
 			strings.HasPrefix(key, "provider_") ||
 			strings.HasPrefix(key, "lang_") ||
+			strings.HasPrefix(key, "interface_") ||
 			isStaleActivityMetric(key) {
 			delete(snap.Metrics, key)
 			deletedCount++
@@ -1524,6 +1525,26 @@ func parseMCPToolName(raw string) (server, function string, ok bool) {
 		return rest[:idx], rest[idx+2:], true
 	}
 
+	// Copilot legacy wrapper format: "<server>_mcp_server_<function>".
+	if strings.Contains(raw, "_mcp_server_") {
+		parts := strings.SplitN(raw, "_mcp_server_", 2)
+		server = sanitizeMCPToolSegment(parts[0])
+		function = sanitizeMCPToolSegment(parts[1])
+		if server != "" && function != "" {
+			return server, function, true
+		}
+	}
+
+	// Copilot legacy wrapper format variant: "<server>-mcp-server-<function>".
+	if strings.Contains(raw, "-mcp-server-") {
+		parts := strings.SplitN(raw, "-mcp-server-", 2)
+		server = sanitizeMCPToolSegment(parts[0])
+		function = sanitizeMCPToolSegment(parts[1])
+		if server != "" && function != "" {
+			return server, function, true
+		}
+	}
+
 	// Legacy format: "something (mcp)" from old Cursor data.
 	if strings.HasSuffix(raw, " (mcp)") {
 		body := strings.TrimSuffix(raw, " (mcp)")
@@ -1549,6 +1570,28 @@ func parseMCPToolName(raw string) (server, function string, ok bool) {
 	}
 
 	return "", "", false
+}
+
+func sanitizeMCPToolSegment(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if raw == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(raw))
+	lastUnderscore := false
+	for _, r := range raw {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteRune('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
 }
 
 // findServerFunctionSplit finds the best hyphen position to split "server-function"

--- a/internal/telemetry/usage_view.go
+++ b/internal/telemetry/usage_view.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/janekbaraniewski/openusage/internal/core"
@@ -124,7 +125,8 @@ type telemetryUsageAgg struct {
 type usageFilter struct {
 	ProviderIDs     []string
 	AccountID       string
-	TimeWindowHours int // 0 = no filter
+	TimeWindowHours int    // 0 = no filter
+	materializedTbl string // if set, queries read from this temp table instead of rebuilding the CTE
 }
 
 func clientDimensionExpr() string {
@@ -161,7 +163,10 @@ func applyCanonicalUsageViewWithDB(
 
 	out := make(map[string]core.UsageSnapshot, len(snaps))
 	cache := make(map[string]*telemetryUsageAgg)
+
+	activeStart := time.Now()
 	telemetryActiveProviders := queryTelemetryActiveProviders(ctx, db)
+	core.Tracef("[usage_view_perf] queryTelemetryActiveProviders: %dms", time.Since(activeStart).Milliseconds())
 
 	for accountID, snap := range snaps {
 		s := snap
@@ -605,6 +610,7 @@ func loadUsageViewForProviderWithSources(ctx context.Context, db *sql.DB, provid
 }
 
 func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter) (*telemetryUsageAgg, error) {
+	filterStart := time.Now()
 	agg := &telemetryUsageAgg{
 		ModelDaily:   make(map[string][]core.TimePoint),
 		SourceDaily:  make(map[string][]core.TimePoint),
@@ -612,65 +618,121 @@ func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter)
 		ClientTokens: make(map[string][]core.TimePoint),
 	}
 
+	// Materialize the deduped CTE into a temp table so subsequent queries
+	// read from a flat table instead of rebuilding the 3-level CTE each time.
 	usageCTE, whereArgs := dedupedUsageCTE(filter)
-	countQuery := usageCTE + `
+	tempTable := "_deduped_tmp"
+
+	matStart := time.Now()
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tempTable))
+	materializeSQL := fmt.Sprintf("CREATE TEMP TABLE %s AS %s SELECT * FROM deduped_usage", tempTable, usageCTE)
+	if _, err := db.ExecContext(ctx, materializeSQL, whereArgs...); err != nil {
+		return nil, fmt.Errorf("materialize deduped usage: %w", err)
+	}
+	core.Tracef("[usage_view_perf] materialize temp table: %dms (providers=%v, windowHours=%d)",
+		time.Since(matStart).Milliseconds(), filter.ProviderIDs, filter.TimeWindowHours)
+	defer func() {
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tempTable))
+	}()
+
+	// Create indexes on the temp table for the aggregation queries.
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_deduped_event_type ON %s(event_type)", tempTable))
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_deduped_occurred ON %s(occurred_at)", tempTable))
+
+	// Count from the materialized table.
+	countStart := time.Now()
+	countQuery := fmt.Sprintf(`
 		SELECT COALESCE(MAX(occurred_at), ''), COUNT(*)
-		FROM deduped_usage
-		WHERE 1=1
-		  AND event_type IN ('message_usage', 'tool_usage')
-	`
-	if err := db.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&agg.LastOccurred, &agg.EventCount); err != nil {
+		FROM %s
+		WHERE event_type IN ('message_usage', 'tool_usage')
+	`, tempTable)
+	if err := db.QueryRowContext(ctx, countQuery).Scan(&agg.LastOccurred, &agg.EventCount); err != nil {
 		return nil, fmt.Errorf("canonical usage count query: %w", err)
 	}
+	core.Tracef("[usage_view_perf] countQuery: %dms (events=%d, providers=%v, windowHours=%d)",
+		time.Since(countStart).Milliseconds(), agg.EventCount, filter.ProviderIDs, filter.TimeWindowHours)
 	if agg.EventCount == 0 {
 		return agg, nil
 	}
 
-	models, err := queryModelAgg(ctx, db, filter)
+	// All subsequent queries use the materialized temp table.
+	matFilter := filter
+	matFilter.materializedTbl = tempTable
+
+	trace := func(label string) func() {
+		start := time.Now()
+		return func() { core.Tracef("[usage_view_perf]   %s: %dms", label, time.Since(start).Milliseconds()) }
+	}
+
+	done := trace("queryModelAgg")
+	models, err := queryModelAgg(ctx, db, matFilter)
+	done()
 	if err != nil {
 		return nil, err
 	}
-	sources, err := querySourceAgg(ctx, db, filter)
+	done = trace("querySourceAgg")
+	sources, err := querySourceAgg(ctx, db, matFilter)
+	done()
 	if err != nil {
 		return nil, err
 	}
-	tools, err := queryToolAgg(ctx, db, filter)
+	done = trace("queryToolAgg")
+	tools, err := queryToolAgg(ctx, db, matFilter)
+	done()
 	if err != nil {
 		return nil, err
 	}
-	providers, err := queryProviderAgg(ctx, db, filter)
+	done = trace("queryProviderAgg")
+	providers, err := queryProviderAgg(ctx, db, matFilter)
+	done()
 	if err != nil {
 		return nil, err
 	}
-	languages, err := queryLanguageAgg(ctx, db, filter)
+	done = trace("queryLanguageAgg")
+	languages, err := queryLanguageAgg(ctx, db, matFilter)
+	done()
 	if err != nil {
 		return nil, err
 	}
-	activity, err := queryActivityAgg(ctx, db, filter)
+	done = trace("queryActivityAgg")
+	activity, err := queryActivityAgg(ctx, db, matFilter)
+	done()
 	if err != nil {
 		return nil, err
 	}
-	codeStats, err := queryCodeStatsAgg(ctx, db, filter)
+	done = trace("queryCodeStatsAgg")
+	codeStats, err := queryCodeStatsAgg(ctx, db, matFilter)
+	done()
 	if err != nil {
 		return nil, err
 	}
-	daily, err := queryDailyTotals(ctx, db, filter)
+	done = trace("queryDailyTotals")
+	daily, err := queryDailyTotals(ctx, db, matFilter)
+	done()
 	if err != nil {
 		return nil, err
 	}
-	modelDaily, err := queryDailyByDimension(ctx, db, filter, "model")
+	done = trace("queryDailyByDimension(model)")
+	modelDaily, err := queryDailyByDimension(ctx, db, matFilter, "model")
+	done()
 	if err != nil {
 		return nil, err
 	}
-	sourceDaily, err := queryDailyByDimension(ctx, db, filter, "source")
+	done = trace("queryDailyByDimension(source)")
+	sourceDaily, err := queryDailyByDimension(ctx, db, matFilter, "source")
+	done()
 	if err != nil {
 		return nil, err
 	}
-	clientDaily, err := queryDailyByDimension(ctx, db, filter, "client")
+	done = trace("queryDailyByDimension(client)")
+	clientDaily, err := queryDailyByDimension(ctx, db, matFilter, "client")
+	done()
 	if err != nil {
 		return nil, err
 	}
-	clientTokens, err := queryDailyClientTokens(ctx, db, filter)
+	done = trace("queryDailyClientTokens")
+	clientTokens, err := queryDailyClientTokens(ctx, db, matFilter)
+	done()
 	if err != nil {
 		return nil, err
 	}
@@ -688,6 +750,7 @@ func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter)
 	agg.SourceDaily = sourceDaily
 	agg.ClientDaily = clientDaily
 	agg.ClientTokens = clientTokens
+	core.Tracef("[usage_view_perf] loadUsageViewForFilter TOTAL: %dms (providers=%v)", time.Since(filterStart).Milliseconds(), filter.ProviderIDs)
 	return agg, nil
 }
 
@@ -1292,6 +1355,10 @@ func queryDailyClientTokens(ctx context.Context, db *sql.DB, filter usageFilter)
 }
 
 func dedupedUsageCTE(filter usageFilter) (string, []any) {
+	// If a materialized temp table exists, just alias it — no CTE rebuild needed.
+	if filter.materializedTbl != "" {
+		return fmt.Sprintf(`WITH deduped_usage AS (SELECT * FROM %s) `, filter.materializedTbl), nil
+	}
 	where, args := usageWhereClause("e", filter)
 	cte := fmt.Sprintf(`
 		WITH scoped_usage AS (

--- a/internal/telemetry/usage_view.go
+++ b/internal/telemetry/usage_view.go
@@ -39,9 +39,15 @@ type telemetrySourceAgg struct {
 }
 
 type telemetryToolAgg struct {
-	Tool    string
-	Calls   float64
-	Calls1d float64
+	Tool           string
+	Calls          float64
+	Calls1d        float64
+	CallsOK        float64
+	CallsOK1d      float64
+	CallsError     float64
+	CallsError1d   float64
+	CallsAborted   float64
+	CallsAborted1d float64
 }
 
 type telemetryMCPFunctionAgg struct {
@@ -119,6 +125,26 @@ type usageFilter struct {
 	ProviderIDs     []string
 	AccountID       string
 	TimeWindowHours int // 0 = no filter
+}
+
+func clientDimensionExpr() string {
+	return `COALESCE(
+		NULLIF(TRIM(
+			COALESCE(
+				json_extract(source_payload, '$.client'),
+				json_extract(source_payload, '$.payload.client'),
+				json_extract(source_payload, '$._normalized.client'),
+				json_extract(source_payload, '$.cursor_source'),
+				json_extract(source_payload, '$.source.client'),
+				''
+			)
+		), ''),
+		CASE
+			WHEN LOWER(TRIM(source_system)) = 'codex' THEN 'CLI'
+			ELSE NULL
+		END,
+		COALESCE(NULLIF(TRIM(source_system), ''), NULLIF(TRIM(workspace_id), ''), 'unknown')
+	)`
 }
 
 func applyCanonicalUsageViewWithDB(
@@ -208,6 +234,16 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 	if snap.DailySeries == nil {
 		snap.DailySeries = make(map[string][]core.TimePoint)
 	}
+
+	// Save API-sourced model cost metrics (billing-cycle) before cleanup.
+	// These will be restored if telemetry events lack sufficient cost attribution.
+	savedAPIModelCosts := make(map[string]core.Metric)
+	for key, m := range snap.Metrics {
+		if strings.HasPrefix(key, "model_") && strings.HasSuffix(key, "_cost") && m.Window == "billing-cycle" {
+			savedAPIModelCosts[key] = m
+		}
+	}
+
 	metricsBefore := len(snap.Metrics)
 	_, hadFiveHourBefore := snap.Metrics["usage_five_hour"]
 	stripAllTime := timeWindow != "" && timeWindow != "all"
@@ -308,11 +344,22 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 			Requests:        float64Ptr(model.Requests),
 		})
 	}
-	// Only compute unattributed model cost when we have windowed model data.
-	// When agg.Models is empty (no events in window), the authoritativeCost
-	// represents the full billing cycle — attributing it as "unattributed"
-	// would be misleading for the selected time range.
-	if len(agg.Models) > 0 {
+	// When telemetry events lack cost attribution but the provider's API
+	// supplied per-model cost data (e.g. Cursor's GetAggregatedUsageEvents),
+	// restore the API model costs so the Model Burn section shows the real
+	// per-model breakdown instead of a single "unattributed" entry.
+	telemetryCostInsufficient := authoritativeCost > 0 && modelCostTotal < authoritativeCost*0.1
+	if telemetryCostInsufficient && len(savedAPIModelCosts) > 0 {
+		for key, m := range savedAPIModelCosts {
+			snap.Metrics[key] = m
+		}
+		core.Tracef("[usage_view] %s: restored %d API model cost metrics (telemetry cost %.2f << authoritative %.2f)",
+			snap.ProviderID, len(savedAPIModelCosts), modelCostTotal, authoritativeCost)
+	} else if len(agg.Models) > 0 {
+		// Only compute unattributed model cost when telemetry has meaningful
+		// cost data. When agg.Models is empty (no events in window), the
+		// authoritativeCost represents the full billing cycle — attributing
+		// it as "unattributed" would be misleading for the selected time range.
 		if delta := authoritativeCost - modelCostTotal; authoritativeCost > 0 && delta > 0.000001 {
 			uk := "model_unattributed"
 			snap.Metrics[uk+"_cost_usd"] = core.Metric{Used: float64Ptr(delta), Unit: "USD", Window: timeWindow}
@@ -320,19 +367,21 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 		}
 	}
 
-	providerCostTotal := 0.0
-	for _, provider := range agg.Providers {
-		pk := sanitizeMetricID(provider.Provider)
-		snap.Metrics["provider_"+pk+"_cost_usd"] = core.Metric{Used: float64Ptr(provider.CostUSD), Unit: "USD", Window: timeWindow}
-		snap.Metrics["provider_"+pk+"_input_tokens"] = core.Metric{Used: float64Ptr(provider.Input), Unit: "tokens", Window: timeWindow}
-		snap.Metrics["provider_"+pk+"_output_tokens"] = core.Metric{Used: float64Ptr(provider.Output), Unit: "tokens", Window: timeWindow}
-		snap.Metrics["provider_"+pk+"_requests"] = core.Metric{Used: float64Ptr(provider.Requests), Unit: "requests", Window: timeWindow}
-		providerCostTotal += provider.CostUSD
-	}
-	if delta := authoritativeCost - providerCostTotal; authoritativeCost > 0 && delta > 0.000001 {
-		uk := "provider_unattributed"
-		snap.Metrics[uk+"_cost_usd"] = core.Metric{Used: float64Ptr(delta), Unit: "USD", Window: timeWindow}
-		snap.SetDiagnostic("telemetry_unattributed_provider_cost_usd", fmt.Sprintf("%.6f", delta))
+	if !strings.EqualFold(strings.TrimSpace(snap.ProviderID), "codex") {
+		providerCostTotal := 0.0
+		for _, provider := range agg.Providers {
+			pk := sanitizeMetricID(provider.Provider)
+			snap.Metrics["provider_"+pk+"_cost_usd"] = core.Metric{Used: float64Ptr(provider.CostUSD), Unit: "USD", Window: timeWindow}
+			snap.Metrics["provider_"+pk+"_input_tokens"] = core.Metric{Used: float64Ptr(provider.Input), Unit: "tokens", Window: timeWindow}
+			snap.Metrics["provider_"+pk+"_output_tokens"] = core.Metric{Used: float64Ptr(provider.Output), Unit: "tokens", Window: timeWindow}
+			snap.Metrics["provider_"+pk+"_requests"] = core.Metric{Used: float64Ptr(provider.Requests), Unit: "requests", Window: timeWindow}
+			providerCostTotal += provider.CostUSD
+		}
+		if delta := authoritativeCost - providerCostTotal; authoritativeCost > 0 && delta > 0.000001 {
+			uk := "provider_unattributed"
+			snap.Metrics[uk+"_cost_usd"] = core.Metric{Used: float64Ptr(delta), Unit: "USD", Window: timeWindow}
+			snap.SetDiagnostic("telemetry_unattributed_provider_cost_usd", fmt.Sprintf("%.6f", delta))
+		}
 	}
 
 	for _, source := range agg.Sources {
@@ -352,10 +401,29 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 		snap.Metrics["client_"+sk+"_sessions"] = core.Metric{Used: float64Ptr(source.Sessions), Unit: "sessions", Window: timeWindow}
 	}
 
+	var totalToolCalls float64
+	var totalToolCallsOK float64
+	var totalToolCallsError float64
+	var totalToolCallsAborted float64
 	for _, tool := range agg.Tools {
 		tk := sanitizeMetricID(tool.Tool)
 		snap.Metrics["tool_"+tk] = core.Metric{Used: float64Ptr(tool.Calls), Unit: "calls", Window: timeWindow}
 		snap.Metrics["tool_"+tk+"_today"] = core.Metric{Used: float64Ptr(tool.Calls1d), Unit: "calls", Window: "1d"}
+		totalToolCalls += tool.Calls
+		totalToolCallsOK += tool.CallsOK
+		totalToolCallsError += tool.CallsError
+		totalToolCallsAborted += tool.CallsAborted
+	}
+	if totalToolCalls > 0 {
+		snap.Metrics["tool_calls_total"] = core.Metric{Used: float64Ptr(totalToolCalls), Unit: "calls", Window: timeWindow}
+		snap.Metrics["tool_completed"] = core.Metric{Used: float64Ptr(totalToolCallsOK), Unit: "calls", Window: timeWindow}
+		snap.Metrics["tool_errored"] = core.Metric{Used: float64Ptr(totalToolCallsError), Unit: "calls", Window: timeWindow}
+		snap.Metrics["tool_cancelled"] = core.Metric{Used: float64Ptr(totalToolCallsAborted), Unit: "calls", Window: timeWindow}
+		successRate := 0.0
+		if totalToolCalls > 0 {
+			successRate = (totalToolCallsOK / totalToolCalls) * 100
+		}
+		snap.Metrics["tool_success_rate"] = core.Metric{Used: float64Ptr(successRate), Unit: "%", Window: timeWindow}
 	}
 
 	// MCP server metrics.
@@ -408,6 +476,12 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 	cs := agg.CodeStats
 	if cs.FilesChanged > 0 {
 		snap.Metrics["composer_files_changed"] = core.Metric{Used: float64Ptr(cs.FilesChanged), Unit: "files", Window: timeWindow}
+	}
+	if cs.LinesAdded > 0 {
+		snap.Metrics["composer_lines_added"] = core.Metric{Used: float64Ptr(cs.LinesAdded), Unit: "lines", Window: timeWindow}
+	}
+	if cs.LinesRemoved > 0 {
+		snap.Metrics["composer_lines_removed"] = core.Metric{Used: float64Ptr(cs.LinesRemoved), Unit: "lines", Window: timeWindow}
 	}
 
 	// Emit window-level aggregate metrics for the TUI header/tile display.
@@ -672,7 +746,7 @@ func querySourceAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]tele
 	usageCTE, whereArgs := dedupedUsageCTE(filter)
 	query := usageCTE + `
 		SELECT
-			COALESCE(NULLIF(TRIM(workspace_id), ''), COALESCE(NULLIF(TRIM(source_system), ''), 'unknown')) AS source_name,
+			` + clientDimensionExpr() + ` AS source_name,
 			SUM(COALESCE(requests, 1)) AS requests,
 			SUM(CASE WHEN date(occurred_at) = date('now') THEN COALESCE(requests, 1) ELSE 0 END) AS requests_today,
 			SUM(COALESCE(total_tokens,
@@ -726,11 +800,16 @@ func queryToolAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]teleme
 		SELECT
 			COALESCE(NULLIF(TRIM(LOWER(tool_name)), ''), 'unknown') AS tool_name,
 			SUM(COALESCE(requests, 1)) AS calls,
-			SUM(CASE WHEN date(occurred_at) = date('now') THEN COALESCE(requests, 1) ELSE 0 END) AS calls_today
+			SUM(CASE WHEN date(occurred_at) = date('now') THEN COALESCE(requests, 1) ELSE 0 END) AS calls_today,
+			SUM(CASE WHEN status = 'ok' THEN COALESCE(requests, 1) ELSE 0 END) AS calls_ok,
+			SUM(CASE WHEN date(occurred_at) = date('now') AND status = 'ok' THEN COALESCE(requests, 1) ELSE 0 END) AS calls_ok_today,
+			SUM(CASE WHEN status = 'error' THEN COALESCE(requests, 1) ELSE 0 END) AS calls_error,
+			SUM(CASE WHEN date(occurred_at) = date('now') AND status = 'error' THEN COALESCE(requests, 1) ELSE 0 END) AS calls_error_today,
+			SUM(CASE WHEN status = 'aborted' THEN COALESCE(requests, 1) ELSE 0 END) AS calls_aborted,
+			SUM(CASE WHEN date(occurred_at) = date('now') AND status = 'aborted' THEN COALESCE(requests, 1) ELSE 0 END) AS calls_aborted_today
 		FROM deduped_usage
 		WHERE 1=1
 		  AND event_type = 'tool_usage'
-		  AND status != 'error'
 		GROUP BY tool_name
 		ORDER BY calls DESC
 	`
@@ -743,7 +822,17 @@ func queryToolAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]teleme
 	var out []telemetryToolAgg
 	for rows.Next() {
 		var row telemetryToolAgg
-		if err := rows.Scan(&row.Tool, &row.Calls, &row.Calls1d); err != nil {
+		if err := rows.Scan(
+			&row.Tool,
+			&row.Calls,
+			&row.Calls1d,
+			&row.CallsOK,
+			&row.CallsOK1d,
+			&row.CallsError,
+			&row.CallsError1d,
+			&row.CallsAborted,
+			&row.CallsAborted1d,
+		); err != nil {
 			continue
 		}
 		out = append(out, row)
@@ -753,7 +842,7 @@ func queryToolAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]teleme
 
 func queryLanguageAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]telemetryLanguageAgg, error) {
 	usageCTE, whereArgs := dedupedUsageCTE(filter)
-	// Query file paths from tool_usage events. Language is inferred in Go
+	// Query file paths from usage events. Language is inferred in Go
 	// from the file extension since SQLite lacks convenient path functions.
 	//
 	// File paths live in different locations depending on the source:
@@ -761,6 +850,7 @@ func queryLanguageAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]te
 	//   - Hook events:      $.tool_input.file_path (Read/Edit/Write)
 	//                       $.tool_input.path (Grep/Glob)
 	//   - Hook response:    $.tool_response.file.filePath (Read response)
+	//   - Cursor tracking:  $.file or $.file_extension (message_usage events)
 	query := usageCTE + `
 		SELECT
 			COALESCE(
@@ -769,11 +859,12 @@ func queryLanguageAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]te
 				NULLIF(TRIM(json_extract(source_payload, '$.tool_input.file_path')), ''),
 				NULLIF(TRIM(json_extract(source_payload, '$.tool_input.path')), ''),
 				NULLIF(TRIM(json_extract(source_payload, '$.tool_response.file.filePath')), ''),
+				NULLIF(TRIM(json_extract(source_payload, '$.file_extension')), ''),
 				''
 			) AS file_path,
 			COALESCE(requests, 1) AS requests
 		FROM deduped_usage
-		WHERE event_type = 'tool_usage'
+		WHERE event_type IN ('tool_usage', 'message_usage')
 		  AND status != 'error'
 	`
 	rows, err := db.QueryContext(ctx, query, whereArgs...)
@@ -805,7 +896,8 @@ func queryLanguageAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]te
 	return out, nil
 }
 
-// inferLanguageFromFilePath maps a file path to a programming language name.
+// inferLanguageFromFilePath maps a file path, file extension, or bare
+// extension string to a programming language name.
 func inferLanguageFromFilePath(path string) string {
 	p := strings.TrimSpace(path)
 	if p == "" {
@@ -828,9 +920,18 @@ func inferLanguageFromFilePath(path string) string {
 	// Check file extension.
 	idx := strings.LastIndex(p, ".")
 	if idx < 0 {
+		// Handle bare extension without dot (e.g., "go", "py" from file_extension fields).
+		if lang := extToLanguage("." + strings.ToLower(p)); lang != "" {
+			return lang
+		}
 		return ""
 	}
 	ext := strings.ToLower(p[idx:])
+	return extToLanguage(ext)
+}
+
+// extToLanguage maps a dotted file extension to a language name.
+func extToLanguage(ext string) string {
 	switch ext {
 	case ".go":
 		return "go"
@@ -866,6 +967,10 @@ func inferLanguageFromFilePath(path string) string {
 		return "php"
 	case ".swift":
 		return "swift"
+	case ".kt", ".kts":
+		return "kotlin"
+	case ".cs":
+		return "csharp"
 	case ".vue":
 		return "vue"
 	case ".svelte":
@@ -874,6 +979,24 @@ func inferLanguageFromFilePath(path string) string {
 		return "toml"
 	case ".xml":
 		return "xml"
+	case ".css", ".scss", ".less":
+		return "css"
+	case ".html", ".htm":
+		return "html"
+	case ".dart":
+		return "dart"
+	case ".zig":
+		return "zig"
+	case ".lua":
+		return "lua"
+	case ".r":
+		return "r"
+	case ".proto":
+		return "protobuf"
+	case ".ex", ".exs":
+		return "elixir"
+	case ".graphql", ".gql":
+		return "graphql"
 	}
 	return ""
 }
@@ -932,21 +1055,21 @@ func queryActivityAgg(ctx context.Context, db *sql.DB, filter usageFilter) (tele
 	usageCTE, whereArgs := dedupedUsageCTE(filter)
 	query := usageCTE + `
 		SELECT
-			COUNT(DISTINCT CASE WHEN event_type = 'message_usage' THEN
+			COUNT(DISTINCT CASE WHEN event_type = 'message_usage' AND status != 'error' THEN
 				COALESCE(NULLIF(TRIM(message_id), ''), COALESCE(NULLIF(TRIM(turn_id), ''), dedup_key))
 			END) AS messages,
-			COUNT(DISTINCT CASE WHEN event_type = 'message_usage' THEN
+			COUNT(DISTINCT CASE WHEN event_type = 'message_usage' AND status != 'error' THEN
 				NULLIF(TRIM(session_id), '')
 			END) AS sessions,
 			SUM(CASE WHEN event_type = 'tool_usage' THEN COALESCE(requests, 1) ELSE 0 END) AS tool_calls,
-			SUM(CASE WHEN event_type = 'message_usage' THEN COALESCE(input_tokens, 0) ELSE 0 END) AS input_tokens,
-			SUM(CASE WHEN event_type = 'message_usage' THEN COALESCE(output_tokens, 0) ELSE 0 END) AS output_tokens,
-			SUM(CASE WHEN event_type = 'message_usage' THEN COALESCE(cache_read_tokens, 0) ELSE 0 END) AS cached_tokens,
-			SUM(CASE WHEN event_type = 'message_usage' THEN COALESCE(reasoning_tokens, 0) ELSE 0 END) AS reasoning_tokens,
-			SUM(CASE WHEN event_type = 'message_usage' THEN COALESCE(total_tokens, 0) ELSE 0 END) AS total_tokens,
-			SUM(CASE WHEN event_type = 'message_usage' THEN COALESCE(cost_usd, 0) ELSE 0 END) AS total_cost
+			SUM(CASE WHEN event_type = 'message_usage' AND status != 'error' THEN COALESCE(input_tokens, 0) ELSE 0 END) AS input_tokens,
+			SUM(CASE WHEN event_type = 'message_usage' AND status != 'error' THEN COALESCE(output_tokens, 0) ELSE 0 END) AS output_tokens,
+			SUM(CASE WHEN event_type = 'message_usage' AND status != 'error' THEN COALESCE(cache_read_tokens, 0) ELSE 0 END) AS cached_tokens,
+			SUM(CASE WHEN event_type = 'message_usage' AND status != 'error' THEN COALESCE(reasoning_tokens, 0) ELSE 0 END) AS reasoning_tokens,
+			SUM(CASE WHEN event_type = 'message_usage' AND status != 'error' THEN COALESCE(total_tokens, 0) ELSE 0 END) AS total_tokens,
+			SUM(CASE WHEN event_type = 'message_usage' AND status != 'error' THEN COALESCE(cost_usd, 0) ELSE 0 END) AS total_cost
 		FROM deduped_usage
-		WHERE status != 'error'
+		WHERE 1=1
 	`
 	var out telemetryActivityAgg
 	err := db.QueryRowContext(ctx, query, whereArgs...).Scan(
@@ -964,15 +1087,18 @@ func queryCodeStatsAgg(ctx context.Context, db *sql.DB, filter usageFilter) (tel
 	usageCTE, whereArgs := dedupedUsageCTE(filter)
 	// Count distinct file paths from tool_usage events to estimate files changed.
 	// Only count mutating tools (edit, write, create, delete, rename, move).
+	// Also sum lines_added/lines_removed from message_usage event payloads
+	// (e.g. Cursor composer sessions store these).
 	query := usageCTE + `
 		SELECT
 			COUNT(DISTINCT CASE
-				WHEN LOWER(tool_name) LIKE '%edit%'
+				WHEN event_type = 'tool_usage'
+				  AND (LOWER(tool_name) LIKE '%edit%'
 				  OR LOWER(tool_name) LIKE '%write%'
 				  OR LOWER(tool_name) LIKE '%create%'
 				  OR LOWER(tool_name) LIKE '%delete%'
 				  OR LOWER(tool_name) LIKE '%rename%'
-				  OR LOWER(tool_name) LIKE '%move%'
+				  OR LOWER(tool_name) LIKE '%move%')
 				THEN NULLIF(TRIM(COALESCE(
 					json_extract(source_payload, '$.file'),
 					json_extract(source_payload, '$.payload.file'),
@@ -980,13 +1106,15 @@ func queryCodeStatsAgg(ctx context.Context, db *sql.DB, filter usageFilter) (tel
 					json_extract(source_payload, '$.tool_input.path'),
 					''
 				)), '')
-			END) AS files_changed
+			END) AS files_changed,
+			SUM(COALESCE(CAST(json_extract(source_payload, '$.lines_added') AS REAL), 0)) AS lines_added,
+			SUM(COALESCE(CAST(json_extract(source_payload, '$.lines_removed') AS REAL), 0)) AS lines_removed
 		FROM deduped_usage
-		WHERE event_type = 'tool_usage'
+		WHERE event_type IN ('tool_usage', 'message_usage')
 		  AND status != 'error'
 	`
 	var out telemetryCodeStatsAgg
-	err := db.QueryRowContext(ctx, query, whereArgs...).Scan(&out.FilesChanged)
+	err := db.QueryRowContext(ctx, query, whereArgs...).Scan(&out.FilesChanged, &out.LinesAdded, &out.LinesRemoved)
 	if err != nil {
 		return out, fmt.Errorf("canonical usage code stats query: %w", err)
 	}
@@ -1054,7 +1182,7 @@ func queryDailyByDimension(ctx context.Context, db *sql.DB, filter usageFilter, 
 			  AND status != 'error'%s
 			GROUP BY day, dim_key
 		`, dailyTimeFilter)
-	case "source", "client":
+	case "source":
 		query = usageCTE + fmt.Sprintf(`
 			SELECT date(occurred_at) AS day,
 			       COALESCE(NULLIF(TRIM(workspace_id), ''), COALESCE(NULLIF(TRIM(source_system), ''), 'unknown')) AS dim_key,
@@ -1065,6 +1193,17 @@ func queryDailyByDimension(ctx context.Context, db *sql.DB, filter usageFilter, 
 			  AND status != 'error'%s
 			GROUP BY day, dim_key
 		`, dailyTimeFilter)
+	case "client":
+		query = usageCTE + fmt.Sprintf(`
+			SELECT date(occurred_at) AS day,
+			       %s AS dim_key,
+			       SUM(COALESCE(requests, 1)) AS value
+			FROM deduped_usage
+			WHERE 1=1
+			  AND event_type = 'message_usage'
+			  AND status != 'error'%s
+			GROUP BY day, dim_key
+		`, clientDimensionExpr(), dailyTimeFilter)
 	default:
 		return map[string][]core.TimePoint{}, nil
 	}
@@ -1108,7 +1247,7 @@ func queryDailyClientTokens(ctx context.Context, db *sql.DB, filter usageFilter)
 	query := usageCTE + fmt.Sprintf(`
 		SELECT
 			date(occurred_at) AS day,
-			COALESCE(NULLIF(TRIM(workspace_id), ''), COALESCE(NULLIF(TRIM(source_system), ''), 'unknown')) AS source_name,
+			%s AS source_name,
 			SUM(COALESCE(total_tokens,
 				COALESCE(input_tokens, 0) +
 				COALESCE(output_tokens, 0) +
@@ -1120,7 +1259,7 @@ func queryDailyClientTokens(ctx context.Context, db *sql.DB, filter usageFilter)
 		  AND event_type = 'message_usage'
 		  AND status != 'error'%s
 		GROUP BY day, source_name
-	`, dailyTimeFilter)
+	`, clientDimensionExpr(), dailyTimeFilter)
 	rows, err := db.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("canonical usage daily client token query: %w", err)
@@ -1168,12 +1307,16 @@ func dedupedUsageCTE(filter usageFilter) (string, []any) {
 		ranked_usage AS (
 			SELECT
 				scoped_usage.*,
-				CASE
-					WHEN COALESCE(NULLIF(TRIM(tool_call_id), ''), '') != '' THEN 'tool:' || LOWER(TRIM(tool_call_id))
-					WHEN COALESCE(NULLIF(TRIM(message_id), ''), '') != '' THEN 'message:' || LOWER(TRIM(message_id))
-					WHEN COALESCE(NULLIF(TRIM(turn_id), ''), '') != '' THEN 'turn:' || LOWER(TRIM(turn_id))
-					ELSE 'fallback:' || dedup_key
-				END AS logical_event_id,
+					CASE
+						WHEN COALESCE(NULLIF(TRIM(tool_call_id), ''), '') != '' THEN 'tool:' || LOWER(TRIM(tool_call_id))
+						WHEN LOWER(TRIM(event_type)) = 'message_usage'
+							AND LOWER(TRIM(source_system)) = 'codex'
+							AND COALESCE(NULLIF(TRIM(turn_id), ''), '') != ''
+						THEN 'message_turn:' || LOWER(TRIM(turn_id))
+						WHEN COALESCE(NULLIF(TRIM(message_id), ''), '') != '' THEN 'message:' || LOWER(TRIM(message_id))
+						WHEN COALESCE(NULLIF(TRIM(turn_id), ''), '') != '' THEN 'turn:' || LOWER(TRIM(turn_id))
+						ELSE 'fallback:' || dedup_key
+					END AS logical_event_id,
 				CASE COALESCE(NULLIF(TRIM(source_channel), ''), '')
 					WHEN 'hook' THEN 4
 					WHEN 'sse' THEN 3
@@ -1284,7 +1427,7 @@ func isStaleActivityMetric(key string) bool {
 		"today_api_cost",
 		"burn_rate",
 		"composer_lines_added", "composer_lines_removed",
-		"composer_files_changed", "scored_commits", "total_prompts":
+		"composer_files_changed":
 		return true
 	}
 	// Fixed-window cost metrics from provider Fetch() are preserved —

--- a/internal/telemetry/usage_view_test.go
+++ b/internal/telemetry/usage_view_test.go
@@ -641,6 +641,19 @@ func TestApplyCanonicalUsageView_IncludesErroredToolCallsAndMCPBreakdown(t *test
 	}
 }
 
+func TestParseMCPToolName_CopilotLegacyWrapper(t *testing.T) {
+	server, function, ok := parseMCPToolName("github_mcp_server_list_issues")
+	if !ok {
+		t.Fatal("parseMCPToolName should parse copilot wrapper pattern")
+	}
+	if server != "github" {
+		t.Fatalf("server = %q, want github", server)
+	}
+	if function != "list_issues" {
+		t.Fatalf("function = %q, want list_issues", function)
+	}
+}
+
 func TestApplyCanonicalUsageView_SkipsProviderBurnMetricsForCodex(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "telemetry.db")
 	store, err := OpenStore(dbPath)

--- a/internal/telemetry/usage_view_test.go
+++ b/internal/telemetry/usage_view_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -555,6 +556,294 @@ func TestApplyCanonicalUsageView_ProviderFallbackUsesProviderIDWhenUpstreamMissi
 	}
 	if _, ok := snap.Metrics["provider_qwen_cost_usd"]; ok {
 		t.Fatal("provider_qwen_cost_usd should not exist without explicit upstream provider")
+	}
+}
+
+func TestApplyCanonicalUsageView_IncludesErroredToolCallsAndMCPBreakdown(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telemetry.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	occurredAt := time.Now().UTC().Add(-2 * time.Minute)
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    occurredAt,
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		AgentName:     "codex",
+		EventType:     EventTypeToolUsage,
+		SessionID:     "sess-codex-1",
+		ToolCallID:    "tool-ok-1",
+		ToolName:      "exec_command",
+		Requests:      int64Ptr(1),
+		Status:        EventStatusOK,
+	}); err != nil {
+		t.Fatalf("ingest ok tool event: %v", err)
+	}
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    occurredAt.Add(1 * time.Second),
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		AgentName:     "codex",
+		EventType:     EventTypeToolUsage,
+		SessionID:     "sess-codex-1",
+		ToolCallID:    "tool-err-1",
+		ToolName:      "mcp__gopls__go_workspace",
+		Requests:      int64Ptr(1),
+		Status:        EventStatusError,
+	}); err != nil {
+		t.Fatalf("ingest errored mcp tool event: %v", err)
+	}
+
+	snaps := map[string]core.UsageSnapshot{
+		"codex-cli": {
+			ProviderID: "codex",
+			AccountID:  "codex-cli",
+			Metrics:    map[string]core.Metric{},
+		},
+	}
+	merged, err := applyCanonicalUsageViewForTest(context.Background(), dbPath, snaps)
+	if err != nil {
+		t.Fatalf("apply canonical usage view: %v", err)
+	}
+	snap := merged["codex-cli"]
+
+	if got := metricUsed(snap.Metrics["tool_exec_command"]); got != 1 {
+		t.Fatalf("tool_exec_command = %v, want 1", got)
+	}
+	if got := metricUsed(snap.Metrics["tool_mcp_gopls_go_workspace"]); got != 1 {
+		t.Fatalf("tool_mcp_gopls_go_workspace = %v, want 1", got)
+	}
+	if got := metricUsed(snap.Metrics["tool_calls_total"]); got != 2 {
+		t.Fatalf("tool_calls_total = %v, want 2", got)
+	}
+	if got := metricUsed(snap.Metrics["tool_completed"]); got != 1 {
+		t.Fatalf("tool_completed = %v, want 1", got)
+	}
+	if got := metricUsed(snap.Metrics["tool_errored"]); got != 1 {
+		t.Fatalf("tool_errored = %v, want 1", got)
+	}
+	if got := metricUsed(snap.Metrics["tool_success_rate"]); got != 50 {
+		t.Fatalf("tool_success_rate = %v, want 50", got)
+	}
+
+	if got := metricUsed(snap.Metrics["mcp_calls_total"]); got != 1 {
+		t.Fatalf("mcp_calls_total = %v, want 1", got)
+	}
+	if got := metricUsed(snap.Metrics["mcp_gopls_total"]); got != 1 {
+		t.Fatalf("mcp_gopls_total = %v, want 1", got)
+	}
+}
+
+func TestApplyCanonicalUsageView_SkipsProviderBurnMetricsForCodex(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telemetry.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	occurredAt := time.Now().UTC()
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    occurredAt,
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		AgentName:     "codex",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-codex-2",
+		MessageID:     "msg-1",
+		ModelRaw:      "gpt-5-codex",
+		InputTokens:   int64Ptr(10),
+		OutputTokens:  int64Ptr(5),
+		TotalTokens:   int64Ptr(15),
+		CostUSD:       float64Ptr(0.01),
+		Requests:      int64Ptr(1),
+		Payload: map[string]any{
+			"upstream_provider": "openai",
+		},
+	}); err != nil {
+		t.Fatalf("ingest codex message event: %v", err)
+	}
+
+	snaps := map[string]core.UsageSnapshot{
+		"codex-cli": {
+			ProviderID: "codex",
+			AccountID:  "codex-cli",
+			Metrics:    map[string]core.Metric{},
+		},
+	}
+	merged, err := applyCanonicalUsageViewForTest(context.Background(), dbPath, snaps)
+	if err != nil {
+		t.Fatalf("apply canonical usage view: %v", err)
+	}
+	snap := merged["codex-cli"]
+
+	for key := range snap.Metrics {
+		if strings.HasPrefix(key, "provider_") {
+			t.Fatalf("unexpected codex provider burn metric: %s", key)
+		}
+	}
+}
+
+func TestApplyCanonicalUsageView_DedupsCodexMessageUsageByTurnID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telemetry.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Now().UTC()
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    now,
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		WorkspaceID:   "openusage",
+		AgentName:     "codex",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-dedup-1",
+		TurnID:        "turn-dedup-1",
+		MessageID:     "sess-dedup-1:101",
+		ModelRaw:      "gpt-5-codex",
+		InputTokens:   int64Ptr(10),
+		OutputTokens:  int64Ptr(5),
+		TotalTokens:   int64Ptr(15),
+		Requests:      int64Ptr(1),
+		Status:        EventStatusOK,
+	}); err != nil {
+		t.Fatalf("ingest first codex message event: %v", err)
+	}
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    now.Add(1 * time.Second),
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		WorkspaceID:   "openusage",
+		AgentName:     "codex",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-dedup-1",
+		TurnID:        "turn-dedup-1",
+		MessageID:     "sess-dedup-1:102",
+		ModelRaw:      "gpt-5-codex",
+		InputTokens:   int64Ptr(15),
+		OutputTokens:  int64Ptr(9),
+		TotalTokens:   int64Ptr(24),
+		Requests:      int64Ptr(1),
+		Status:        EventStatusOK,
+	}); err != nil {
+		t.Fatalf("ingest second codex message event: %v", err)
+	}
+
+	snaps := map[string]core.UsageSnapshot{
+		"codex-cli": {
+			ProviderID: "codex",
+			AccountID:  "codex-cli",
+			Metrics:    map[string]core.Metric{},
+		},
+	}
+	merged, err := applyCanonicalUsageViewForTest(context.Background(), dbPath, snaps)
+	if err != nil {
+		t.Fatalf("apply canonical usage view: %v", err)
+	}
+	snap := merged["codex-cli"]
+
+	if got := metricUsed(snap.Metrics["client_cli_requests"]); got != 1 {
+		t.Fatalf("client_cli_requests = %v, want 1 (deduped by turn_id)", got)
+	}
+	if got := metricUsed(snap.Metrics["window_requests"]); got != 1 {
+		t.Fatalf("window_requests = %v, want 1 (deduped by turn_id)", got)
+	}
+	if got := metricUsed(snap.Metrics["window_tokens"]); got != 24 {
+		t.Fatalf("window_tokens = %v, want 24 from the newest turn event", got)
+	}
+}
+
+func TestApplyCanonicalUsageView_UsesClientFromPayloadBeforeWorkspace(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telemetry.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Now().UTC()
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    now,
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		WorkspaceID:   "openusage",
+		AgentName:     "codex",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-clients-1",
+		MessageID:     "msg-clients-1",
+		ModelRaw:      "gpt-5-codex",
+		InputTokens:   int64Ptr(10),
+		OutputTokens:  int64Ptr(5),
+		TotalTokens:   int64Ptr(15),
+		Requests:      int64Ptr(1),
+		Payload: map[string]any{
+			"client": "CLI",
+		},
+	}); err != nil {
+		t.Fatalf("ingest cli event: %v", err)
+	}
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    now.Add(1 * time.Second),
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		WorkspaceID:   "openusage",
+		AgentName:     "codex",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-clients-1",
+		MessageID:     "msg-clients-2",
+		ModelRaw:      "gpt-5-codex",
+		InputTokens:   int64Ptr(12),
+		OutputTokens:  int64Ptr(6),
+		TotalTokens:   int64Ptr(18),
+		Requests:      int64Ptr(1),
+		Payload: map[string]any{
+			"client": "Desktop App",
+		},
+	}); err != nil {
+		t.Fatalf("ingest desktop event: %v", err)
+	}
+
+	snaps := map[string]core.UsageSnapshot{
+		"codex-cli": {
+			ProviderID: "codex",
+			AccountID:  "codex-cli",
+			Metrics:    map[string]core.Metric{},
+		},
+	}
+	merged, err := applyCanonicalUsageViewForTest(context.Background(), dbPath, snaps)
+	if err != nil {
+		t.Fatalf("apply canonical usage view: %v", err)
+	}
+	snap := merged["codex-cli"]
+
+	if got := metricUsed(snap.Metrics["client_cli_requests"]); got != 1 {
+		t.Fatalf("client_cli_requests = %v, want 1", got)
+	}
+	if got := metricUsed(snap.Metrics["client_desktop_app_requests"]); got != 1 {
+		t.Fatalf("client_desktop_app_requests = %v, want 1", got)
+	}
+	if _, ok := snap.Metrics["client_openusage_requests"]; ok {
+		t.Fatalf("unexpected workspace-derived client metric client_openusage_requests present")
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -119,17 +119,20 @@ type Model struct {
 	appUpdateLatest   string
 	appUpdateHint     string
 
-	providerOrder       []string
-	providerEnabled     map[string]bool
-	accountProviders    map[string]string
-	showSettingsModal   bool
-	settingsModalTab    settingsModalTab
-	settingsCursor      int
-	settingsBodyOffset  int
-	settingsThemeCursor int
-	settingsViewCursor  int
-	settingsStatus      string
-	integrationStatuses []integrations.Status
+	providerOrder            []string
+	providerEnabled          map[string]bool
+	accountProviders         map[string]string
+	showSettingsModal        bool
+	settingsModalTab         settingsModalTab
+	settingsCursor           int
+	settingsBodyOffset       int
+	settingsThemeCursor      int
+	settingsViewCursor       int
+	settingsSectionRowCursor int
+	settingsStatus           string
+	integrationStatuses      []integrations.Status
+
+	widgetSections []config.DashboardWidgetSection
 
 	apiKeyEditing       bool
 	apiKeyInput         string
@@ -195,6 +198,9 @@ type dashboardPrefsPersistedMsg struct {
 type dashboardViewPersistedMsg struct {
 	err error
 }
+type dashboardWidgetSectionsPersistedMsg struct {
+	err error
+}
 type timeWindowPersistedMsg struct {
 	err error
 }
@@ -250,6 +256,17 @@ func (m Model) persistDashboardViewCmd() tea.Cmd {
 			log.Printf("dashboard view persist: %v", err)
 		}
 		return dashboardViewPersistedMsg{err: err}
+	}
+}
+
+func (m Model) persistDashboardWidgetSectionsCmd() tea.Cmd {
+	sections := m.dashboardWidgetSectionConfigEntries()
+	return func() tea.Msg {
+		err := config.SaveDashboardWidgetSections(sections)
+		if err != nil {
+			log.Printf("dashboard widget sections persist: %v", err)
+		}
+		return dashboardWidgetSectionsPersistedMsg{err: err}
 	}
 }
 
@@ -402,6 +419,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.settingsStatus = "view save failed"
 		} else {
 			m.settingsStatus = "view saved"
+		}
+		return m, nil
+
+	case dashboardWidgetSectionsPersistedMsg:
+		if msg.err != nil {
+			m.settingsStatus = "section save failed"
+		} else {
+			m.settingsStatus = "sections saved"
 		}
 		return m, nil
 
@@ -2349,6 +2374,7 @@ func (m *Model) applyDashboardConfig(dashboardCfg config.DashboardConfig, accoun
 	}
 
 	m.providerOrder = order
+	m.setWidgetSections(dashboardCfg.WidgetSections)
 }
 
 func (m *Model) ensureSnapshotProvidersKnown() {
@@ -2388,6 +2414,94 @@ func (m Model) settingsIDs() []string {
 	ids := make([]string, len(m.providerOrder))
 	copy(ids, m.providerOrder)
 	return ids
+}
+
+func (m *Model) setWidgetSections(entries []config.DashboardWidgetSection) {
+	m.widgetSections = normalizeWidgetSectionEntries(entries)
+	m.applyWidgetSectionOverrides()
+}
+
+func normalizeWidgetSectionEntries(entries []config.DashboardWidgetSection) []config.DashboardWidgetSection {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	out := make([]config.DashboardWidgetSection, 0, len(entries))
+	seen := make(map[core.DashboardStandardSection]bool, len(entries))
+	for _, entry := range entries {
+		sectionID := core.DashboardStandardSection(strings.ToLower(strings.TrimSpace(string(entry.ID))))
+		if sectionID == core.DashboardSectionHeader || !core.IsKnownDashboardStandardSection(sectionID) || seen[sectionID] {
+			continue
+		}
+		out = append(out, config.DashboardWidgetSection{
+			ID:      sectionID,
+			Enabled: entry.Enabled,
+		})
+		seen[sectionID] = true
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (m *Model) applyWidgetSectionOverrides() {
+	if len(m.widgetSections) == 0 {
+		setDashboardWidgetSectionOverrides(nil)
+		return
+	}
+	visible := make([]core.DashboardStandardSection, 0, len(m.widgetSections))
+	for _, entry := range m.widgetSections {
+		if !entry.Enabled {
+			continue
+		}
+		visible = append(visible, entry.ID)
+	}
+	setDashboardWidgetSectionOverrides(visible)
+}
+
+func (m Model) defaultWidgetSectionEntries() []config.DashboardWidgetSection {
+	ordered := make([]core.DashboardStandardSection, 0, len(core.DashboardStandardSections()))
+	for _, section := range core.DashboardStandardSections() {
+		if section == core.DashboardSectionHeader {
+			continue
+		}
+		ordered = append(ordered, section)
+	}
+
+	entries := make([]config.DashboardWidgetSection, 0, len(ordered))
+	for _, section := range ordered {
+		entries = append(entries, config.DashboardWidgetSection{
+			ID:      section,
+			Enabled: true,
+		})
+	}
+	return entries
+}
+
+func (m Model) widgetSectionEntries() []config.DashboardWidgetSection {
+	if len(m.widgetSections) == 0 {
+		return m.defaultWidgetSectionEntries()
+	}
+	out := make([]config.DashboardWidgetSection, len(m.widgetSections))
+	copy(out, m.widgetSections)
+	return out
+}
+
+func (m *Model) setWidgetSectionEntries(entries []config.DashboardWidgetSection) {
+	normalized := normalizeWidgetSectionEntries(entries)
+	m.widgetSections = normalized
+	m.applyWidgetSectionOverrides()
+}
+
+func (m Model) dashboardWidgetSectionConfigEntries() []config.DashboardWidgetSection {
+	if len(m.widgetSections) == 0 {
+		return nil
+	}
+	out := make([]config.DashboardWidgetSection, len(m.widgetSections))
+	copy(out, m.widgetSections)
+	return out
 }
 
 func (m Model) telemetryUnmappedProviders() []string {

--- a/internal/tui/provider_widget.go
+++ b/internal/tui/provider_widget.go
@@ -13,6 +13,10 @@ var (
 	providerWidgets   map[string]core.DashboardWidget
 	providerDetails   map[string]core.DetailWidget
 	providerOrder     []string
+
+	providerWidgetOverridesMu    sync.RWMutex
+	providerSectionOrderOverride []core.DashboardStandardSection
+	providerSectionOverrideSet   bool
 )
 
 func loadProviderSpecs() {
@@ -38,9 +42,9 @@ func dashboardWidget(providerID string) core.DashboardWidget {
 	loadProviderSpecs()
 
 	if cfg, ok := providerWidgets[providerID]; ok {
-		return cfg
+		return applyDashboardSectionOverride(cfg)
 	}
-	return core.DefaultDashboardWidget()
+	return applyDashboardSectionOverride(core.DefaultDashboardWidget())
 }
 
 func detailWidget(providerID string) core.DetailWidget {
@@ -100,4 +104,41 @@ func envVarForProvider(providerID string) string {
 		return ""
 	}
 	return spec.Auth.APIKeyEnv
+}
+
+func setDashboardWidgetSectionOverrides(sections []core.DashboardStandardSection) {
+	providerWidgetOverridesMu.Lock()
+	defer providerWidgetOverridesMu.Unlock()
+
+	if sections == nil {
+		providerSectionOrderOverride = nil
+		providerSectionOverrideSet = false
+		return
+	}
+
+	seen := make(map[core.DashboardStandardSection]bool, len(sections))
+	filtered := make([]core.DashboardStandardSection, 0, len(sections))
+	for _, section := range sections {
+		if !core.IsKnownDashboardStandardSection(section) || seen[section] {
+			continue
+		}
+		filtered = append(filtered, section)
+		seen[section] = true
+	}
+	providerSectionOrderOverride = append([]core.DashboardStandardSection(nil), filtered...)
+	providerSectionOverrideSet = true
+}
+
+func applyDashboardSectionOverride(cfg core.DashboardWidget) core.DashboardWidget {
+	providerWidgetOverridesMu.RLock()
+	sections := providerSectionOrderOverride
+	set := providerSectionOverrideSet
+	providerWidgetOverridesMu.RUnlock()
+
+	if !set {
+		return cfg
+	}
+
+	cfg.StandardSectionOrder = append([]core.DashboardStandardSection(nil), sections...)
+	return cfg
 }

--- a/internal/tui/provider_widget_test.go
+++ b/internal/tui/provider_widget_test.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/config"
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+func TestDashboardWidget_AppliesSectionOverride(t *testing.T) {
+	t.Cleanup(func() { setDashboardWidgetSectionOverrides(nil) })
+
+	setDashboardWidgetSectionOverrides([]core.DashboardStandardSection{
+		core.DashboardSectionOtherData,
+		core.DashboardSectionTopUsageProgress,
+	})
+
+	got := dashboardWidget("openai").EffectiveStandardSectionOrder()
+	want := []core.DashboardStandardSection{
+		core.DashboardSectionOtherData,
+		core.DashboardSectionTopUsageProgress,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("section count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("section[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDashboardWidget_AppliesGlobalOverrideToAllProviders(t *testing.T) {
+	t.Cleanup(func() { setDashboardWidgetSectionOverrides(nil) })
+
+	setDashboardWidgetSectionOverrides([]core.DashboardStandardSection{
+		core.DashboardSectionOtherData,
+	})
+
+	for _, providerID := range []string{"openai", "claude_code", "openrouter"} {
+		got := dashboardWidget(providerID).EffectiveStandardSectionOrder()
+		if len(got) != 1 || got[0] != core.DashboardSectionOtherData {
+			t.Fatalf("provider %q effective section order = %#v, want [other_data]", providerID, got)
+		}
+	}
+}
+
+func TestSetDashboardWidgetSectionOverrides_NormalizesInvalidValues(t *testing.T) {
+	t.Cleanup(func() { setDashboardWidgetSectionOverrides(nil) })
+
+	setDashboardWidgetSectionOverrides([]core.DashboardStandardSection{
+		core.DashboardSectionTopUsageProgress,
+		core.DashboardStandardSection("unknown"),
+		core.DashboardSectionTopUsageProgress,
+		core.DashboardSectionOtherData,
+	})
+
+	got := dashboardWidget("openai").EffectiveStandardSectionOrder()
+	want := []core.DashboardStandardSection{
+		core.DashboardSectionTopUsageProgress,
+		core.DashboardSectionOtherData,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("section count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("section[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestNewModel_AppliesWidgetSectionOverridesFromConfig(t *testing.T) {
+	t.Cleanup(func() { setDashboardWidgetSectionOverrides(nil) })
+
+	_ = NewModel(
+		0.2,
+		0.05,
+		false,
+		config.DashboardConfig{
+			WidgetSections: []config.DashboardWidgetSection{
+				{
+					ID:      core.DashboardSectionOtherData,
+					Enabled: true,
+				},
+				{
+					ID:      core.DashboardSectionTopUsageProgress,
+					Enabled: false,
+				},
+			},
+		},
+		[]core.AccountConfig{
+			{ID: "openai", Provider: "openai"},
+		},
+		core.TimeWindow7d,
+	)
+
+	got := dashboardWidget("openai").EffectiveStandardSectionOrder()
+	if len(got) != 1 || got[0] != core.DashboardSectionOtherData {
+		t.Fatalf("effective section order = %#v, want [other_data]", got)
+	}
+}

--- a/internal/tui/settings_modal.go
+++ b/internal/tui/settings_modal.go
@@ -14,6 +14,7 @@ type settingsModalTab int
 
 const (
 	settingsTabProviders settingsModalTab = iota
+	settingsTabWidgetSections
 	settingsTabTheme
 	settingsTabView
 	settingsTabAPIKeys
@@ -24,6 +25,7 @@ const (
 
 var settingsTabNames = []string{
 	"Providers",
+	"Widget Sections",
 	"Theme",
 	"View",
 	"API Keys",
@@ -42,6 +44,7 @@ func (m *Model) openSettingsModal() {
 	if len(m.providerOrder) > 0 {
 		m.settingsCursor = clamp(m.settingsCursor, 0, len(m.providerOrder)-1)
 	}
+	m.settingsSectionRowCursor = 0
 	themes := AvailableThemes()
 	if len(themes) > 0 {
 		m.settingsThemeCursor = clamp(ActiveThemeIndex(), 0, len(themes)-1)
@@ -59,6 +62,7 @@ func (m *Model) closeSettingsModal() {
 	m.apiKeyInput = ""
 	m.apiKeyStatus = ""
 	m.settingsBodyOffset = 0
+	m.settingsSectionRowCursor = 0
 }
 
 func (m Model) settingsModalInfo() string {
@@ -160,6 +164,33 @@ func (m Model) handleSettingsModalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.rebuildSortedIDs()
 			m.settingsStatus = "saving settings..."
 			return m, m.persistDashboardPrefsCmd()
+		}
+	case settingsTabWidgetSections:
+		switch msg.String() {
+		case "up", "k":
+			if m.settingsSectionRowCursor > 0 {
+				m.settingsSectionRowCursor--
+			}
+		case "down", "j":
+			entries := m.widgetSectionEntries()
+			if m.settingsSectionRowCursor < len(entries)-1 {
+				m.settingsSectionRowCursor++
+			}
+		case "K", "shift+k", "shift+up", "ctrl+up", "alt+up":
+			cmd := m.moveSelectedWidgetSection(-1)
+			if cmd != nil {
+				return m, cmd
+			}
+		case "J", "shift+j", "shift+down", "ctrl+down", "alt+down":
+			cmd := m.moveSelectedWidgetSection(1)
+			if cmd != nil {
+				return m, cmd
+			}
+		case " ", "enter":
+			cmd := m.toggleSelectedWidgetSection()
+			if cmd != nil {
+				return m, cmd
+			}
 		}
 	case settingsTabTheme:
 		themes := AvailableThemes()
@@ -332,12 +363,50 @@ func (m *Model) moveSelectedProvider(ids []string, delta int) tea.Cmd {
 	return m.persistDashboardPrefsCmd()
 }
 
+func (m *Model) moveSelectedWidgetSection(delta int) tea.Cmd {
+	if m == nil || delta == 0 {
+		return nil
+	}
+	entries := m.widgetSectionEntries()
+	if len(entries) == 0 {
+		return nil
+	}
+
+	cursor := clamp(m.settingsSectionRowCursor, 0, len(entries)-1)
+	target := cursor + delta
+	if target < 0 || target >= len(entries) {
+		return nil
+	}
+	entries[cursor], entries[target] = entries[target], entries[cursor]
+	m.settingsSectionRowCursor = target
+	m.setWidgetSectionEntries(entries)
+	m.settingsStatus = "saving sections..."
+	return m.persistDashboardWidgetSectionsCmd()
+}
+
+func (m *Model) toggleSelectedWidgetSection() tea.Cmd {
+	if m == nil {
+		return nil
+	}
+	entries := m.widgetSectionEntries()
+	if len(entries) == 0 {
+		return nil
+	}
+	cursor := clamp(m.settingsSectionRowCursor, 0, len(entries)-1)
+	entries[cursor].Enabled = !entries[cursor].Enabled
+	m.setWidgetSectionEntries(entries)
+	m.settingsStatus = "saving sections..."
+	return m.persistDashboardWidgetSectionsCmd()
+}
+
 func (m *Model) resetSettingsCursorForTab() {
 	switch m.settingsModalTab {
 	case settingsTabTelemetry:
 		m.settingsCursor = m.currentTimeWindowIndex()
 	case settingsTabView:
 		m.settingsViewCursor = dashboardViewIndex(m.configuredDashboardView())
+	case settingsTabWidgetSections:
+		m.settingsSectionRowCursor = 0
 	default:
 		m.settingsCursor = 0
 	}
@@ -425,6 +494,8 @@ func (m Model) settingsModalHint() string {
 	switch m.settingsModalTab {
 	case settingsTabProviders:
 		return "Up/Down: select  ·  Shift+↑/↓ or Shift+J/K: move item  ·  Space/Enter: enable/disable  ·  Left/Right: switch tab  ·  Esc: close"
+	case settingsTabWidgetSections:
+		return "Up/Down: select section  ·  Shift+↑/↓ or Shift+J/K: reorder  ·  Space/Enter: show/hide  ·  Esc: close"
 	case settingsTabAPIKeys:
 		if m.apiKeyEditing {
 			return "Type API key  ·  Enter: validate & save  ·  Esc: cancel"
@@ -445,6 +516,8 @@ func (m Model) renderSettingsModalBody(w, h int) string {
 	switch m.settingsModalTab {
 	case settingsTabProviders:
 		return m.renderSettingsProvidersBody(w, h)
+	case settingsTabWidgetSections:
+		return m.renderSettingsWidgetSectionsBody(w, h)
 	case settingsTabAPIKeys:
 		return m.renderSettingsAPIKeysBody(w, h)
 	case settingsTabView:
@@ -490,6 +563,54 @@ func (m Model) renderSettingsProvidersBody(w, h int) string {
 			prefix = lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("➤ ")
 		}
 		line := fmt.Sprintf("%s%s %2d. %s  %s", prefix, boxStyle.Render(box), i+1, id, dimStyle.Render(providerID))
+		lines = append(lines, line)
+	}
+
+	return padToSize(strings.Join(lines, "\n"), w, h)
+}
+
+func (m Model) renderSettingsWidgetSectionsBody(w, h int) string {
+	entries := m.widgetSectionEntries()
+	if len(entries) == 0 {
+		return padToSize(dimStyle.Render("No dashboard sections available."), w, h)
+	}
+
+	cursor := clamp(m.settingsSectionRowCursor, 0, len(entries)-1)
+	headerLines := 4
+	listHeight := h - headerLines
+	if listHeight < 1 {
+		listHeight = 1
+	}
+	start, end := listWindow(len(entries), cursor, listHeight)
+
+	visibleCount := 0
+	for _, entry := range entries {
+		if entry.Enabled {
+			visibleCount++
+		}
+	}
+
+	lines := make([]string, 0, h)
+	lines = append(lines, lipgloss.NewStyle().Foreground(colorTeal).Bold(true).Render("Global Dashboard Widget Sections"))
+	lines = append(lines, dimStyle.Render("Applies to all provider widgets"))
+	lines = append(lines, dimStyle.Render(fmt.Sprintf("%d/%d sections visible", visibleCount, len(entries))))
+	lines = append(lines, "")
+
+	for i := start; i < end; i++ {
+		entry := entries[i]
+		prefix := "  "
+		if i == cursor {
+			prefix = lipgloss.NewStyle().Foreground(colorAccent).Bold(true).Render("➤ ")
+		}
+
+		box := "☐"
+		boxStyle := lipgloss.NewStyle().Foreground(colorRed)
+		if entry.Enabled {
+			box = "☑"
+			boxStyle = lipgloss.NewStyle().Foreground(colorGreen)
+		}
+
+		line := fmt.Sprintf("%s%s %2d. %s", prefix, boxStyle.Render(box), i+1, entry.ID)
 		lines = append(lines, line)
 	}
 

--- a/internal/tui/settings_widget_sections_test.go
+++ b/internal/tui/settings_widget_sections_test.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/janekbaraniewski/openusage/internal/config"
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+func TestHandleSettingsModalKey_WidgetSectionsToggle(t *testing.T) {
+	t.Cleanup(func() { setDashboardWidgetSectionOverrides(nil) })
+
+	m := Model{
+		showSettingsModal: true,
+		settingsModalTab:  settingsTabWidgetSections,
+		widgetSections: []config.DashboardWidgetSection{
+			{ID: core.DashboardSectionTopUsageProgress, Enabled: true},
+			{ID: core.DashboardSectionOtherData, Enabled: true},
+		},
+	}
+
+	updated, cmd := m.handleSettingsModalKey(tea.KeyMsg{Type: tea.KeyEnter})
+	got := updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("expected persist command when toggling widget section")
+	}
+	if got.widgetSections[0].Enabled {
+		t.Fatal("expected first widget section to be toggled off")
+	}
+}
+
+func TestHandleSettingsModalKey_WidgetSectionsMoveRow(t *testing.T) {
+	t.Cleanup(func() { setDashboardWidgetSectionOverrides(nil) })
+
+	m := Model{
+		showSettingsModal: true,
+		settingsModalTab:  settingsTabWidgetSections,
+		widgetSections: []config.DashboardWidgetSection{
+			{ID: core.DashboardSectionTopUsageProgress, Enabled: true},
+			{ID: core.DashboardSectionOtherData, Enabled: true},
+		},
+	}
+
+	updated, cmd := m.handleSettingsModalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("J")})
+	got := updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("expected persist command when moving widget section")
+	}
+	if got.settingsSectionRowCursor != 1 {
+		t.Fatalf("settingsSectionRowCursor = %d, want 1", got.settingsSectionRowCursor)
+	}
+	if got.widgetSections[0].ID != core.DashboardSectionOtherData {
+		t.Fatalf("first section ID = %q, want %q", got.widgetSections[0].ID, core.DashboardSectionOtherData)
+	}
+}
+
+func TestHandleSettingsModalKey_WidgetSectionsReorderAffectsRenderedWidget(t *testing.T) {
+	t.Cleanup(func() { setDashboardWidgetSectionOverrides(nil) })
+
+	m := NewModel(
+		0.2,
+		0.05,
+		false,
+		config.DashboardConfig{},
+		[]core.AccountConfig{
+			{ID: "openai", Provider: "openai"},
+		},
+		core.TimeWindow7d,
+	)
+	m.showSettingsModal = true
+	m.settingsModalTab = settingsTabWidgetSections
+
+	updated, cmd := m.handleSettingsModalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("J")})
+	got := updated.(Model)
+	if cmd == nil {
+		t.Fatal("expected persist command when reordering widget sections")
+	}
+	if got.settingsSectionRowCursor != 1 {
+		t.Fatalf("settingsSectionRowCursor = %d, want 1", got.settingsSectionRowCursor)
+	}
+
+	order := dashboardWidget("openai").EffectiveStandardSectionOrder()
+	if len(order) < 2 {
+		t.Fatalf("effective section order too short: %#v", order)
+	}
+	if order[0] != core.DashboardSectionModelBurn || order[1] != core.DashboardSectionTopUsageProgress {
+		t.Fatalf("effective section order prefix = %#v, want [model_burn top_usage_progress]", order[:2])
+	}
+}

--- a/internal/tui/tiles.go
+++ b/internal/tui/tiles.go
@@ -587,7 +587,7 @@ func (m Model) renderTile(snap core.UsageSnapshot, selected, modelMixExpanded bo
 	var mcpUsageLines []string
 	var mcpUsageKeys map[string]bool
 	if widget.ShowMCPUsage {
-		mcpUsageLines, mcpUsageKeys = buildMCPUsageLines(snap, innerW)
+		mcpUsageLines, mcpUsageKeys = buildMCPUsageLines(snap, innerW, modelMixExpanded)
 		if len(mcpUsageLines) > 0 {
 			sectionsByID[core.DashboardSectionMCPUsage] = section{withSectionPadding(mcpUsageLines)}
 		}
@@ -3070,7 +3070,7 @@ func sourceAsClientBucket(source string) string {
 	}
 
 	switch s {
-	case "composer", "tab", "human", "vscode", "ide", "editor":
+	case "composer", "tab", "human", "vscode", "ide", "editor", "cursor":
 		return "ide"
 	case "cloud", "cloud_agent", "cloud_agents", "web", "web_agent", "background_agent":
 		return "cloud_agents"
@@ -3173,7 +3173,10 @@ func collectInterfaceAsClients(snap core.UsageSnapshot) ([]clientMixEntry, map[s
 		clients = append(clients, *entry)
 	}
 	sort.Slice(clients, func(i, j int) bool {
-		return clients[i].requests > clients[j].requests
+		if clients[i].requests != clients[j].requests {
+			return clients[i].requests > clients[j].requests
+		}
+		return clients[i].name < clients[j].name
 	})
 	return clients, usedKeys
 }
@@ -4595,7 +4598,7 @@ func buildActualToolUsageLines(snap core.UsageSnapshot, innerW int, expanded boo
 			continue
 		}
 		// Skip MCP tools — they have their own dedicated section.
-		if strings.HasPrefix(name, "mcp_") {
+		if isMCPToolMetricName(name) {
 			usedKeys[key] = true
 			continue
 		}
@@ -4687,6 +4690,20 @@ func buildActualToolUsageLines(snap core.UsageSnapshot, innerW int, expanded boo
 	return lines, usedKeys
 }
 
+func isMCPToolMetricName(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "" {
+		return false
+	}
+	if strings.HasPrefix(normalized, "mcp_") {
+		return true
+	}
+	if strings.Contains(normalized, "_mcp_server_") || strings.Contains(normalized, "-mcp-server-") {
+		return true
+	}
+	return strings.HasSuffix(normalized, "_mcp")
+}
+
 // prettifyMCPServerName cleans up raw MCP server identifiers for display.
 // Strips common prefixes (claude_ai_, plugin_), suffixes (_mcp), deduplicates,
 // and title-cases the result.
@@ -4740,7 +4757,7 @@ func prettifyMCPName(s string) string {
 	return strings.Join(words, " ")
 }
 
-func buildMCPUsageLines(snap core.UsageSnapshot, innerW int) ([]string, map[string]bool) {
+func buildMCPUsageLines(snap core.UsageSnapshot, innerW int, expanded bool) ([]string, map[string]bool) {
 	usedKeys := make(map[string]bool)
 
 	type funcEntry struct {
@@ -4863,6 +4880,9 @@ func buildMCPUsageLines(snap core.UsageSnapshot, innerW int) ([]string, map[stri
 
 	// Show up to 6 servers with nested function breakdown.
 	displayLimit := 6
+	if expanded {
+		displayLimit = len(servers)
+	}
 	visible := servers
 	if len(visible) > displayLimit {
 		visible = visible[:displayLimit]
@@ -4878,6 +4898,9 @@ func buildMCPUsageLines(snap core.UsageSnapshot, innerW int) ([]string, map[stri
 
 		// Show top 3 functions per server, indented.
 		maxFuncs := 3
+		if expanded {
+			maxFuncs = len(srv.funcs)
+		}
 		if len(srv.funcs) < maxFuncs {
 			maxFuncs = len(srv.funcs)
 		}
@@ -4887,13 +4910,13 @@ func buildMCPUsageLines(snap core.UsageSnapshot, innerW int) ([]string, map[stri
 			fnValue := fmt.Sprintf("%s calls", shortCompact(fn.calls))
 			lines = append(lines, renderDotLeaderRow(fnLabel, fnValue, innerW))
 		}
-		if len(srv.funcs) > 3 {
-			lines = append(lines, dimStyle.Render(fmt.Sprintf("    + %d more", len(srv.funcs)-3)))
+		if !expanded && len(srv.funcs) > 3 {
+			lines = append(lines, dimStyle.Render(fmt.Sprintf("    + %d more (Ctrl+O)", len(srv.funcs)-3)))
 		}
 	}
 
-	if len(servers) > displayLimit {
-		lines = append(lines, dimStyle.Render(fmt.Sprintf("+ %d more servers", len(servers)-displayLimit)))
+	if !expanded && len(servers) > displayLimit {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("+ %d more servers (Ctrl+O)", len(servers)-displayLimit)))
 	}
 
 	return lines, usedKeys

--- a/internal/tui/tiles.go
+++ b/internal/tui/tiles.go
@@ -3092,6 +3092,15 @@ func sourceAsClientBucket(source string) string {
 	return s
 }
 
+func canonicalClientBucket(name string) string {
+	bucket := sourceAsClientBucket(name)
+	switch bucket {
+	case "codex", "openusage":
+		return "cli_agents"
+	}
+	return bucket
+}
+
 // collectInterfaceAsClients builds clientMixEntry items from interface_ metrics
 // so the interface breakdown (composer, cli, human, tab) can be shown directly
 // in the client composition section instead of a separate panel.
@@ -3113,7 +3122,7 @@ func collectInterfaceAsClients(snap core.UsageSnapshot) ([]clientMixEntry, map[s
 		if !strings.HasPrefix(key, "interface_") {
 			continue
 		}
-		name := strings.TrimPrefix(key, "interface_")
+		name := canonicalClientBucket(strings.TrimPrefix(key, "interface_"))
 		if name == "" {
 			continue
 		}
@@ -3128,7 +3137,7 @@ func collectInterfaceAsClients(snap core.UsageSnapshot) ([]clientMixEntry, map[s
 		}
 		switch {
 		case strings.HasPrefix(key, "usage_client_"):
-			name := strings.TrimPrefix(key, "usage_client_")
+			name := canonicalClientBucket(strings.TrimPrefix(key, "usage_client_"))
 			if name == "" {
 				continue
 			}
@@ -3138,7 +3147,7 @@ func collectInterfaceAsClients(snap core.UsageSnapshot) ([]clientMixEntry, map[s
 			if source == "" {
 				continue
 			}
-			name := sourceAsClientBucket(source)
+			name := canonicalClientBucket(source)
 			mergeSeriesByDay(usageSeriesByName, name, points)
 		}
 	}
@@ -3465,6 +3474,7 @@ func collectProviderClientMix(snap core.UsageSnapshot) ([]clientMixEntry, map[st
 	usageSourceSeriesByClient := make(map[string]map[string]float64)
 	hasAllTimeRequests := make(map[string]bool)
 	requestsTodayFallback := make(map[string]float64)
+	hasAnyClientMetrics := false
 
 	for key, met := range snap.Metrics {
 		if met.Used == nil {
@@ -3475,6 +3485,8 @@ func collectProviderClientMix(snap core.UsageSnapshot) ([]clientMixEntry, map[st
 			if !ok {
 				continue
 			}
+			name = canonicalClientBucket(name)
+			hasAnyClientMetrics = true
 			client := ensure(name)
 			switch field {
 			case "total_tokens":
@@ -3501,7 +3513,7 @@ func collectProviderClientMix(snap core.UsageSnapshot) ([]clientMixEntry, map[st
 			if !ok {
 				continue
 			}
-			clientName := sourceAsClientBucket(sourceName)
+			clientName := canonicalClientBucket(sourceName)
 			client := ensure(clientName)
 			switch field {
 			case "requests":
@@ -3522,6 +3534,13 @@ func collectProviderClientMix(snap core.UsageSnapshot) ([]clientMixEntry, map[st
 			client.requests = value
 		}
 	}
+	hasAnyClientSeries := false
+	for key := range snap.DailySeries {
+		if strings.HasPrefix(key, "tokens_client_") || strings.HasPrefix(key, "usage_client_") {
+			hasAnyClientSeries = true
+			break
+		}
+	}
 
 	for key, points := range snap.DailySeries {
 		if len(points) == 0 {
@@ -3530,19 +3549,22 @@ func collectProviderClientMix(snap core.UsageSnapshot) ([]clientMixEntry, map[st
 
 		switch {
 		case strings.HasPrefix(key, "tokens_client_"):
-			name := strings.TrimPrefix(key, "tokens_client_")
+			name := canonicalClientBucket(strings.TrimPrefix(key, "tokens_client_"))
 			if name == "" {
 				continue
 			}
 			mergeSeriesByDay(tokenSeriesByClient, name, points)
 		case strings.HasPrefix(key, "usage_client_"):
-			name := strings.TrimPrefix(key, "usage_client_")
+			name := canonicalClientBucket(strings.TrimPrefix(key, "usage_client_"))
 			if name == "" {
 				continue
 			}
 			mergeSeriesByDay(usageClientSeriesByClient, name, points)
 		case strings.HasPrefix(key, "usage_source_"):
-			name := sourceAsClientBucket(strings.TrimPrefix(key, "usage_source_"))
+			if hasAnyClientMetrics || hasAnyClientSeries {
+				continue
+			}
+			name := canonicalClientBucket(strings.TrimPrefix(key, "usage_source_"))
 			if name == "" {
 				continue
 			}

--- a/internal/tui/tiles_normalization_test.go
+++ b/internal/tui/tiles_normalization_test.go
@@ -187,6 +187,50 @@ func TestCollectProviderClientMix_AggregatesSourceSeriesByClient(t *testing.T) {
 	}
 }
 
+func TestCollectProviderClientMix_IgnoresSourceSeriesWhenClientSeriesExists(t *testing.T) {
+	snap := core.UsageSnapshot{
+		Metrics: map[string]core.Metric{
+			"client_cli_requests": {Used: float64Ptr(10), Unit: "requests"},
+		},
+		DailySeries: map[string][]core.TimePoint{
+			"usage_client_cli": {
+				{Date: "2026-03-04", Value: 4},
+				{Date: "2026-03-05", Value: 6},
+			},
+			"usage_source_openusage": {
+				{Date: "2026-03-04", Value: 40},
+				{Date: "2026-03-05", Value: 60},
+			},
+			"usage_source_codex": {
+				{Date: "2026-03-04", Value: 40},
+				{Date: "2026-03-05", Value: 60},
+			},
+		},
+	}
+
+	clients, _ := collectProviderClientMix(snap)
+
+	if _, ok := clientByName(clients, "openusage"); ok {
+		t.Fatalf("unexpected workspace-derived client bucket present: %+v", clients)
+	}
+	if _, ok := clientByName(clients, "codex"); ok {
+		t.Fatalf("unexpected source-system-derived client bucket present: %+v", clients)
+	}
+	cli, ok := clientByName(clients, "cli_agents")
+	if !ok {
+		t.Fatalf("missing canonical cli_agents client: %+v", clients)
+	}
+	if len(cli.series) != 2 {
+		t.Fatalf("cli_agents series length = %d, want 2", len(cli.series))
+	}
+	if cli.series[0].Date != "2026-03-04" || cli.series[0].Value != 4 {
+		t.Fatalf("unexpected cli_agents day1 point: %+v", cli.series[0])
+	}
+	if cli.series[1].Date != "2026-03-05" || cli.series[1].Value != 6 {
+		t.Fatalf("unexpected cli_agents day2 point: %+v", cli.series[1])
+	}
+}
+
 func TestCollectProviderClientMix_DoesNotDoubleCountRequestsTodayFallback(t *testing.T) {
 	snap := core.UsageSnapshot{
 		Metrics: map[string]core.Metric{

--- a/internal/tui/tiles_normalization_test.go
+++ b/internal/tui/tiles_normalization_test.go
@@ -456,6 +456,77 @@ func TestSortToolMixEntries_BreaksTiesAlphabetically(t *testing.T) {
 	}
 }
 
+func TestBuildActualToolUsageLines_FiltersMCPToolNames(t *testing.T) {
+	snap := core.UsageSnapshot{
+		AccountID: "copilot",
+		Metrics: map[string]core.Metric{
+			"tool_view":                          {Used: float64Ptr(10), Unit: "calls"},
+			"tool_bash":                          {Used: float64Ptr(3), Unit: "calls"},
+			"tool_mcp_github_list_issues":        {Used: float64Ptr(4), Unit: "calls"},
+			"tool_github_mcp_server_get_commit":  {Used: float64Ptr(2), Unit: "calls"},
+			"tool_gopls_go_workspace_mcp":        {Used: float64Ptr(1), Unit: "calls"},
+			"tool_calls_total":                   {Used: float64Ptr(20), Unit: "calls"},
+			"tool_success_rate":                  {Used: float64Ptr(98), Unit: "%"},
+			"tool_github_mcp_server_list_issues": {Used: float64Ptr(5), Unit: "calls"},
+		},
+	}
+
+	lines, used := buildActualToolUsageLines(snap, 120, false)
+	joined := strings.Join(lines, "\n")
+
+	if !strings.Contains(joined, "13 calls") {
+		t.Fatalf("expected non-MCP total in heading, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "view") || !strings.Contains(joined, "bash") {
+		t.Fatalf("expected non-MCP tools to remain, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "github_mcp_server") || strings.Contains(joined, "mcp_github") || strings.Contains(joined, "_mcp") {
+		t.Fatalf("expected MCP tools to be excluded from tool usage, got:\n%s", joined)
+	}
+	for _, key := range []string{
+		"tool_mcp_github_list_issues",
+		"tool_github_mcp_server_get_commit",
+		"tool_gopls_go_workspace_mcp",
+		"tool_github_mcp_server_list_issues",
+	} {
+		if !used[key] {
+			t.Fatalf("expected key %q to be marked as consumed", key)
+		}
+	}
+}
+
+func TestBuildMCPUsageLines_ExpandedShowsHiddenFunctions(t *testing.T) {
+	snap := core.UsageSnapshot{
+		AccountID: "copilot",
+		Metrics: map[string]core.Metric{
+			"mcp_calls_total":              {Used: float64Ptr(11), Unit: "calls"},
+			"mcp_servers_active":           {Used: float64Ptr(1), Unit: "servers"},
+			"mcp_github_total":             {Used: float64Ptr(11), Unit: "calls"},
+			"mcp_github_get_file_contents": {Used: float64Ptr(2), Unit: "calls"},
+			"mcp_github_actions_list":      {Used: float64Ptr(2), Unit: "calls"},
+			"mcp_github_get_commit":        {Used: float64Ptr(2), Unit: "calls"},
+			"mcp_github_list_branches":     {Used: float64Ptr(2), Unit: "calls"},
+			"mcp_github_list_issues":       {Used: float64Ptr(2), Unit: "calls"},
+			"mcp_github_search_code":       {Used: float64Ptr(1), Unit: "calls"},
+		},
+	}
+
+	collapsed, _ := buildMCPUsageLines(snap, 120, false)
+	expanded, _ := buildMCPUsageLines(snap, 120, true)
+	collapsedJoined := strings.Join(collapsed, "\n")
+	expandedJoined := strings.Join(expanded, "\n")
+
+	if !strings.Contains(collapsedJoined, "+ 3 more (Ctrl+O)") {
+		t.Fatalf("collapsed MCP view should show expand hint, got:\n%s", collapsedJoined)
+	}
+	if strings.Contains(expandedJoined, "+ 3 more") {
+		t.Fatalf("expanded MCP view should show all functions, got:\n%s", expandedJoined)
+	}
+	if len(expanded) <= len(collapsed) {
+		t.Fatalf("expanded MCP view should contain more rows; collapsed=%d expanded=%d", len(collapsed), len(expanded))
+	}
+}
+
 func TestBuildModelColorMap_AssignsDistinctColorsForVisibleModels(t *testing.T) {
 	models := []modelMixEntry{
 		{name: "claude-opus"},


### PR DESCRIPTION
## Summary

Major performance optimization for the telemetry read model (5-13x faster time window switching) plus expanded Cursor telemetry data extraction and TUI fixes.

### Performance
- **Materialize deduped CTE into temp table** — the expensive 3-level dedup CTE was being rebuilt 13 times per provider per read; now materialized once into a temp table with indexes, reused across all aggregation queries
- **Move data repair migrations from read path to daemon startup** — `repairLegacyProviderIDs` was running 3 UPDATE queries on every dashboard read (5-10s each); moved to one-shot migrations tracked in `_migrations` table, executed at daemon startup only
- **Add raw payload pruning** — clears `source_payload` to `'{}'` after 1 hour (keeps hash for dedup), preventing unbounded DB growth
- **Increase read model timeout** from 500ms to 5s to handle larger datasets

### Cursor telemetry expansion
- Extract `fileName`, `requestId`, `conversationId` from tracking DB
- Link tracking events to composer sessions via `conversationId`
- New `collectBubbleTokenEvents`: extract input/output token counts from `bubbleId` entries
- New `collectDailyStatsEvents`: extract tab/composer suggested/accepted lines per day
- Richer composer metadata: `forceMode`, `modelConfig.modelName`, file change counts, context token usage

### TUI fixes
- Fix client deduplication ("IDE" + "Cursor" appearing separately)
- Stable sort with name tiebreaker to prevent list flickering
- Improved MCP tool name detection with broader pattern matching
- Expanded MCP usage view support

### Other
- Resolve merge conflict in claude hook template (curl-first to daemon socket, spool fallback)

## Test plan
- [x] `make build` succeeds
- [x] Existing tests pass (`make test`)
- [x] New tests for MCP tool filtering and expanded MCP view
- [x] Manual verification: switch time windows in dashboard, confirm sub-second response
- [x] Verify cursor telemetry shows richer data (tokens, daily stats, file paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)