### PR TITLE
fix: remove unused vite plugin breaking website CI

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16,8 +16,7 @@
         "@vitejs/plugin-react": "^4.7.0",
         "puppeteer": "^24.41.0",
         "serve-handler": "^6.1.7",
-        "vite": "^6.4.1",
-        "vite-plugin-css-injected-by-js": "^5.0.0"
+        "vite": "^6.4.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -51,6 +50,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1513,6 +1513,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1724,7 +1725,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2352,6 +2354,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2500,6 +2503,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2848,6 +2852,7 @@
       "version": "6.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -2915,16 +2920,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-css-injected-by-js": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-5.0.0.tgz",
-      "integrity": "sha512-fj1yav+R4WNYP1uA/smg/rSdOxtmqjC1fDQ9qylsZaFIx2VUoDksMbfWUJ/8sCjhkDYEzqWYhpNNCseyM2ygQw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "vite": ">8.0.0-0"
       }
     },
     "node_modules/webdriver-bidi-protocol": {

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,6 @@
     "@vitejs/plugin-react": "^4.7.0",
     "puppeteer": "^24.41.0",
     "serve-handler": "^6.1.7",
-    "vite": "^6.4.1",
-    "vite-plugin-css-injected-by-js": "^5.0.0"
+    "vite": "^6.4.1"
   }
 }


### PR DESCRIPTION
## Summary
* Remove `vite-plugin-css-injected-by-js` from devDependencies — it requires `vite >8.0.0` but we use `vite 6.4.1`, and it's not imported in `vite.config.js` (leftover from a reverted CSS-in-JS approach)
* Regenerate `package-lock.json` without the conflicting peer dependency
* Fixes the `npm ci` ERESOLVE failure in the Deploy Website workflow

## Test plan
- [ ] Verify `npm ci && npm run build` succeeds in CI
- [ ] Verify website deploys successfully to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)