### PR TITLE
[codex] Improve website analytics and marketing copy

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -19,6 +19,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
+      VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
     defaults:
       run:
         working-directory: website

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,0 +1,2 @@
+VITE_POSTHOG_KEY=
+VITE_POSTHOG_HOST=https://eu.i.posthog.com

--- a/website/index.html
+++ b/website/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <title>OpenUsage — LLM Cost Tracking &amp; AI Agent Usage Dashboard for Your Terminal</title>
+    <title>OpenUsage — Terminal Dashboard for AI Usage, Spend &amp; Quotas</title>
     <meta
       name="description"
-      content="Track AI agent costs, LLM token usage, and API spend across 17 providers. OpenUsage auto-detects Claude Code, Cursor, Copilot, Codex CLI, OpenRouter, and more. Free open-source LLM dashboard for your terminal."
+      content="OpenUsage is a keyboard-first terminal dashboard for AI coding tools and APIs. Track spend, quotas, rate limits, model usage, and session telemetry across 17 providers."
     />
     <link rel="canonical" href="https://openusage.sh/" />
 
@@ -15,21 +15,19 @@
     <meta name="color-scheme" content="dark" />
     <meta name="robots" content="index, follow" />
     <meta name="author" content="Jan Baraniewski" />
-    <meta name="keywords" content="LLM cost tracking, AI agent costs, agent token usage tracking, agent token consumption, LLM dashboard, LLM monitoring, LLM observability, AI observability, AI agent monitoring, model usage tracking, model usage monitoring, MCP usage tracking, MCP tool tracking, API cost tracking, API usage monitoring, API spend tracker, AI billing dashboard, AI budget tracking, quota monitoring, rate limit tracking, session tracking, tool call tracking, daily cost trends, token distribution, code statistics, Claude Code cost tracking, Cursor cost tracking, Copilot cost tracking, OpenAI API cost tracking, Anthropic API usage, OpenRouter cost tracking, Codex CLI usage, Gemini CLI usage, AI coding tools, terminal dashboard, developer tools, open source, coding agent monitor" />
-
-    <meta property="og:title" content="OpenUsage — LLM Cost Tracking &amp; AI Agent Usage Dashboard" />
-    <meta property="og:description" content="Track AI agent costs and LLM token consumption across 17 providers. Auto-detects Claude Code, Cursor, Copilot, Codex, Gemini CLI, OpenRouter. Free open-source terminal dashboard." />
+    <meta property="og:title" content="OpenUsage — Terminal Dashboard for AI Usage" />
+    <meta property="og:description" content="Track spend, quotas, rate limits, model usage, and session telemetry across 17 providers from a keyboard-first terminal dashboard." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://openusage.sh/" />
     <meta property="og:image" content="https://openusage.sh/brand/og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="OpenUsage — LLM cost tracking and AI agent usage dashboard for your terminal" />
+    <meta property="og:image:alt" content="OpenUsage terminal dashboard showing AI usage, spend, and quota monitoring" />
     <meta property="og:site_name" content="OpenUsage" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="OpenUsage — LLM Cost Tracking &amp; AI Agent Dashboard" />
