### PR TITLE
Add telemetry-based project breakdown dashboard section

### DIFF
--- a/docs/PROJECT_BREAKDOWN_SECTION_DESIGN.md
+++ b/docs/PROJECT_BREAKDOWN_SECTION_DESIGN.md
@@ -1,0 +1,198 @@
+# Project Breakdown Dashboard Section Design
+
+Date: 2026-03-06
+Status: Proposed
+Author: Codex
+
+## 0. Pre-Design Quiz Answers
+
+1. Problem solved: dashboard tiles do not show per-project (PWD/workspace) request share, so users cannot see how work splits across repositories/projects.
+2. Beneficiaries: end users primarily; contributors secondarily (clearer telemetry dimensions and section architecture).
+3. Affected subsystems: core types, TUI, telemetry, providers (audit/compat only).
+4. Out of scope: retrofitting non-telemetry API providers with synthetic project attribution; per-provider custom naming/rules for project buckets.
+5. Overlapping docs: `UNIFIED_AGENT_USAGE_TRACKING_DESIGN.md` (workspace dimension in canonical events), `PROVIDER_WIDGET_SECTION_SETTINGS_DESIGN.md` (normalized section framework), `MCP_USAGE_SECTION_DESIGN.md` (pattern for adding a new dashboard section).
+6. Simplest MVP: add a new dashboard tile section that reads telemetry-derived `project_*_requests` metrics (workspace/PWD based) and renders percent breakdown per provider.
+7. Public interfaces changed: `core.DashboardStandardSection` adds one new normalized section ID (`project_breakdown`).
+8. Backward compatibility: additive only; providers without workspace data simply do not render this section.
+
+## 1. Problem Statement
+
+OpenUsage currently shows model/client/language/tool breakdowns, but it does not expose request distribution by project workspace (PWD), so users cannot answer "what percent of my requests went to each project".
+
+## 2. Goals
+
+1. Add a dedicated dashboard section for project/PWD request breakdown per provider.
+2. Aggregate project counts from canonical telemetry `workspace_id` (not client/source heuristics).
+3. Preserve existing client/language/model sections and behavior.
+4. Ensure section participates in global widget section ordering/toggling.
+5. Provide deterministic tests for telemetry aggregation and tile rendering.
+
+## 3. Non-Goals
+
+1. Adding new CLI commands, daemon APIs, or settings schema fields.
+2. Backfilling project data for providers that do not emit workspace/PWD information.
+3. Renaming existing `client_*` semantics or reworking the client composition model.
+4. Introducing filesystem path storage beyond current sanitized workspace basename handling.
+
+## 4. Impact Analysis
+
+### 4.1 Affected Subsystems
+
+| Subsystem | Impact | Summary |
+|-----------|--------|---------|
+| core types | minor | Add `project_breakdown` dashboard section constant and default ordering support |
+| providers | minor | No fetch contract changes; verify capability matrix and compatibility |
+| TUI | major | New tile section builder + section wiring + used-key tracking |
+| config | none | Existing widget section config supports new section ID automatically |
+| detect | none | No detection changes |
+| daemon | none | No daemon protocol changes |
+| telemetry | major | New workspace/project aggregation query + metric/daily-series emission |
+| CLI | none | No command or flag changes |
+
+### 4.2 Existing Design Doc Overlap
+
+- `UNIFIED_AGENT_USAGE_TRACKING_DESIGN.md`: this design implements the serving-layer "project/workspace" dimension for dashboard tiles.
+- `PROVIDER_WIDGET_SECTION_SETTINGS_DESIGN.md`: this design extends normalized section IDs and leverages existing section ordering/toggle configuration.
+- `MCP_USAGE_SECTION_DESIGN.md`: reused implementation pattern (new telemetry aggregate + new TUI section + standard section ID).
+
+### 4.3 Provider Capability Audit (All Providers)
+
+| Provider | Main data path today | Workspace/PWD signal available for request attribution | Project breakdown support in MVP |
+|----------|----------------------|---------------------------------------------------------|----------------------------------|
+| `openai` | API headers/limits | No | No |
+| `anthropic` | API headers/limits | No | No |
+| `alibaba_cloud` | API headers/limits | No | No |
+| `openrouter` | API analytics/generations | No PWD/workspace dimension | No |
+| `groq` | API headers/limits | No | No |
+| `mistral` | API headers/limits | No | No |
+| `deepseek` | API headers/limits | No | No |
+| `xai` | API headers/limits | No | No |
+| `zai` | API monitor endpoints | No PWD/workspace dimension | No |
+| `gemini_api` | API headers/limits | No | No |
+| `gemini_cli` | local session telemetry | Not currently emitted as `workspace_id` | No (future possible) |
+| `ollama` | local SQLite telemetry | No workspace on emitted events | No |
+| `cursor` | local SQLite telemetry | Not currently emitted as `workspace_id` | No (future possible) |
+| `copilot` | local telemetry/SQLite | Yes (`cwd` -> sanitized workspace) | Yes |
+| `claude_code` | local JSONL + hook telemetry | Yes (`cwd` -> sanitized workspace) | Yes |
+| `codex` | local JSONL + hook telemetry | Yes (`cwd`/hook workspace fields) | Yes |
+| `opencode` | hook + JSONL + SQLite telemetry | Yes (`path.cwd`/`path.root`) | Yes |
+
+Notes:
+- Current canonical usage view uses client heuristics that frequently prefer `source_system` over workspace. This design intentionally adds a separate project aggregate directly from `workspace_id`.
+- `claude_code` non-telemetry fetch already has project-like totals in `Raw`, but not in windowed per-request form required for this feature.
+
+## 5. Detailed Design
+
+### 5.1 Telemetry: Add Project Aggregation by Workspace
+
+Extend canonical usage aggregation to compute project/workspace request totals from `workspace_id` only:
+
+- Add `telemetryProjectAgg` to `internal/telemetry/usage_view.go`.
+- Add `Projects []telemetryProjectAgg` and `ProjectDaily map[string][]core.TimePoint` to `telemetryUsageAgg`.
+- Add `queryProjectAgg(...)`:
+  - Source: `deduped_usage`
+  - Filter: `event_type='message_usage'`, `status!='error'`, non-empty `workspace_id`
+  - Group: workspace id
+  - Metrics: total requests + requests_today
+- Extend `queryDailyByDimension(..., "project")` to emit per-day request series by workspace.
+
+Metric and series emission in `applyUsageViewToSnapshot`:
+
+- `project_<workspace>_requests`
+- `project_<workspace>_requests_today`
+- `DailySeries["usage_project_<workspace>"]`
+
+Cleanup updates:
+
+- Remove stale project metrics/series when rebuilding canonical view (same behavior as existing `model_`, `client_`, etc.).
+
+### 5.2 Core: Add Standard Section ID
+
+In `internal/core/widget.go`:
+
+- Add `DashboardSectionProjectBreakdown DashboardStandardSection = "project_breakdown"`.
+- Add to:
+  - `defaultDashboardSectionOrder()`
+  - `isKnownDashboardSection(...)`
+
+Placement in default order: after `client_burn` and before `tool_usage`.
+
+Rationale: project split is a composition view adjacent to model/client composition.
+
+### 5.3 TUI: New Project Breakdown Section
+
+In `internal/tui/tiles.go`:
+
+- Add `projectMixEntry` type (name, requests, series).
+- Add `collectProviderProjectMix(snap)`:
+  - Primary source: `project_*_requests` metrics
+  - Fallback: sum `usage_project_*` daily series when aggregate metric absent
+- Add `buildProviderProjectBreakdownLines(snap, innerW, expanded)`:
+  - Heading: `Project Breakdown  <N req>`
+  - Stacked bar similar to language/client sections
+  - Rows: `■ rank project-name .... xx% <requests> req`
+  - Collapsed/expanded top-N behavior consistent with other composition sections
+- Wire into section map in `renderTile(...)` and mark consumed keys.
+
+No extra provider opt-in flag is required; the section renders only when project data exists.
+
+### 5.4 Backward Compatibility and Data Behavior
+
+- Additive constants/metrics only.
+- Existing client/language/model sections unchanged.
+- Providers lacking workspace telemetry render no project section (no placeholder to avoid noise).
+- Existing `dashboard.widget_sections` remains valid; unknown IDs are already filtered, and the new known ID becomes available automatically.
+
+## 6. Alternatives Considered
+
+### Alternative A: Reuse `client_*` as project breakdown
+
+Rejected. `client_*` is intentionally heuristic and often maps to `source_system` (`codex`, `claude_code`, etc.) or UI client labels, not workspace/PWD.
+
+### Alternative B: Infer project from file paths in tool payload only
+
+Rejected for MVP. Tool events are partial and not equivalent to request-level attribution; message usage rows already carry cleaner workspace IDs where available.
+
+### Alternative C: Add per-provider custom extraction rules in TUI only
+
+Rejected. Project attribution belongs in telemetry aggregation layer so all consumers (TUI/detail/future exports) share one source of truth.
+
+## 7. Implementation Tasks
+
+### Task 1: Add canonical telemetry project aggregation
+Files: `internal/telemetry/usage_view.go`, `internal/telemetry/usage_view_test.go`
+Depends on: none
+Description: Add project aggregation structs/queries, emit `project_*` metrics and `usage_project_*` daily series from workspace data, and include cleanup of stale project series in canonical overwrite flow.
+Tests: Add/extend usage view tests verifying workspace-derived project request metrics/series and non-regression of client behavior.
+
+### Task 2: Add normalized dashboard section ID for project breakdown
+Files: `internal/core/widget.go`, `internal/core/widget_test.go`
+Depends on: none
+Description: Add new `project_breakdown` section constant and include it in default/known section order logic.
+Tests: Update section-order tests to assert presence and stable ordering.
+
+### Task 3: Implement dashboard project breakdown renderer
+Files: `internal/tui/tiles.go`, `internal/tui/tiles_normalization_test.go`
+Depends on: Task 1, Task 2
+Description: Implement project mix collection + section rendering (bar + rows + hidden-count behavior), wire section into tile assembly, and mark consumed metric keys.
+Tests: Add tests for project mix extraction from `project_*_requests` and daily-series fallback; add rendering smoke test assertions.
+
+### Task 4: Verify widget section configuration integration
+Files: `internal/tui/settings_widget_sections_test.go` (and any failing section-order tests)
+Depends on: Task 2
+Description: Ensure settings/UI expectations remain correct with the new standard section inserted in canonical order.
+Tests: Update expected section-order assertions where order prefixes are validated.
+
+### Task 5: Integration verification
+Files: none (verification only)
+Depends on: Tasks 1-4
+Description: Run build/tests/vet/lint for changed scope and confirm no regressions.
+Tests: `make build`, changed-package tests with `-race`, `make vet`, `make lint` (skip if unavailable).
+
+### Dependency Graph
+
+- Tasks 1 and 2: parallel (telemetry and core constants independent)
+- Task 3: depends on 1 and 2
+- Task 4: depends on 2
+- Task 5: depends on 1-4
+

