### PR TITLE
feat: synthesize copilot model burn metrics from turn events

### DIFF
--- a/docs/COPILOT_TELEMETRY_INTEGRATION_DESIGN.md
+++ b/docs/COPILOT_TELEMETRY_INTEGRATION_DESIGN.md
@@ -1,0 +1,232 @@
+# Copilot Telemetry Integration — Design Doc
+
+## Problem
+
+The copilot provider is missing **Model Burn** metrics in the dashboard. Investigation reveals that Copilot CLI v0.0.415 defines `assistant.usage` events in its schema (with model, tokens, cost) but **never emits them** to session `events.jsonl` files. Our telemetry collector has working code to parse these events, but there's zero data to parse.
+
+Current state:
+- **11,594** `limit_snapshot` events (from API polling) — working
+- **267** `tool_usage` events (from events.jsonl) — working
+- **0** `message_usage` events — broken, no source data
+
+As a result, the copilot detail view shows tool usage, language breakdown, MCP usage, and code stats — but has a completely empty Model Burn section.
+
+## Data Sources Available
+
+| Source | What's There | What's Missing |
+|--------|-------------|----------------|
+| `events.jsonl` | tool events, session.start (selectedModel), model_change, turn_start/turn_end | assistant.usage (never emitted) |
+| `session-store.db` | turns (user_message, assistant_response), session_files | No token counts |
+| `~/.copilot/logs/*.log` | CompactionProcessor: `Utilization X% (used/limit tokens)` per turn | No per-model breakdown |
+| GitHub API | Plan, quota, features, rate limits | No per-model token/cost data |
+| `session.shutdown` | modelMetrics (per-model requests/cost), code changes | Sessions rarely shut down cleanly |
+
+## Solution
+
+Two-phase approach that delivers value immediately, then adds richer real-time data.
+
+### Phase 1: Synthesize model metrics from existing data (no plugin)
+
+Generate `message_usage` telemetry events from turn sequences already present in session files:
+
+1. **Model tracking**: `session.start` has `selectedModel`, `session.model_change` tracks switches. We know which model is active for each turn.
+
+2. **Turn counting**: `assistant.turn_start`/`assistant.turn_end` pairs represent LLM calls. Each pair = 1 request for the active model.
+
+3. **Token estimation from logs**: CompactionProcessor log lines show `Utilization X% (used/limit tokens)`. Positive deltas between consecutive entries approximate input tokens consumed per turn. This is imprecise but gives us a reasonable signal.
+
+4. **Session shutdown fallback**: When `session.shutdown` events exist, they contain authoritative `modelMetrics` with per-model request counts and costs.
+
+**Output**: For each turn, emit a synthetic `TelemetryEventTypeMessageUsage` event with:
+- `ModelRaw`: active model from session context
+- `Requests`: 1
+- `InputTokens`: estimated from log delta (or nil if unavailable)
+- `OutputTokens`: nil (cannot be estimated)
+
+This gets Model Burn showing immediately — at minimum a "Model Activity" breakdown by request count, with token estimates where available.
+
+### Phase 2: Copilot plugin with hooks (real-time capture)
+
+Copilot CLI supports a **plugin system** with hooks that fire on session events. Create an `openusage` plugin:
+
+```
+~/.copilot/pkg/openusage/
+  plugin.json
+  hooks.json
+  hooks/
+    post-tool-use.sh    — captures tool context + model
+    session-end.sh      — captures session summary with code changes
+```
+
+**Hook types to implement:**
+
+| Hook | Fires When | Data Captured |
+|------|-----------|---------------|
+| `postToolUse` | After each tool execution | toolName, toolArgs (truncated), success, model context, timing |
+| `sessionEnd` | Session terminates | reason, totalPremiumRequests, codeChanges, duration |
+
+**Delivery**: Same pattern as claude code hooks — POST to daemon unix socket, fallback to spool directory.
+
+**Delivery**: Same pattern as claude code hooks — POST to daemon unix socket, fallback to spool directory.
+
+**Integration management**: Add `copilotDef` to `internal/integrations/definitions.go`. Note: the current framework is single-file only (one template → one target file). For a multi-file copilot plugin (plugin.json + hooks.json + scripts), we have two options:
+1. Use `copilot plugin install /local/path` to install from a rendered directory (preferred — leverages copilot's own plugin manager)
+2. Extend the integration framework with multi-file support
+
+Option 1 is simpler: we render the plugin directory, then shell out to `copilot plugin install`. The integration detector checks `copilot plugin list` output.
+
+### Phase 2b: Future — assistant.usage capture
+
+If Copilot CLI starts emitting `assistant.usage` events to `events.jsonl` in a future version, our existing telemetry collector code (telemetry.go lines 576-640) will automatically pick them up with no changes needed. The synthetic turn-based metrics from Phase 1 will be superseded by accurate per-turn token/cost data.
+
+## Implementation Tasks
+
+### Task 1: Synthesize message_usage from turns in telemetry collector
+
+**File**: `internal/providers/copilot/telemetry.go`
+
+Modify `parseCopilotTelemetrySessionFile()`:
+- `currentModel` is already tracked via `session.model_change` and `session.info`. Seed it also from `session.start.selectedModel` (Task 3).
+- Add case for `assistant.turn_end`: if `assistantUsageSeen` is still false, emit a synthetic `TelemetryEventTypeMessageUsage` with the active model and `Requests: 1`
+- Only emit if we have a non-empty model name
+- Use existing `copilotTelemetryBasePayload()` helper for the payload
+- Mark synthetic events with `payload["synthetic"] = true` so they can be distinguished from real assistant.usage events
+
+**Note**: `assistant.turn_start`/`turn_end` are not currently handled in the switch block — they need new cases. The `turnIndex` variable is already tracked.
+
+**Estimated change**: ~25 lines in the existing switch/case block.
+
+### Task 2: Estimate tokens from CompactionProcessor logs
+
+**File**: `internal/providers/copilot/telemetry.go`
+
+New function `parseCopilotLogTokenDeltas(logsDir string) map[string][]logTokenDelta`:
+- Parse all `~/.copilot/logs/*.log` files
+- Extract CompactionProcessor lines with timestamps and token counts
+- Compute positive deltas between consecutive entries
+- Return a time-indexed map of token deltas
+
+In `Collect()`, after parsing session files, cross-reference turn timestamps with log token deltas to attach estimated `InputTokens` to synthetic message_usage events.
+
+**Estimated change**: ~60 lines new function + ~15 lines integration.
+
+### Task 3: Extract selectedModel from session.start
+
+**File**: `internal/providers/copilot/telemetry.go`
+
+The `session.start` event has a `selectedModel` field (confirmed in the copilot schema). The `sessionStartData` struct in `copilot.go` (not telemetry.go) has `SessionID`, `CopilotVersion`, `StartTime`, and `Context` — but no `SelectedModel`. The struct is also used in telemetry.go's `parseCopilotTelemetrySessionFile`.
+
+Add `SelectedModel string \`json:"selectedModel"\`` to `sessionStartData` and seed `currentModel` from it in the `session.start` case (both in copilot.go and telemetry.go).
+
+**Estimated change**: ~5 lines across 2 files.
+
+### Task 4: Create copilot hook scripts
+
+**Files**:
+- `internal/integrations/assets/copilot-post-tool-use.sh.tpl`
+- `internal/integrations/assets/copilot-session-end.sh.tpl`
+
+Follow the claude-hook.sh.tpl pattern:
+- Read JSON from stdin
+- Check `OPENUSAGE_TELEMETRY_ENABLED`
+- POST to daemon unix socket, fallback to spool
+- Payload: `{"source":"copilot","account_id":"copilot","payload":{...}}`
+
+The `postToolUse` hook receives: `sessionId`, `timestamp`, `toolName`, `toolArgs`, `toolResult`, `success`.
+The `sessionEnd` hook receives: `sessionId`, `timestamp`, `reason`, and optionally session-level stats.
+
+**Estimated change**: ~70 lines per script.
+
+### Task 5: Create copilot plugin manifest
+
+**Files**:
+- `internal/integrations/assets/copilot-plugin.json.tpl`
+- `internal/integrations/assets/copilot-hooks.json.tpl`
+
+```json
+// plugin.json
+{
+  "name": "openusage",
+  "description": "OpenUsage telemetry integration for GitHub Copilot CLI",
+  "version": "__OPENUSAGE_INTEGRATION_VERSION__",
+  "hooks": "hooks.json"
+}
+
+// hooks.json
+{
+  "postToolUse": [{ "script": "hooks/post-tool-use.sh", "timeoutSec": 5 }],
+  "sessionEnd": [{ "script": "hooks/session-end.sh", "timeoutSec": 5 }]
+}
+```
+
+**Estimated change**: ~20 lines.
+
+### Task 6: Add copilot integration definition
+
+**File**: `internal/integrations/definitions.go`
+
+The integration framework is single-file only. For the multi-file copilot plugin, use a hybrid approach:
+- `Definition` renders a single hook script (the `postToolUse` hook) as the primary target file
+- The `ConfigPatcher` renders the full plugin directory (plugin.json + hooks.json + hook scripts) to a temp dir, then runs `copilot plugin install /path/to/dir`
+- The `Detector` checks `copilot plugin list` for "openusage" and parses its version
+
+Alternative (simpler for Phase 2): Skip the integration framework entirely and add a dedicated `copilot integration install` CLI subcommand that handles the multi-file setup directly. Register it in the settings modal as a custom action.
+
+**Estimated change**: ~100 lines.
+
+### Task 7: Add ParseHookPayload for copilot
+
+**File**: `internal/providers/copilot/telemetry.go`
+
+Currently `ParseHookPayload` returns `ErrHookUnsupported`. Implement it to parse the hook payloads from Task 4:
+- `postToolUse` payloads → `TelemetryEventTypeToolUsage` events (with richer context than events.jsonl)
+- `sessionEnd` payloads → `TelemetryEventTypeTurnCompleted` events with code change metadata
+
+**Estimated change**: ~50 lines.
+
+### Task 8: Tests
+
+**File**: `internal/providers/copilot/telemetry_test.go`
+
+- Test synthetic message_usage generation from turn sequences
+- Test selectedModel extraction from session.start
+- Test log token delta parsing
+- Test ParseHookPayload for both hook types
+- Test integration definition detection
+
+**Estimated change**: ~150 lines.
+
+## Task Ordering
+
+```
+Task 3 (selectedModel extraction)     ← prerequisite for Task 1
+Task 1 (synthetic message_usage)      ← core fix, enables model burn
+Task 2 (log token estimation)         ← enrichment, can be parallel with Task 1
+Task 8 (tests for Tasks 1-3)          ← after Tasks 1-3
+
+Task 4 (hook scripts)                 ← independent
+Task 5 (plugin manifest)              ← independent
+Task 6 (integration definition)       ← depends on Tasks 4-5
+Task 7 (ParseHookPayload)             ← depends on Task 4 payload format
+Task 8 (tests for Tasks 4-7)          ← after Tasks 4-7
+```
+
+Phase 1 (Tasks 1-3 + tests) can ship independently.
+Phase 2 (Tasks 4-7 + tests) can ship as a follow-up.
+
+## Non-goals
+
+- **Capturing assistant.usage at hook time**: These events are ephemeral in the copilot runtime and not exposed to the hook context. We cannot intercept them.
+- **Per-turn cost estimation**: Without assistant.usage, we don't know costs. We show request counts and estimated tokens, not costs.
+- **Modifying copilot's events.jsonl format**: We work with what copilot gives us.
+- **preToolUse hooks**: We don't need to block or modify tool execution, only observe.
+
+## Risks
+
+1. **Token estimation accuracy**: CompactionProcessor log deltas are approximate. Token counts may be off by 10-30%. This is acceptable for a "Model Burn" overview — the metric labels will indicate estimates where applicable.
+
+2. **Log file rotation**: Copilot may rotate log files. We scan all available logs on each collection cycle. Historical data may be lost if logs are cleaned up.
+
+3. **Plugin format stability**: Copilot CLI plugin system is new (GA Feb 2026). The manifest format may change. We pin to a version and detect incompatibilities in the integration status check.
+
+4. **Session state rotation**: Copilot aggressively rotates `session-state/` directories. The session-store.db fallback already handles this for tool events. Synthetic message_usage events may be incomplete for rotated sessions.

--- a/internal/providers/copilot/copilot.go
+++ b/internal/providers/copilot/copilot.go
@@ -220,6 +220,7 @@ type sessionStartData struct {
 	SessionID      string `json:"sessionId"`
 	CopilotVersion string `json:"copilotVersion"`
 	StartTime      string `json:"startTime"`
+	SelectedModel  string `json:"selectedModel"`
 	Context        struct {
 		CWD        string `json:"cwd"`
 		GitRoot    string `json:"gitRoot"`
@@ -1071,6 +1072,9 @@ func (p *Provider) readSessions(copilotDir string, snap *core.UsageSnapshot, log
 						}
 						if si.createdAt.IsZero() {
 							si.createdAt = flexParseTime(start.StartTime)
+						}
+						if currentModel == "" && start.SelectedModel != "" {
+							currentModel = start.SelectedModel
 						}
 					}
 

--- a/internal/providers/copilot/telemetry.go
+++ b/internal/providers/copilot/telemetry.go
@@ -1,13 +1,16 @@
 package copilot
 
 import (
+	"bufio"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +23,7 @@ const (
 	telemetrySchemaVersion   = "copilot_v2"
 	defaultCopilotSessionDir = ".copilot/session-state"
 	defaultCopilotStoreDB    = ".copilot/session-store.db"
+	defaultCopilotLogsDir    = ".copilot/logs"
 )
 
 type copilotTelemetryAssistantMessageData struct {
@@ -107,6 +111,14 @@ func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOpti
 	if err == nil {
 		out = append(out, storeEvents...)
 	}
+
+	// Enrich synthetic message_usage events with estimated token counts from
+	// CompactionProcessor log entries.
+	logsDir := shared.ExpandHome(opts.Path("logs_dir", defaultCopilotLogsPath()))
+	if deltas := parseCopilotLogTokenDeltas(logsDir); len(deltas) > 0 {
+		enrichSyntheticTokenEstimates(out, deltas)
+	}
+
 	return out, nil
 }
 
@@ -177,6 +189,9 @@ func parseCopilotTelemetrySessionFile(path, sessionID string) ([]shared.Telemetr
 					workspaceID = shared.SanitizeWorkspace(start.Context.CWD)
 				}
 				clientLabel = normalizeCopilotClient(repo, cwd)
+				if currentModel == "" && start.SelectedModel != "" {
+					currentModel = start.SelectedModel
+				}
 			}
 
 		case "session.context_changed":
@@ -569,6 +584,38 @@ func parseCopilotTelemetrySessionFile(path, sessionID string) ([]shared.Telemetr
 				ModelRaw:      model,
 				ToolName:      "workspace_file_" + op,
 				Requests:      shared.Int64Ptr(0),
+				Status:        shared.TelemetryStatusOK,
+				Payload:       payload,
+			})
+
+		case "assistant.turn_start":
+			// Track turn starts; actual metric emission happens at turn_end.
+			continue
+
+		case "assistant.turn_end":
+			turnIndex++
+			if assistantUsageSeen || currentModel == "" {
+				continue
+			}
+			turnID := shared.FirstNonEmpty(strings.TrimSpace(evt.ID), fmt.Sprintf("%s:synth:%d", sessionID, turnIndex))
+			messageID := fmt.Sprintf("%s:%d", sessionID, lineNum+1)
+			payload := copilotTelemetryBasePayload(path, lineNum+1, clientLabel, repo, cwd, "assistant.turn_end")
+			payload["synthetic"] = true
+			payload["upstream_provider"] = copilotUpstreamProviderForModel(currentModel)
+			out = append(out, shared.TelemetryEvent{
+				SchemaVersion: telemetrySchemaVersion,
+				Channel:       shared.TelemetryChannelJSONL,
+				OccurredAt:    occurredAt,
+				AccountID:     "copilot",
+				WorkspaceID:   workspaceID,
+				SessionID:     sessionID,
+				TurnID:        turnID,
+				MessageID:     messageID,
+				ProviderID:    "copilot",
+				AgentName:     "copilot",
+				EventType:     shared.TelemetryEventTypeMessageUsage,
+				ModelRaw:      currentModel,
+				Requests:      shared.Int64Ptr(1),
 				Status:        shared.TelemetryStatusOK,
 				Payload:       payload,
 			})
@@ -1486,6 +1533,125 @@ func parseCopilotTelemetrySessionStore(ctx context.Context, dbPath string, skipS
 	}
 
 	return out, nil
+}
+
+// logTokenDelta represents a token count observation from CompactionProcessor logs.
+type logTokenDelta struct {
+	Timestamp time.Time
+	Used      int64
+	Limit     int64
+}
+
+// compactionRe matches CompactionProcessor utilization log lines.
+// Example: 2026-02-21T19:45:41.056Z [INFO] CompactionProcessor: Utilization 16.0% (20465/128000 tokens)
+var compactionRe = regexp.MustCompile(
+	`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+\[INFO\]\s+CompactionProcessor:\s+Utilization\s+[\d.]+%\s+\((\d+)/(\d+)\s+tokens\)`,
+)
+
+// parseCopilotLogTokenDeltas parses CompactionProcessor log entries and returns
+// estimated token deltas (positive differences between consecutive entries).
+func parseCopilotLogTokenDeltas(logsDir string) []logTokenDelta {
+	if logsDir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		return nil
+	}
+
+	var observations []logTokenDelta
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".log") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(logsDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			m := compactionRe.FindStringSubmatch(scanner.Text())
+			if m == nil {
+				continue
+			}
+			ts, err := time.Parse(time.RFC3339Nano, m[1])
+			if err != nil {
+				continue
+			}
+			used, _ := strconv.ParseInt(m[2], 10, 64)
+			limit, _ := strconv.ParseInt(m[3], 10, 64)
+			observations = append(observations, logTokenDelta{Timestamp: ts, Used: used, Limit: limit})
+		}
+		f.Close()
+	}
+
+	if len(observations) < 2 {
+		return nil
+	}
+
+	sort.Slice(observations, func(i, j int) bool {
+		return observations[i].Timestamp.Before(observations[j].Timestamp)
+	})
+
+	// Compute positive deltas — each delta represents approximate tokens consumed
+	// between consecutive CompactionProcessor observations.
+	var deltas []logTokenDelta
+	for i := 1; i < len(observations); i++ {
+		diff := observations[i].Used - observations[i-1].Used
+		if diff > 0 {
+			deltas = append(deltas, logTokenDelta{
+				Timestamp: observations[i].Timestamp,
+				Used:      diff,
+				Limit:     observations[i].Limit,
+			})
+		}
+	}
+	return deltas
+}
+
+// enrichSyntheticTokenEstimates attaches estimated InputTokens to synthetic
+// message_usage events by matching event timestamps to log token deltas.
+func enrichSyntheticTokenEstimates(events []shared.TelemetryEvent, deltas []logTokenDelta) {
+	if len(deltas) == 0 {
+		return
+	}
+	for i := range events {
+		ev := &events[i]
+		if ev.EventType != shared.TelemetryEventTypeMessageUsage || ev.InputTokens != nil {
+			continue
+		}
+		if len(ev.Payload) == 0 {
+			continue
+		}
+		if syn, _ := ev.Payload["synthetic"].(bool); !syn {
+			continue
+		}
+		// Find the closest delta within 30 seconds of the event.
+		var bestDelta *logTokenDelta
+		bestGap := 30 * time.Second
+		for j := range deltas {
+			gap := ev.OccurredAt.Sub(deltas[j].Timestamp)
+			if gap < 0 {
+				gap = -gap
+			}
+			if gap < bestGap {
+				bestGap = gap
+				bestDelta = &deltas[j]
+			}
+		}
+		if bestDelta != nil {
+			ev.InputTokens = shared.Int64Ptr(bestDelta.Used)
+			ev.Payload["estimated_tokens"] = true
+		}
+	}
+}
+
+func defaultCopilotLogsPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, defaultCopilotLogsDir)
 }
 
 func copilotTelemetryTableExists(ctx context.Context, db *sql.DB, table string) bool {

--- a/internal/providers/copilot/telemetry_test.go
+++ b/internal/providers/copilot/telemetry_test.go
@@ -533,3 +533,250 @@ func findToolEventByName(events []shared.TelemetryEvent, toolName string) (share
 	}
 	return shared.TelemetryEvent{}, false
 }