-    <meta name="twitter:description" content="Track AI agent costs and LLM token usage across 17 providers. Monitor spend, quotas, model burn, and token consumption from your terminal. Free and open source." />
+    <meta name="twitter:title" content="OpenUsage — Terminal Dashboard for AI Usage" />
+    <meta name="twitter:description" content="Track spend, quotas, rate limits, model usage, and session telemetry across 17 providers from your terminal." />
     <meta name="twitter:image" content="https://openusage.sh/brand/og.png" />
 
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%brand/favicon.svg" />
@@ -45,7 +43,7 @@
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "OpenUsage",
-      "description": "LLM cost tracking and AI agent usage dashboard for your terminal. Track agent costs, token consumption, model usage, MCP tool calls, and API spend across 17 providers including Claude Code, Cursor, Copilot, Codex CLI, Gemini CLI, OpenRouter, and Ollama. LLM observability with live spend, quota monitoring, rate limit tracking, model burn rates, session tracking, and code statistics.",
+      "description": "OpenUsage is a terminal dashboard for AI coding tools and APIs. Track spend, quotas, rate limits, model usage, MCP activity, session telemetry, and local history across 17 providers.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux",
       "offers": {
@@ -67,22 +65,14 @@
       "codeRepository": "https://github.com/janekbaraniewski/openusage",
       "license": "https://github.com/janekbaraniewski/openusage/blob/main/LICENSE",
       "featureList": [
-        "LLM cost tracking across 17 AI providers",
-        "AI agent token usage and consumption monitoring",
-        "Real-time API cost tracking and spend monitoring",
-        "Model usage tracking with per-model cost breakdown",
-        "Model burn rate analysis and daily cost trends",
-        "Token distribution breakdown by model",
-        "Agent cost tracking for Claude Code, Cursor, Copilot, Codex",
-        "MCP usage tracking and tool call monitoring",
-        "Quota monitoring and rate limit tracking",
-        "Session tracking with per-session cost analysis",
-        "Code statistics per provider (lines, languages, files)",
-        "Background daemon with SQLite telemetry for LLM observability",
+        "Spend, credits, and quota visibility across 17 providers",
+        "Model and token breakdowns when telemetry supports them",
+        "Session, client, project, and MCP activity views",
+        "Background daemon with local SQLite history",
         "Hook integrations for Claude Code, Codex, and OpenCode",
-        "OpenAI, Anthropic, OpenRouter, Groq, Mistral, DeepSeek API monitoring",
-        "17 built-in color themes",
-        "Keyboard-driven terminal LLM dashboard"
+        "Detail, compare, and analytics views in the terminal",
+        "Dashboard section, graph, and time-window configuration",
+        "Keyboard-driven local-first workflow"
       ]
     }
     </script>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.86.0",
+        "posthog-js": "^1.369.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -795,6 +796,328 @@
       "integrity": "sha512-Qiww2yiHiRxPXGa9KXgS0Ttg2wTWRDZjXZruTzdY6jgT/jbEKAUj03Tfvp5Hc1NNUmZGQ+HzdodM4mQ0DQEZ7g==",
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz",
+      "integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
+      "license": "MIT"
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.369.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.1.tgz",
+      "integrity": "sha512-5sUMa/gmGloazdnDZF8hfzMhGAhxtuTy3v7plnx+mR72fjDyg0aUQjmCeoxxyFOrBAO5aVYxESxPVKJepE6EfA==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
@@ -1248,12 +1571,17 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -1648,6 +1976,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -1724,6 +2063,15 @@
       "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -1941,6 +2289,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2136,6 +2490,12 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -2387,6 +2747,37 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.369.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.1.tgz",
+      "integrity": "sha512-xerj/T3NE65H9cqUKzg2LbNmavTC/qr26CnE+yBw+yNyro6Fmvs9+CMvRc2+RkDsoOdSmrq9cwR9noZqfjC2Kg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.25.2",
+        "@posthog/types": "1.369.1",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2395,6 +2786,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-agent": {
@@ -2485,6 +2900,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.0",
@@ -2812,9 +3233,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -2919,6 +3338,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@lobehub/icons-static-svg": "^1.86.0",
+    "posthog-js": "^1.369.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -328,6 +328,12 @@ export default function App() {
       <section className="features-section" id="features">
         <div className="w">
           <R><h2 className="features-title">What it shows</h2></R>
+          <R delay={0.05}>
+            <p className="features-lede">
+              The useful stuff: spend, quotas, model activity, session history, and tool telemetry.
+              No vanity counters. No decorative dashboard filler.
+            </p>
+          </R>
           <div className="features-grid">
             <R><div className="feature-item">
               <h3>Spend, credits, and quotas</h3>

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -1,4 +1,11 @@
 import { useEffect, useRef, useState } from "react";