--- a/internal/core/widget.go
+++ b/internal/core/widget.go
@@ -93,6 +93,7 @@ const (
 	DashboardSectionTopUsageProgress DashboardStandardSection = "top_usage_progress"
 	DashboardSectionModelBurn        DashboardStandardSection = "model_burn"
 	DashboardSectionClientBurn       DashboardStandardSection = "client_burn"
+	DashboardSectionProjectBreakdown DashboardStandardSection = "project_breakdown"
 	DashboardSectionToolUsage        DashboardStandardSection = "tool_usage"
 	// DashboardSectionActualToolUsage is a legacy section ID kept for backward compatibility.
 	// It is normalized to DashboardSectionToolUsage at runtime and config load.
@@ -112,6 +113,7 @@ func defaultDashboardSectionOrder() []DashboardStandardSection {
 		DashboardSectionTopUsageProgress,
 		DashboardSectionModelBurn,
 		DashboardSectionClientBurn,
+		DashboardSectionProjectBreakdown,
 		DashboardSectionToolUsage,
 		DashboardSectionMCPUsage,
 		DashboardSectionLanguageBurn,
@@ -140,6 +142,7 @@ func isKnownDashboardSection(section DashboardStandardSection) bool {
 		DashboardSectionTopUsageProgress,
 		DashboardSectionModelBurn,
 		DashboardSectionClientBurn,
+		DashboardSectionProjectBreakdown,
 		DashboardSectionToolUsage,
 		DashboardSectionMCPUsage,
 		DashboardSectionLanguageBurn,

--- a/internal/core/widget_test.go
+++ b/internal/core/widget_test.go
@@ -10,6 +10,7 @@ func TestDefaultDashboardWidget_StandardSectionOrder(t *testing.T) {
 		DashboardSectionTopUsageProgress,
 		DashboardSectionModelBurn,
 		DashboardSectionClientBurn,
+		DashboardSectionProjectBreakdown,
 		DashboardSectionToolUsage,
 		DashboardSectionMCPUsage,
 		DashboardSectionLanguageBurn,

--- a/internal/telemetry/usage_view.go
+++ b/internal/telemetry/usage_view.go
@@ -39,6 +39,12 @@ type telemetrySourceAgg struct {
 	Sessions   float64
 }
 
+type telemetryProjectAgg struct {
+	Project    string
+	Requests   float64
+	Requests1d float64
+}
+
 type telemetryToolAgg struct {
 	Tool           string
 	Calls          float64
@@ -110,6 +116,7 @@ type telemetryUsageAgg struct {
 	Models       []telemetryModelAgg
 	Providers    []telemetryProviderAgg
 	Sources      []telemetrySourceAgg
+	Projects     []telemetryProjectAgg
 	Tools        []telemetryToolAgg
 	MCPServers   []telemetryMCPServerAgg
 	Languages    []telemetryLanguageAgg
@@ -118,6 +125,7 @@ type telemetryUsageAgg struct {
 	Daily        []telemetryDayPoint
 	ModelDaily   map[string][]core.TimePoint
 	SourceDaily  map[string][]core.TimePoint
+	ProjectDaily map[string][]core.TimePoint
 	ClientDaily  map[string][]core.TimePoint
 	ClientTokens map[string][]core.TimePoint
 }
@@ -258,6 +266,7 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 			strings.HasPrefix(key, "client_") ||
 			strings.HasPrefix(key, "tool_") ||
 			strings.HasPrefix(key, "model_") ||
+			strings.HasPrefix(key, "project_") ||
 			strings.HasPrefix(key, "provider_") ||
 			strings.HasPrefix(key, "lang_") ||
 			strings.HasPrefix(key, "interface_") ||
@@ -280,6 +289,7 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 			strings.HasPrefix(key, "client_") ||
 			strings.HasPrefix(key, "tool_") ||
 			strings.HasPrefix(key, "model_") ||
+			strings.HasPrefix(key, "project_") ||
 			strings.HasPrefix(key, "provider_") ||
 			strings.HasPrefix(key, "lang_") ||
 			strings.HasPrefix(key, "jsonl_") ||
@@ -293,6 +303,7 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 			strings.HasPrefix(key, "client_") ||
 			strings.HasPrefix(key, "tool_") ||
 			strings.HasPrefix(key, "model_") ||
+			strings.HasPrefix(key, "project_") ||
 			strings.HasPrefix(key, "provider_") ||
 			strings.HasPrefix(key, "usage_") ||
 			strings.HasPrefix(key, "analytics_") {
@@ -304,6 +315,7 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 			strings.HasPrefix(key, "client_") ||
 			strings.HasPrefix(key, "tool_") ||
 			strings.HasPrefix(key, "model_") ||
+			strings.HasPrefix(key, "project_") ||
 			strings.HasPrefix(key, "provider_") ||
 			strings.HasPrefix(key, "usage_") ||
 			strings.HasPrefix(key, "analytics_") {
@@ -313,6 +325,7 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 	for key := range snap.DailySeries {
 		if strings.HasPrefix(key, "usage_model_") ||
 			strings.HasPrefix(key, "usage_source_") ||
+			strings.HasPrefix(key, "usage_project_") ||
 			strings.HasPrefix(key, "usage_client_") ||
 			strings.HasPrefix(key, "tokens_client_") ||
 			key == "analytics_cost" ||
@@ -405,6 +418,14 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 		snap.Metrics["client_"+sk+"_reasoning_tokens"] = core.Metric{Used: core.Float64Ptr(source.Reasoning), Unit: "tokens", Window: timeWindow}
 		snap.Metrics["client_"+sk+"_requests"] = core.Metric{Used: core.Float64Ptr(source.Requests), Unit: "requests", Window: timeWindow}
 		snap.Metrics["client_"+sk+"_sessions"] = core.Metric{Used: core.Float64Ptr(source.Sessions), Unit: "sessions", Window: timeWindow}
+	}
+	for _, project := range agg.Projects {
+		pk := sanitizeMetricID(project.Project)
+		if pk == "" {
+			continue
+		}
+		snap.Metrics["project_"+pk+"_requests"] = core.Metric{Used: core.Float64Ptr(project.Requests), Unit: "requests", Window: timeWindow}
+		snap.Metrics["project_"+pk+"_requests_today"] = core.Metric{Used: core.Float64Ptr(project.Requests1d), Unit: "requests", Window: "1d"}
 	}
 
 	var totalToolCalls float64
@@ -523,6 +544,9 @@ func applyUsageViewToSnapshot(snap *core.UsageSnapshot, agg *telemetryUsageAgg, 
 	for source, series := range agg.SourceDaily {
 		snap.DailySeries["usage_source_"+sanitizeMetricID(source)] = series
 	}
+	for project, series := range agg.ProjectDaily {
+		snap.DailySeries["usage_project_"+sanitizeMetricID(project)] = series
+	}
 	for client, series := range agg.ClientDaily {
 		snap.DailySeries["usage_client_"+sanitizeMetricID(client)] = series
 	}
@@ -614,6 +638,7 @@ func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter)
 	agg := &telemetryUsageAgg{
 		ModelDaily:   make(map[string][]core.TimePoint),
 		SourceDaily:  make(map[string][]core.TimePoint),
+		ProjectDaily: make(map[string][]core.TimePoint),
 		ClientDaily:  make(map[string][]core.TimePoint),
 		ClientTokens: make(map[string][]core.TimePoint),
 	}
@@ -676,6 +701,12 @@ func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter)
 	if err != nil {
 		return nil, err
 	}
+	done = trace("queryProjectAgg")
+	projects, err := queryProjectAgg(ctx, db, matFilter)
+	done()
+	if err != nil {
+		return nil, err
+	}
 	done = trace("queryToolAgg")
 	tools, err := queryToolAgg(ctx, db, matFilter)
 	done()
@@ -724,6 +755,12 @@ func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter)
 	if err != nil {
 		return nil, err
 	}
+	done = trace("queryDailyByDimension(project)")
+	projectDaily, err := queryDailyByDimension(ctx, db, matFilter, "project")
+	done()
+	if err != nil {
+		return nil, err
+	}
 	done = trace("queryDailyByDimension(client)")
 	clientDaily, err := queryDailyByDimension(ctx, db, matFilter, "client")
 	done()
@@ -740,6 +777,7 @@ func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter)
 	agg.Models = models
 	agg.Providers = providers
 	agg.Sources = sources
+	agg.Projects = projects
 	agg.Tools = tools
 	agg.MCPServers = buildMCPAgg(tools)
 	agg.Languages = languages
@@ -748,6 +786,7 @@ func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter)
 	agg.Daily = daily
 	agg.ModelDaily = modelDaily
 	agg.SourceDaily = sourceDaily
+	agg.ProjectDaily = projectDaily
 	agg.ClientDaily = clientDaily
 	agg.ClientTokens = clientTokens
 	core.Tracef("[usage_view_perf] loadUsageViewForFilter TOTAL: %dms (providers=%v)", time.Since(filterStart).Milliseconds(), filter.ProviderIDs)
@@ -851,6 +890,38 @@ func querySourceAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]tele
 			&row.Reasoning,
 			&row.Sessions,
 		); err != nil {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}
+
+func queryProjectAgg(ctx context.Context, db *sql.DB, filter usageFilter) ([]telemetryProjectAgg, error) {
+	usageCTE, whereArgs := dedupedUsageCTE(filter)
+	query := usageCTE + `
+		SELECT
+			COALESCE(NULLIF(TRIM(workspace_id), ''), '') AS project_name,
+			SUM(COALESCE(requests, 1)) AS requests,
+			SUM(CASE WHEN date(occurred_at) = date('now') THEN COALESCE(requests, 1) ELSE 0 END) AS requests_today
+		FROM deduped_usage
+		WHERE 1=1
+		  AND event_type = 'message_usage'
+		  AND status != 'error'
+		  AND NULLIF(TRIM(workspace_id), '') IS NOT NULL
+		GROUP BY project_name
+		ORDER BY requests DESC
+	`
+	rows, err := db.QueryContext(ctx, query, whereArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("canonical usage project query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []telemetryProjectAgg
+	for rows.Next() {
+		var row telemetryProjectAgg
+		if err := rows.Scan(&row.Project, &row.Requests, &row.Requests1d); err != nil {
 			continue
 		}
 		out = append(out, row)
@@ -1257,6 +1328,18 @@ func queryDailyByDimension(ctx context.Context, db *sql.DB, filter usageFilter, 
 			  AND status != 'error'%s
 			GROUP BY day, dim_key
 		`, dailyTimeFilter)
+	case "project":
+		query = usageCTE + fmt.Sprintf(`
+			SELECT date(occurred_at) AS day,
+			       COALESCE(NULLIF(TRIM(workspace_id), ''), '') AS dim_key,
+			       SUM(COALESCE(requests, 1)) AS value
+			FROM deduped_usage
+			WHERE 1=1
+			  AND event_type = 'message_usage'
+			  AND status != 'error'
+			  AND NULLIF(TRIM(workspace_id), '') IS NOT NULL%s
+			GROUP BY day, dim_key
+		`, dailyTimeFilter)
 	case "client":
 		query = usageCTE + fmt.Sprintf(`
 			SELECT date(occurred_at) AS day,
@@ -1288,6 +1371,9 @@ func queryDailyByDimension(ctx context.Context, db *sql.DB, filter usageFilter, 
 		key = sanitizeMetricID(key)
 		if key == "" {
 			key = "unknown"
+		}
+		if dimension == "project" && key == "unknown" {
+			continue
 		}
 		if byDim[key] == nil {
 			byDim[key] = make(map[string]float64)

--- a/internal/telemetry/usage_view_test.go
+++ b/internal/telemetry/usage_view_test.go
@@ -862,6 +862,113 @@ func TestApplyCanonicalUsageView_UsesClientFromPayloadBeforeWorkspace(t *testing
 	}
 }
 
+func TestApplyCanonicalUsageView_EmitsProjectMetricsFromWorkspace(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telemetry.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Now().UTC()
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    now,
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		WorkspaceID:   "openusage",
+		AgentName:     "codex",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-projects-1",
+		MessageID:     "msg-projects-1",
+		ModelRaw:      "gpt-5-codex",
+		InputTokens:   int64Ptr(10),
+		OutputTokens:  int64Ptr(5),
+		TotalTokens:   int64Ptr(15),
+		Requests:      int64Ptr(1),
+		Payload: map[string]any{
+			"client": "CLI",
+		},
+	}); err != nil {
+		t.Fatalf("ingest openusage event: %v", err)
+	}
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    now.Add(1 * time.Second),
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		WorkspaceID:   "garage-tracker",
+		AgentName:     "codex",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-projects-2",
+		MessageID:     "msg-projects-2",
+		ModelRaw:      "gpt-5-codex",
+		InputTokens:   int64Ptr(12),
+		OutputTokens:  int64Ptr(6),
+		TotalTokens:   int64Ptr(18),
+		Requests:      int64Ptr(1),
+		Payload: map[string]any{
+			"client": "CLI",
+		},
+	}); err != nil {
+		t.Fatalf("ingest garage-tracker event: %v", err)
+	}
+	if _, err := store.Ingest(context.Background(), IngestRequest{
+		SourceSystem:  SourceSystem("codex"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    now.Add(2 * time.Second),
+		ProviderID:    "codex",
+		AccountID:     "codex-cli",
+		AgentName:     "codex",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-projects-3",
+		MessageID:     "msg-projects-3",
+		ModelRaw:      "gpt-5-codex",
+		InputTokens:   int64Ptr(8),
+		OutputTokens:  int64Ptr(4),
+		TotalTokens:   int64Ptr(12),
+		Requests:      int64Ptr(1),
+		Payload: map[string]any{
+			"client": "CLI",
+		},
+	}); err != nil {
+		t.Fatalf("ingest no-workspace event: %v", err)
+	}
+
+	snaps := map[string]core.UsageSnapshot{
+		"codex-cli": {
+			ProviderID: "codex",
+			AccountID:  "codex-cli",
+			Metrics:    map[string]core.Metric{},
+		},
+	}
+	merged, err := applyCanonicalUsageViewForTest(context.Background(), dbPath, snaps)
+	if err != nil {
+		t.Fatalf("apply canonical usage view: %v", err)
+	}
+	snap := merged["codex-cli"]
+
+	if got := metricUsed(snap.Metrics["project_openusage_requests"]); got != 1 {
+		t.Fatalf("project_openusage_requests = %v, want 1", got)
+	}
+	if got := metricUsed(snap.Metrics["project_garage_tracker_requests"]); got != 1 {
+		t.Fatalf("project_garage_tracker_requests = %v, want 1", got)
+	}
+	if _, ok := snap.Metrics["project_unknown_requests"]; ok {
+		t.Fatalf("unexpected unknown project bucket emitted: %+v", snap.Metrics["project_unknown_requests"])
+	}
+
+	day := now.Format("2006-01-02")
+	if got := seriesValueByDate(snap.DailySeries["usage_project_openusage"], day); got != 1 {
+		t.Fatalf("usage_project_openusage[%s] = %v, want 1", day, got)
+	}
+	if got := seriesValueByDate(snap.DailySeries["usage_project_garage_tracker"], day); got != 1 {
+		t.Fatalf("usage_project_garage_tracker[%s] = %v, want 1", day, got)
+	}
+}
+
 func metricUsed(m core.Metric) float64 {
 	if m.Used == nil {
 		return 0

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2462,12 +2462,13 @@ func normalizeWidgetSectionEntries(entries []config.DashboardWidgetSection) []co
 }
 
 func (m *Model) applyWidgetSectionOverrides() {
-	if len(m.widgetSections) == 0 {
+	entries := m.resolvedWidgetSectionEntries()
+	if len(entries) == 0 {
 		setDashboardWidgetSectionOverrides(nil)
 		return
 	}
-	visible := make([]core.DashboardStandardSection, 0, len(m.widgetSections))
-	for _, entry := range m.widgetSections {
+	visible := make([]core.DashboardStandardSection, 0, len(entries))
+	for _, entry := range entries {
 		if !entry.Enabled {
 			continue
 		}
@@ -2496,11 +2497,28 @@ func (m Model) defaultWidgetSectionEntries() []config.DashboardWidgetSection {
 }
 
 func (m Model) widgetSectionEntries() []config.DashboardWidgetSection {
+	return m.resolvedWidgetSectionEntries()
+}
+
+func (m Model) resolvedWidgetSectionEntries() []config.DashboardWidgetSection {
 	if len(m.widgetSections) == 0 {
 		return m.defaultWidgetSectionEntries()
 	}
+
 	out := make([]config.DashboardWidgetSection, len(m.widgetSections))
 	copy(out, m.widgetSections)
+
+	seen := make(map[core.DashboardStandardSection]bool, len(out))
+	for _, entry := range out {
+		seen[entry.ID] = true
+	}
+	for _, entry := range m.defaultWidgetSectionEntries() {
+		if seen[entry.ID] {
+			continue
+		}
+		out = append(out, entry)
+	}
+
 	return out
 }
 

--- a/internal/tui/provider_widget_test.go
+++ b/internal/tui/provider_widget_test.go
@@ -96,7 +96,25 @@ func TestNewModel_AppliesWidgetSectionOverridesFromConfig(t *testing.T) {
 	)
 
 	got := dashboardWidget("openai").EffectiveStandardSectionOrder()
-	if len(got) != 1 || got[0] != core.DashboardSectionOtherData {
-		t.Fatalf("effective section order = %#v, want [other_data]", got)
+	want := []core.DashboardStandardSection{
+		core.DashboardSectionOtherData,
+		core.DashboardSectionModelBurn,
+		core.DashboardSectionClientBurn,
+		core.DashboardSectionProjectBreakdown,
+		core.DashboardSectionToolUsage,
+		core.DashboardSectionMCPUsage,
+		core.DashboardSectionLanguageBurn,
+		core.DashboardSectionCodeStats,
+		core.DashboardSectionDailyUsage,
+		core.DashboardSectionProviderBurn,
+		core.DashboardSectionUpstreamProviders,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("effective section count = %d, want %d (sections=%#v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("effective section[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }

--- a/internal/tui/settings_widget_sections_test.go
+++ b/internal/tui/settings_widget_sections_test.go
@@ -38,6 +38,31 @@ func TestHandleSettingsModalKey_WidgetSectionsToggle(t *testing.T) {
 	}
 }
 
+func TestWidgetSectionEntries_AppendsNewDefaultSectionsForLegacyConfig(t *testing.T) {
+	m := Model{
+		widgetSections: []config.DashboardWidgetSection{
+			{ID: core.DashboardSectionTopUsageProgress, Enabled: true},
+			{ID: core.DashboardSectionOtherData, Enabled: true},
+		},
+	}
+
+	entries := m.widgetSectionEntries()
+	foundProjectBreakdown := false
+	projectBreakdownCount := 0
+	for _, entry := range entries {
+		if entry.ID == core.DashboardSectionProjectBreakdown {
+			foundProjectBreakdown = true
+			projectBreakdownCount++
+		}
+	}
+	if !foundProjectBreakdown {
+		t.Fatalf("expected %q to be present in resolved widget sections, got %#v", core.DashboardSectionProjectBreakdown, entries)
+	}
+	if projectBreakdownCount != 1 {
+		t.Fatalf("expected exactly one %q entry, got %d", core.DashboardSectionProjectBreakdown, projectBreakdownCount)
+	}
+}
+
 func TestHandleSettingsModalKey_WidgetSectionsMoveRow(t *testing.T) {
 	t.Cleanup(func() { setDashboardWidgetSectionOverrides(nil) })
 

--- a/internal/tui/tiles.go
+++ b/internal/tui/tiles.go
@@ -550,6 +550,12 @@ func (m Model) renderTile(snap core.UsageSnapshot, selected, modelMixExpanded bo
 	}
 	compactMetricKeys = addUsedKeys(compactMetricKeys, clientBurnKeys)
 
+	projectBreakdownLines, projectBreakdownKeys := buildProviderProjectBreakdownLines(snap, innerW, modelMixExpanded)
+	if len(projectBreakdownLines) > 0 {
+		sectionsByID[core.DashboardSectionProjectBreakdown] = section{withSectionPadding(projectBreakdownLines)}
+	}
+	compactMetricKeys = addUsedKeys(compactMetricKeys, projectBreakdownKeys)
+
 	var toolBurnLines []string
 	var toolBurnKeys map[string]bool
 	if widget.ShowToolComposition {
@@ -2016,6 +2022,13 @@ type clientMixEntry struct {
 	series     []core.TimePoint
 }
 
+type projectMixEntry struct {
+	name       string
+	requests   float64
+	requests1d float64
+	series     []core.TimePoint
+}
+
 type sourceMixEntry struct {
 	name       string
 	requests   float64
@@ -3136,6 +3149,180 @@ func buildProviderClientCompositionLinesWithWidget(snap core.UsageSnapshot, inne
 	}
 
 	return lines, usedKeys
+}
+
+func buildProviderProjectBreakdownLines(snap core.UsageSnapshot, innerW int, expanded bool) ([]string, map[string]bool) {
+	allProjects, usedKeys := collectProviderProjectMix(snap)
+	if len(allProjects) == 0 {
+		return nil, nil
+	}
+
+	projects, hiddenCount := limitProjectMix(allProjects, expanded, 6)
+	projectColors := buildProjectColorMap(allProjects, snap.AccountID)
+
+	totalRequests := float64(0)
+	for _, project := range allProjects {
+		totalRequests += project.requests
+	}
+	if totalRequests <= 0 {
+		return nil, nil
+	}
+
+	barW := innerW - 2
+	if barW < 12 {
+		barW = 12
+	}
+	if barW > 40 {
+		barW = 40
+	}
+
+	barEntries := make([]toolMixEntry, 0, len(allProjects))
+	for _, project := range allProjects {
+		barEntries = append(barEntries, toolMixEntry{name: project.name, count: project.requests})
+	}
+
+	lines := []string{
+		lipgloss.NewStyle().Foreground(colorSubtext).Bold(true).Render("Project Breakdown") +
+			"  " + dimStyle.Render(shortCompact(totalRequests)+" req"),
+		"  " + renderToolMixBar(barEntries, totalRequests, barW, projectColors),
+	}
+
+	for idx, project := range projects {
+		if project.requests <= 0 {
+			continue
+		}
+		pct := project.requests / totalRequests * 100
+		label := project.name
+		projectColor := colorForProject(projectColors, project.name)
+		colorDot := lipgloss.NewStyle().Foreground(projectColor).Render("■")
+
+		maxLabelLen := tableLabelMaxLen(innerW)
+		if len(label) > maxLabelLen {
+			label = label[:maxLabelLen-1] + "…"
+		}
+		displayLabel := fmt.Sprintf("%s %d %s", colorDot, idx+1, label)
+		valueStr := fmt.Sprintf("%2.0f%% %s req", pct, shortCompact(project.requests))
+		if project.requests1d > 0 {
+			valueStr += fmt.Sprintf(" · today %s", shortCompact(project.requests1d))
+		}
+		lines = append(lines, renderDotLeaderRow(displayLabel, valueStr, innerW))
+	}
+
+	if hiddenCount > 0 {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("+ %d more projects (Ctrl+O)", hiddenCount)))
+	}
+
+	return lines, usedKeys
+}
+
+func collectProviderProjectMix(snap core.UsageSnapshot) ([]projectMixEntry, map[string]bool) {
+	byProject := make(map[string]*projectMixEntry)
+	usedKeys := make(map[string]bool)
+
+	ensure := func(name string) *projectMixEntry {
+		if _, ok := byProject[name]; !ok {
+			byProject[name] = &projectMixEntry{name: name}
+		}
+		return byProject[name]
+	}
+
+	seriesByProject := make(map[string]map[string]float64)
+
+	for key, met := range snap.Metrics {
+		if met.Used == nil {
+			continue
+		}
+		name, field, ok := parseProjectMetricKey(key)
+		if !ok {
+			continue
+		}
+		project := ensure(name)
+		switch field {
+		case "requests":
+			project.requests = *met.Used
+		case "requests_today":
+			project.requests1d = *met.Used
+		}
+		usedKeys[key] = true
+	}
+
+	for key, points := range snap.DailySeries {
+		if !strings.HasPrefix(key, "usage_project_") {
+			continue
+		}
+		name := strings.TrimPrefix(key, "usage_project_")
+		if strings.TrimSpace(name) == "" || len(points) == 0 {
+			continue
+		}
+		mergeSeriesByDay(seriesByProject, name, points)
+	}
+
+	for name, pointsByDay := range seriesByProject {
+		project := ensure(name)
+		project.series = sortedSeriesFromByDay(pointsByDay)
+		if project.requests <= 0 {
+			project.requests = sumSeriesValues(project.series)
+		}
+	}
+
+	projects := make([]projectMixEntry, 0, len(byProject))
+	for _, project := range byProject {
+		if project.requests <= 0 && len(project.series) == 0 {
+			continue
+		}
+		projects = append(projects, *project)
+	}
+
+	sort.Slice(projects, func(i, j int) bool {
+		if projects[i].requests == projects[j].requests {
+			return projects[i].name < projects[j].name
+		}
+		return projects[i].requests > projects[j].requests
+	})
+
+	return projects, usedKeys
+}
+
+func parseProjectMetricKey(key string) (name, field string, ok bool) {
+	const prefix = "project_"
+	if !strings.HasPrefix(key, prefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(key, prefix)
+	if strings.HasSuffix(rest, "_requests_today") {
+		return strings.TrimSuffix(rest, "_requests_today"), "requests_today", true
+	}
+	if strings.HasSuffix(rest, "_requests") {
+		return strings.TrimSuffix(rest, "_requests"), "requests", true
+	}
+	return "", "", false
+}
+
+func limitProjectMix(projects []projectMixEntry, expanded bool, maxVisible int) ([]projectMixEntry, int) {
+	if expanded || maxVisible <= 0 || len(projects) <= maxVisible {
+		return projects, 0
+	}
+	return projects[:maxVisible], len(projects) - maxVisible
+}
+
+func buildProjectColorMap(projects []projectMixEntry, providerID string) map[string]lipgloss.Color {
+	colors := make(map[string]lipgloss.Color, len(projects))
+	if len(projects) == 0 {
+		return colors
+	}
+
+	base := stablePaletteOffset("project", providerID)
+	for i, project := range projects {
+		colors[project.name] = distributedPaletteColor(base, i)
+	}
+	return colors
+}
+
+func colorForProject(colors map[string]lipgloss.Color, name string) lipgloss.Color {
+	if color, ok := colors[name]; ok {
+		return color
+	}
+	return stableModelColor("project:"+name, "project")
 }
 
 func collectProviderClientMix(snap core.UsageSnapshot) ([]clientMixEntry, map[string]bool) {

--- a/internal/tui/tiles_normalization_test.go
+++ b/internal/tui/tiles_normalization_test.go
@@ -32,6 +32,15 @@ func providerByName(providers []providerMixEntry, name string) (providerMixEntry
 	return providerMixEntry{}, false
 }
 
+func projectByName(projects []projectMixEntry, name string) (projectMixEntry, bool) {
+	for _, project := range projects {
+		if project.name == name {
+			return project, true
+		}
+	}
+	return projectMixEntry{}, false
+}
+
 func TestCollectProviderClientMix_NormalizesSourceIntoClient(t *testing.T) {
 	snap := core.UsageSnapshot{
 		Metrics: map[string]core.Metric{
@@ -246,6 +255,78 @@ func TestCollectProviderClientMix_DoesNotDoubleCountRequestsTodayFallback(t *tes
 	}
 	if cli.requests != 367 {
 		t.Fatalf("cli_agents requests = %.0f, want 367", cli.requests)
+	}
+}
+
+func TestCollectProviderProjectMix_UsesMetricsAndDailySeriesFallback(t *testing.T) {
+	snap := core.UsageSnapshot{
+		Metrics: map[string]core.Metric{
+			"project_openusage_requests":               {Used: float64Ptr(4), Unit: "requests"},
+			"project_openusage_requests_today":         {Used: float64Ptr(1), Unit: "requests"},
+			"project_garage_tracker_requests_today":    {Used: float64Ptr(2), Unit: "requests"},
+			"project_garage_tracker_notes_requests":    {Used: nil, Unit: "requests"},
+			"project_garage_tracker_notes_other_field": {Used: float64Ptr(9), Unit: "count"},
+		},
+		DailySeries: map[string][]core.TimePoint{
+			"usage_project_garage_tracker": {
+				{Date: "2026-03-05", Value: 3},
+				{Date: "2026-03-06", Value: 2},
+			},
+		},
+	}
+
+	projects, usedKeys := collectProviderProjectMix(snap)
+
+	openusage, ok := projectByName(projects, "openusage")
+	if !ok {
+		t.Fatalf("missing openusage project bucket: %+v", projects)
+	}
+	if openusage.requests != 4 {
+		t.Fatalf("openusage requests = %.0f, want 4", openusage.requests)
+	}
+	if openusage.requests1d != 1 {
+		t.Fatalf("openusage requests1d = %.0f, want 1", openusage.requests1d)
+	}
+
+	garageTracker, ok := projectByName(projects, "garage_tracker")
+	if !ok {
+		t.Fatalf("missing garage_tracker project bucket: %+v", projects)
+	}
+	if garageTracker.requests != 5 {
+		t.Fatalf("garage_tracker requests = %.0f, want 5 from daily series fallback", garageTracker.requests)
+	}
+	if garageTracker.requests1d != 2 {
+		t.Fatalf("garage_tracker requests1d = %.0f, want 2", garageTracker.requests1d)
+	}
+
+	if !usedKeys["project_openusage_requests"] || !usedKeys["project_garage_tracker_requests_today"] {
+		t.Fatalf("expected project metric keys to be consumed, got: %+v", usedKeys)
+	}
+}
+
+func TestBuildProviderProjectBreakdownLines_RendersBreakdown(t *testing.T) {
+	snap := core.UsageSnapshot{
+		AccountID: "codex-cli",
+		Metrics: map[string]core.Metric{
+			"project_openusage_requests":            {Used: float64Ptr(2), Unit: "requests"},
+			"project_garage_tracker_requests":       {Used: float64Ptr(3), Unit: "requests"},
+			"project_garage_tracker_requests_today": {Used: float64Ptr(1), Unit: "requests"},
+		},
+	}
+
+	lines, used := buildProviderProjectBreakdownLines(snap, 100, false)
+	if len(lines) < 3 {
+		t.Fatalf("expected project breakdown lines, got %d: %#v", len(lines), lines)
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "Project Breakdown") {
+		t.Fatalf("missing project breakdown heading: %q", joined)
+	}
+	if !strings.Contains(joined, "openusage") || !strings.Contains(joined, "garage_tracker") {
+		t.Fatalf("missing project rows in breakdown: %q", joined)
+	}
+	if !used["project_openusage_requests"] || !used["project_garage_tracker_requests"] {
+		t.Fatalf("expected project metric keys to be marked used: %+v", used)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a new dashboard section: `project_breakdown`
- aggregate project/request mix from canonical telemetry `workspace_id` (PWD-derived)
- render per-provider project share as a stacked bar + ranked `%` breakdown rows
- include `project_breakdown` in standard widget section ordering/toggles
- make settings resilient for existing users: legacy `widget_sections` now auto-append newly introduced default sections, so `project_breakdown` is visible without manual config reset

## Provider/Data Audit
- project breakdown is sourced from telemetry `message_usage.workspace_id`
- all provider tiles can render this section when telemetry data exists
- providers/events that do not emit `workspace_id` simply show no project section data (no synthetic fallback)

## Implementation Notes
- telemetry canonical view now emits:
  - `project_<name>_requests`
  - `project_<name>_requests_today`
  - daily series `usage_project_<name>`
- stale project metrics/series are cleaned on rebuild to avoid drift
- TUI section logic uses metric-first parsing with daily-series fallback

## Validation
- `go test ./internal/core/... -count=1`
- `go test ./internal/telemetry/... -count=1`
- `go test ./internal/tui/... -count=1`
- `go test ./internal/tui/... -count=1 -race`
- `go test ./... -count=1`
- `make build`