+
+func TestSyntheticMessageUsageFromTurnEnd(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "session-synth-1"
+	eventsPath := filepath.Join(tmpDir, "events.jsonl")
+
+	events := []map[string]any{
+		{
+			"type":      "session.start",
+			"timestamp": "2026-03-01T10:00:00Z",
+			"data": map[string]any{
+				"sessionId":      sessionID,
+				"copilotVersion": "0.0.500",
+				"startTime":      "2026-03-01T10:00:00Z",
+				"selectedModel":  "claude-sonnet-4.5",
+			},
+		},
+		{
+			"type":      "assistant.turn_start",
+			"timestamp": "2026-03-01T10:00:10Z",
+			"data":      map[string]any{},
+		},
+		{
+			"type":      "assistant.turn_end",
+			"timestamp": "2026-03-01T10:00:20Z",
+			"id":        "turn-end-1",
+			"data":      map[string]any{},
+		},
+		{
+			"type":      "assistant.turn_start",
+			"timestamp": "2026-03-01T10:01:00Z",
+			"data":      map[string]any{},
+		},
+		{
+			"type":      "assistant.turn_end",
+			"timestamp": "2026-03-01T10:01:30Z",
+			"id":        "turn-end-2",
+			"data":      map[string]any{},
+		},
+	}
+	writeCopilotTelemetryEvents(t, eventsPath, events)
+
+	result, err := parseCopilotTelemetrySessionFile(eventsPath, sessionID)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var syntheticEvents []shared.TelemetryEvent
+	for _, ev := range result {
+		if ev.EventType == shared.TelemetryEventTypeMessageUsage {
+			syntheticEvents = append(syntheticEvents, ev)
+		}
+	}
+
+	if len(syntheticEvents) != 2 {
+		t.Fatalf("expected 2 synthetic message_usage events, got %d", len(syntheticEvents))
+	}
+
+	for i, ev := range syntheticEvents {
+		if ev.ModelRaw != "claude-sonnet-4.5" {
+			t.Errorf("event %d: expected model claude-sonnet-4.5, got %s", i, ev.ModelRaw)
+		}
+		if ev.Requests == nil || *ev.Requests != 1 {
+			t.Errorf("event %d: expected Requests=1", i)
+		}
+		if ev.InputTokens != nil {
+			t.Errorf("event %d: expected InputTokens=nil for unenriched event", i)
+		}
+		syn, _ := ev.Payload["synthetic"].(bool)
+		if !syn {
+			t.Errorf("event %d: expected synthetic=true in payload", i)
+		}
+	}
+}
+
+func TestSyntheticMessageUsage_SuppressedByRealUsage(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "session-synth-suppress"
+	eventsPath := filepath.Join(tmpDir, "events.jsonl")
+
+	events := []map[string]any{
+		{
+			"type":      "session.start",
+			"timestamp": "2026-03-01T10:00:00Z",
+			"data": map[string]any{
+				"sessionId":      sessionID,
+				"copilotVersion": "0.0.500",
+				"startTime":      "2026-03-01T10:00:00Z",
+				"selectedModel":  "gpt-4o",
+			},
+		},
+		{
+			"type":      "assistant.usage",
+			"timestamp": "2026-03-01T10:00:15Z",
+			"id":        "usage-1",
+			"data": map[string]any{
+				"model":        "gpt-4o",
+				"inputTokens":  500,
+				"outputTokens": 100,
+			},
+		},
+		{
+			"type":      "assistant.turn_end",
+			"timestamp": "2026-03-01T10:00:20Z",
+			"id":        "turn-end-1",
+			"data":      map[string]any{},
+		},
+	}
+	writeCopilotTelemetryEvents(t, eventsPath, events)
+
+	result, err := parseCopilotTelemetrySessionFile(eventsPath, sessionID)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var messageUsageEvents []shared.TelemetryEvent
+	for _, ev := range result {
+		if ev.EventType == shared.TelemetryEventTypeMessageUsage {
+			messageUsageEvents = append(messageUsageEvents, ev)
+		}
+	}
+
+	// Should have exactly 1 event from assistant.usage, not a synthetic one from turn_end
+	if len(messageUsageEvents) != 1 {
+		t.Fatalf("expected 1 message_usage event (from real assistant.usage), got %d", len(messageUsageEvents))
+	}
+	if messageUsageEvents[0].InputTokens == nil || *messageUsageEvents[0].InputTokens != 500 {
+		t.Error("expected real assistant.usage event with InputTokens=500")
+	}
+}
+
+func TestSelectedModelFromSessionStart(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionID := "session-model-seed"
+	eventsPath := filepath.Join(tmpDir, "events.jsonl")
+
+	events := []map[string]any{
+		{
+			"type":      "session.start",
+			"timestamp": "2026-03-01T10:00:00Z",
+			"data": map[string]any{
+				"sessionId":      sessionID,
+				"copilotVersion": "0.0.500",
+				"startTime":      "2026-03-01T10:00:00Z",
+				"selectedModel":  "o3-mini",
+			},
+		},
+		{
+			"type":      "assistant.turn_end",
+			"timestamp": "2026-03-01T10:00:20Z",
+			"id":        "turn-end-1",
+			"data":      map[string]any{},
+		},
+	}
+	writeCopilotTelemetryEvents(t, eventsPath, events)
+
+	result, err := parseCopilotTelemetrySessionFile(eventsPath, sessionID)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	var found bool
+	for _, ev := range result {
+		if ev.EventType == shared.TelemetryEventTypeMessageUsage && ev.ModelRaw == "o3-mini" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected synthetic message_usage event with model=o3-mini from selectedModel")
+	}
+}
+
+func TestParseCopilotLogTokenDeltas(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	logContent := `2026-02-21T19:45:41.056Z [INFO] CompactionProcessor: Utilization 16.0% (20465/128000 tokens) below threshold 80%
+2026-02-21T19:45:44.145Z [INFO] CompactionProcessor: Utilization 16.5% (21063/128000 tokens) below threshold 80%
+2026-02-21T19:45:46.896Z [INFO] CompactionProcessor: Utilization 21.5% (27463/128000 tokens) below threshold 80%
+2026-02-21T19:46:05.556Z [INFO] Some other log line
+2026-02-21T19:46:20.897Z [INFO] CompactionProcessor: Utilization 21.6% (27708/128000 tokens) below threshold 80%
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "process-1.log"), []byte(logContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	deltas := parseCopilotLogTokenDeltas(tmpDir)
+	if len(deltas) == 0 {
+		t.Fatal("expected non-empty deltas")
+	}
+
+	// 4 observations → up to 3 deltas (only positive ones)
+	// Delta 1: 21063 - 20465 = 598
+	// Delta 2: 27463 - 21063 = 6400
+	// Delta 3: 27708 - 27463 = 245
+	expectedDeltas := []int64{598, 6400, 245}
+	if len(deltas) != len(expectedDeltas) {
+		t.Fatalf("expected %d deltas, got %d", len(expectedDeltas), len(deltas))
+	}
+	for i, d := range deltas {
+		if d.Used != expectedDeltas[i] {
+			t.Errorf("delta %d: expected %d, got %d", i, expectedDeltas[i], d.Used)
+		}
+	}
+}
+
+func TestEnrichSyntheticTokenEstimates(t *testing.T) {
+	ts := shared.FlexParseTime("2026-02-21T19:45:44Z")
+
+	events := []shared.TelemetryEvent{
+		{
+			EventType:  shared.TelemetryEventTypeMessageUsage,
+			OccurredAt: ts,
+			Payload:    map[string]any{"synthetic": true},
+		},
+		{
+			// Real event — should not be modified
+			EventType:   shared.TelemetryEventTypeMessageUsage,
+			OccurredAt:  ts,
+			InputTokens: shared.Int64Ptr(500),
+			Payload:     map[string]any{},
+		},
+	}
+
+	deltas := []logTokenDelta{
+		{Timestamp: shared.FlexParseTime("2026-02-21T19:45:44.145Z"), Used: 598, Limit: 128000},
+		{Timestamp: shared.FlexParseTime("2026-02-21T19:45:46.896Z"), Used: 6400, Limit: 128000},
+	}
+
+	enrichSyntheticTokenEstimates(events, deltas)
+
+	if events[0].InputTokens == nil {
+		t.Fatal("expected synthetic event to be enriched with InputTokens")
+	}
+	if *events[0].InputTokens != 598 {
+		t.Errorf("expected InputTokens=598 (closest delta), got %d", *events[0].InputTokens)
+	}
+	est, _ := events[0].Payload["estimated_tokens"].(bool)
+	if !est {
+		t.Error("expected estimated_tokens=true in payload")
+	}
+
+	// Real event should be untouched
+	if *events[1].InputTokens != 500 {
+		t.Errorf("real event should still have InputTokens=500, got %d", *events[1].InputTokens)
+	}
+}


### PR DESCRIPTION
## Summary

- synthesize `message_usage` telemetry events from copilot `assistant.turn_end` sequences, fixing empty model burn section
- seed model tracking from `session.start.selectedModel` and `session.model_change` events
- estimate input tokens from CompactionProcessor log deltas in `~/.copilot/logs/*.log`
- suppress synthetic events when real `assistant.usage` events exist (future-proof)

## Context

Copilot CLI v0.0.415 defines `assistant.usage` events in its schema (with model, tokens, cost) but never emits them to session `events.jsonl` files. This left the copilot detail view with zero model burn data despite having 11k+ limit_snapshot and 267 tool_usage events.

Phase 1 of the design doc (`docs/COPILOT_TELEMETRY_INTEGRATION_DESIGN.md`) — synthesizes metrics from existing data without requiring a copilot plugin.

## Changes

- `copilot.go`: add `SelectedModel` field to `sessionStartData`, seed `currentModel`
- `telemetry.go`: handle `assistant.turn_start`/`turn_end`, emit synthetic `message_usage`, parse CompactionProcessor logs for token estimation
- `telemetry_test.go`: 5 new tests (synthetic generation, suppression, model seeding, log parsing, enrichment)

## Test plan

- [x] all copilot tests pass including 5 new ones
- [x] full test suite passes with `-race`
- [x] verified 151 synthetic events generated from real session data (claude-haiku-4.5, gpt-4.1, gpt-5-mini)
- [x] verified events ingested into telemetry DB with correct model_raw values