+import {
+  acceptAnalytics,
+  analyticsConfigured,
+  declineAnalytics,
+  hasConsentChoice,
+  track,
+} from "./analytics";
 
 const base = import.meta.env.BASE_URL;
 
@@ -153,6 +160,7 @@ const installData = [
 export default function App() {
   const [copied, setCopied] = useState("");
   const [scrolled, setScrolled] = useState(false);
+  const [showConsentBanner, setShowConsentBanner] = useState(false);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 100);
@@ -162,14 +170,40 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    setShowConsentBanner(analyticsConfigured() && !hasConsentChoice());
+  }, []);
+
+  useEffect(() => {
     if (!copied) return;
     const t = setTimeout(() => setCopied(""), 1500);
     return () => clearTimeout(t);
   }, [copied]);
 
   async function copy(cmd) {
-    try { await navigator.clipboard.writeText(cmd); setCopied(cmd); }
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setCopied(cmd);
+      track("install command copied", { command: cmd });
+    }
     catch { setCopied(""); }
+  }
+
+  function trackCTA(location, target) {
+    track("cta clicked", { location, target });
+  }
+
+  function trackOutbound(target, location) {
+    track("outbound link clicked", { location, target });
+  }
+
+  function acceptTracking() {
+    acceptAnalytics();
+    setShowConsentBanner(false);
+  }
+
+  function declineTracking() {
+    declineAnalytics();
+    setShowConsentBanner(false);
   }
 
   return (
@@ -179,8 +213,8 @@ export default function App() {
         <NavLogo />
         <div className="nav__right">
           <a className="nav__link" href="#providers">Providers</a>
-          <a className="nav__link" href="https://github.com/janekbaraniewski/openusage" rel="noreferrer" target="_blank">GitHub</a>
-          <a className="nav__cta" href="#install">Install</a>
+          <a className="nav__link" href="https://github.com/janekbaraniewski/openusage" rel="noreferrer" target="_blank" onClick={() => trackOutbound("github", "nav")}>GitHub</a>
+          <a className="nav__cta" href="#install" onClick={() => trackCTA("nav", "install")}>Install</a>
         </div>
       </nav>
 
@@ -191,19 +225,20 @@ export default function App() {
           <R><Banner className="banner" /></R>
           <R delay={0.15}>
             <h1 className="hero__title">
-              Know what your AI agents cost.
+              Track AI coding usage, spend, and quotas from your terminal.
             </h1>
           </R>
           <R delay={0.25}>
             <p className="hero__sub">
-              LLM cost tracking and token usage dashboard for your terminal.
-              Auto-detects 17 providers. Zero config.
+              OpenUsage auto-detects supported tools and common API key env vars,
+              then shows spend, quotas, rate limits, model usage, and session telemetry
+              in one keyboard-first dashboard.
             </p>
           </R>
           <R delay={0.35}>
             <div className="hero__actions">
-              <a className="btn btn--fill" href="#install">Get started</a>
-              <a className="btn btn--ghost" href="https://github.com/janekbaraniewski/openusage" rel="noreferrer" target="_blank">GitHub →</a>
+              <a className="btn btn--fill" href="#install" onClick={() => trackCTA("hero", "install")}>Get started</a>
+              <a className="btn btn--ghost" href="https://github.com/janekbaraniewski/openusage" rel="noreferrer" target="_blank" onClick={() => trackOutbound("github", "hero")}>GitHub →</a>
             </div>
           </R>
         </div>
@@ -213,16 +248,16 @@ export default function App() {
       <section className="pitch">
         <div className="w">
           <R as="p" className="pitch__line">
-            <em>Auto-detects</em> your AI coding agents and API keys.
+            <em>Auto-detects</em> your coding tools and common API key env vars.
           </R>
           <R className="pitch__line" delay={0.12}>
             <p className="pitch__line" style={{margin:0}}>
-              Tracks <em>agent costs, token usage,</em> and <em>LLM spend</em> at a glance.
+              Shows <em>spend, quotas,</em> and <em>model usage</em> in one place.
             </p>
           </R>
           <R className="pitch__line" delay={0.24}>
             <p className="pitch__line" style={{margin:0}}>
-              Zero config required — just run <code>openusage</code>.
+              Runs locally. Install it, then run <code>openusage</code>.
             </p>
           </R>
         </div>
@@ -239,7 +274,7 @@ export default function App() {
               ]} />
             </div>
           </R>
-          <R><p className="demo__caption">dashboard · detail · compare · analytics</p></R>
+          <R><p className="demo__caption">dashboard · detail · compare · analytics views</p></R>
         </div>
       </section>
 
@@ -248,7 +283,7 @@ export default function App() {
         <div className="w">
           <R>
             <p className="demo__caption" style={{ textAlign: 'left', marginBottom: 16, fontSize: '1rem', color: 'var(--text-2)' }}>
-              Run it side-by-side with your coding agent
+              Keep it open beside the agent you are using.
             </p>
           </R>
           <R>
@@ -271,7 +306,7 @@ export default function App() {
         <div className="w">
           <R>
             <p className="demo__caption" style={{ textAlign: 'left', marginBottom: 16, fontSize: '1rem', color: 'var(--text-2)' }}>
-              Configurable tile sections. Customizable detail graphs. Customizable dashboards. Time windows. Thresholds. 17 built-in themes.
+              Rearrange dashboard sections. Tune detail graphs. Switch time windows. Set thresholds.
             </p>
           </R>
           <R>
@@ -285,38 +320,38 @@ export default function App() {
               />
             </div>
           </R>
-          <R><p className="demo__caption">Settings modal — tile sections, detail graphs, themes, and live preview</p></R>
+          <R><p className="demo__caption">Settings modal — layout, graphs, thresholds, and live preview</p></R>
         </div>
       </section>
 
       {/* ── Features (keyword-rich, 2-col grid) ─────────── */}
       <section className="features-section" id="features">
         <div className="w">
-          <R><h2 className="features-title">What it tracks</h2></R>
+          <R><h2 className="features-title">What it shows</h2></R>
           <div className="features-grid">
             <R><div className="feature-item">
-              <h3>Agent cost tracking</h3>
-              <p>Real-time spend monitoring across Claude Code, Cursor, Copilot, Codex, and every other provider. See daily cost trends and burn rates at a glance.</p>
+              <h3>Spend, credits, and quotas</h3>
+              <p>See daily spend, remaining credits, plan usage, resets, and burn rate wherever the provider exposes them.</p>
             </div></R>
             <R delay={0.06}><div className="feature-item">
-              <h3>Token usage &amp; consumption</h3>
-              <p>Per-model token distribution, input vs output breakdown, cost per token. Track token consumption across sessions and time windows.</p>
+              <h3>Token and model breakdowns</h3>
+              <p>Compare input, output, cached, and reasoning tokens with per-model usage where provider or local telemetry supports it.</p>
             </div></R>
             <R delay={0.12}><div className="feature-item">
-              <h3>Model usage monitoring</h3>
-              <p>See which models you're burning through — GPT-4o, Claude Sonnet, Gemini Pro, DeepSeek, and more. Compare model usage patterns across providers.</p>
+              <h3>Session and client activity</h3>
+              <p>Inspect sessions, projects, clients, and daily trends from supported local telemetry and provider APIs.</p>
             </div></R>
             <R delay={0.18}><div className="feature-item">
-              <h3>MCP &amp; tool call tracking</h3>
-              <p>Track MCP tool usage, tool call frequency, and which tools each agent session invokes. Full session-level visibility.</p>
+              <h3>MCP and tool usage</h3>
+              <p>See which MCP servers and tools were used, how often they ran, and which sessions they appeared in for supported integrations.</p>
             </div></R>
             <R delay={0.24}><div className="feature-item">
-              <h3>Quotas &amp; rate limits</h3>
-              <p>Live quota monitoring and rate limit tracking. See remaining requests, token limits, plan usage percentages, and threshold alerts.</p>
+              <h3>Daemon-backed history</h3>
+              <p>Keep collecting data in the background and analyze time windows from the local SQLite telemetry store.</p>
             </div></R>
             <R delay={0.30}><div className="feature-item">
               <h3>Code statistics</h3>
-              <p>Lines added and removed, languages used, files touched per session. Track code generation output across providers.</p>
+              <p>Track lines added, files touched, and language mix from supported coding-tool telemetry.</p>
             </div></R>
           </div>
         </div>
@@ -329,7 +364,7 @@ export default function App() {
             <div className="prov-header">
               <h2 className="prov-header__title">17 providers</h2>
               <p className="prov-header__sub">
-                Track costs across coding agents, API platforms, and local LLMs.<br />One dashboard.
+                Coding agents, API platforms, and local runtimes.<br />One place to watch them all.
               </p>
             </div>
           </R>
@@ -369,8 +404,8 @@ export default function App() {
             <div className="install-header">
               <h2 className="install-title">Get started</h2>
               <p className="install-desc">
-                One command. Auto-detects every provider and API key on first run.
-                Start tracking agent costs immediately — no config file needed.
+                Install it, run <code>openusage</code>, and let auto-detection pick up supported
+                tools and common API key env vars. Add manual accounts later only if you need to.
               </p>
             </div>
           </R>
@@ -404,11 +439,26 @@ export default function App() {
         <div className="w" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%" }}>
           <span>OpenUsage · open source</span>
           <div className="footer__links">
-            <a className="footer__link" href="https://github.com/janekbaraniewski/openusage" rel="noreferrer" target="_blank">GitHub</a>
-            <a className="footer__link" href="https://github.com/janekbaraniewski/openusage/releases" rel="noreferrer" target="_blank">Releases</a>
+            <a className="footer__link" href="https://github.com/janekbaraniewski/openusage" rel="noreferrer" target="_blank" onClick={() => trackOutbound("github", "footer")}>GitHub</a>
+            <a className="footer__link" href="https://github.com/janekbaraniewski/openusage/releases" rel="noreferrer" target="_blank" onClick={() => trackOutbound("releases", "footer")}>Releases</a>
           </div>
         </div>
       </footer>
+      {showConsentBanner ? (
+        <div className="consent-banner" role="dialog" aria-live="polite" aria-label="Analytics preference">
+          <p className="consent-banner__text">
+            Allow privacy-respecting analytics so we can see pageviews, GitHub clicks, and install intent.
+          </p>
+          <div className="consent-banner__actions">
+            <button className="consent-banner__button consent-banner__button--primary" type="button" onClick={acceptTracking}>
+              Allow
+            </button>
+            <button className="consent-banner__button" type="button" onClick={declineTracking}>
+              Decline
+            </button>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/website/src/analytics.js
+++ b/website/src/analytics.js
@@ -1,0 +1,125 @@
+import posthog from "posthog-js";
+
+const analyticsKey = import.meta.env.VITE_POSTHOG_KEY?.trim();
+const analyticsHost = import.meta.env.VITE_POSTHOG_HOST?.trim() || "https://eu.i.posthog.com";
+const consentStorageKey = "openusage.analytics-consent";
+
+let analyticsReady = false;
+let analyticsInitialized = false;
+
+function canInitializeAnalytics() {
+  if (typeof window === "undefined" || !analyticsKey) {
+    return false;
+  }
+
+  const host = window.location.hostname;
+  if (host === "localhost" || host === "127.0.0.1" || host === "[::1]" || window.navigator.webdriver) {
+    return false;
+  }
+
+  return true;
+}
+
+function readConsentChoice() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(consentStorageKey);
+  } catch {
+    return null;
+  }
+}
+
+function writeConsentChoice(value) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(consentStorageKey, value);
+  } catch {
+    // Ignore storage failures and keep the app usable.
+  }
+}
+
+function capturePageview(origin) {
+  if (!analyticsReady || posthog.has_opted_out_capturing()) {
+    return;
+  }
+
+  posthog.capture("$pageview", {
+    origin,
+    path: window.location.pathname,
+    url: window.location.href,
+  });
+}
+
+export function initAnalytics() {
+  if (analyticsInitialized) {
+    return analyticsReady;
+  }
+
+  analyticsInitialized = true;
+  analyticsReady = canInitializeAnalytics();
+  if (!analyticsReady) {
+    return false;
+  }
+
+  posthog.init(analyticsKey, {
+    api_host: analyticsHost,
+    autocapture: false,
+    capture_pageleave: false,
+    capture_pageview: false,
+    defaults: "2026-01-30",
+    disable_session_recording: true,
+    disable_surveys: true,
+    opt_out_capturing_by_default: true,
+  });
+
+  if (readConsentChoice() === "accepted") {
+    posthog.opt_in_capturing();
+    capturePageview("load");
+  } else {
+    posthog.opt_out_capturing();
+  }
+
+  return true;
+}
+
+export function analyticsConfigured() {
+  return canInitializeAnalytics();
+}
+
+export function hasConsentChoice() {
+  return readConsentChoice() !== null;
+}
+
+export function acceptAnalytics() {
+  writeConsentChoice("accepted");
+  if (!analyticsReady) {
+    return;
+  }
+
+  posthog.opt_in_capturing();
+  posthog.capture("analytics consent accepted");
+  capturePageview("consent");
+}
+
+export function declineAnalytics() {
+  writeConsentChoice("declined");
+  if (!analyticsReady) {
+    return;
+  }
+
+  posthog.opt_out_capturing();
+}
+
+export function track(event, properties = {}) {
+  if (!analyticsReady || posthog.has_opted_out_capturing()) {
+    return;
+  }
+
+  posthog.capture(event, properties);
+}

--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -1,7 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { initAnalytics } from "./analytics";
 import "./styles.css";
+
+initAnalytics();
 
 const root = document.getElementById("root");
 const app = (

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -526,6 +526,50 @@ button { font: inherit; cursor: pointer; }
 .footer__link { color: var(--text-2); transition: color 0.2s; }
 .footer__link:hover { color: var(--text); }
 
+/* ── Consent ───────────────────────────────────────────────── */
+
+.consent-banner {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 120;
+  width: min(420px, calc(100vw - 32px));
+  padding: 16px;
+  background: rgba(21,21,21,0.96);
+  border: 1px solid var(--border);
+  box-shadow: 0 16px 48px rgba(0,0,0,0.35);
+}
+
+.consent-banner__text {
+  margin: 0 0 12px;
+  color: var(--text-2);
+  font-size: 0.75rem;
+  line-height: 1.7;
+}
+
+.consent-banner__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.consent-banner__button {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.62rem;
+  font-weight: 700;
+}
+
+.consent-banner__button--primary {
+  border-color: var(--green);
+  background: var(--green);
+  color: var(--bg);
+}
+
 /* ── Responsive ────────────────────────────────────────────── */
 
 @media (max-width: 900px) {
@@ -539,4 +583,13 @@ button { font: inherit; cursor: pointer; }
   .install-label { display: none; }
   .prov-detect { display: none; }
   .nav__link { display: none; }
+  .consent-banner {
+    right: 16px;
+    left: 16px;
+    width: auto;
+  }
+  .consent-banner__actions {
+    justify-content: stretch;
+    flex-direction: column;
+  }
 }

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -308,40 +308,82 @@ button { font: inherit; cursor: pointer; }
 }
 
 .features-title {
-  margin: 0 0 clamp(32px, 5vw, 56px);
+  margin: 0 0 12px;
   font-size: clamp(1.8rem, 4vw, 3rem);
   font-weight: 800;
   letter-spacing: -0.02em;
 }
 
-.features-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 2px;
+.features-lede {
+  max-width: 44rem;
+  margin: 0 0 clamp(28px, 4vw, 44px);
+  color: var(--text-2);
+  font-size: 0.92rem;
+  line-height: 1.75;
 }
 
-.feature-item {
-  padding: clamp(20px, 3vw, 32px);
-  background: var(--surface);
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  align-items: stretch;
   border: 1px solid var(--border);
 }
 
+.feature-item {
+  min-height: 184px;
+  padding: clamp(24px, 3vw, 32px);
+  background: linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0)), var(--surface);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.feature-item:nth-child(2n) {
+  border-right: 0;
+}
+
+.feature-item:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
 .feature-item h3 {
-  margin: 0 0 8px;
-  font-size: 0.88rem;
+  margin: 0;
+  font-size: 1rem;
   font-weight: 700;
   color: var(--text);
+  line-height: 1.45;
 }
 
 .feature-item p {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: 0.86rem;
   color: var(--text-2);
-  line-height: 1.65;
+  line-height: 1.8;
 }
 
 @media (max-width: 640px) {
-  .features-grid { grid-template-columns: 1fr; }
+  .demo .demo__frame {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .features-grid {
+    grid-template-columns: 1fr;
+    border: 0;
+    gap: 12px;
+  }
+  .feature-item {
+    min-height: 0;
+    border: 1px solid var(--border);
+  }
+  .feature-item:nth-child(2n) {
+    border-right: 1px solid var(--border);
+  }
+  .feature-item:nth-last-child(-n + 2) {
+    border-bottom: 1px solid var(--border);
+  }
 }
 
 /* ── Providers ─────────────────────────────────────────────── */

--- a/website/vite.config.js
+++ b/website/vite.config.js
@@ -3,5 +3,24 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   base: "/",
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: "redirect-legacy-openusage-base",
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          const url = req.url || "/";
+          if (!url.startsWith("/openusage")) {
+            next();
+            return;
+          }
+
+          const redirectTo = url.replace(/^\/openusage/, "") || "/";
+          res.statusCode = 302;
+          res.setHeader("Location", redirectTo);
+          res.end();
+        });
+      },
+    },
+  ],
 });


### PR DESCRIPTION
## Summary

This PR tightens the website copy around the product's real strengths, adds a minimal PostHog integration for the landing site, and fixes local development for legacy `/openusage/` URLs.

## What changed

- replaced the hero and supporting website copy with more accurate product language
- removed low-signal theme-focused marketing copy
- added a small PostHog client with explicit consent gating
- track only high-signal website events: pageviews after consent, CTA clicks, outbound clicks, and install-command copies
- wired the Pages workflow to read `VITE_POSTHOG_KEY` and `VITE_POSTHOG_HOST` from GitHub Actions secrets
- added a dev-server redirect so old `/openusage/` local URLs resolve correctly during Vite development
- added `website/.env.example` for local configuration

## Why

The previous site copy leaned too hard on generic marketing language and low-value claims. The website also had no analytics setup, and local development at `/openusage/` could look broken because the site now ships with a root base path while some local bookmarks still point at the old Pages-style path.

## Impact

- clearer, more concrete marketing copy
- privacy-respecting website analytics with replay disabled
- simpler GitHub configuration for the website deploy
- local `yarn dev` and `npm run dev` are more forgiving for old `/openusage/` URLs

## GitHub setup

The website deploy now expects these repository secrets:

- `VITE_POSTHOG_KEY`
- `VITE_POSTHOG_HOST`

For EU PostHog cloud, `VITE_POSTHOG_HOST` should be `https://eu.i.posthog.com`.

## Validation

- `cd website && npm run build`
- manually verified the dev server renders at `/`
- manually verified `/openusage/` redirects to `/` during local dev
