### PR TITLE
chore: upgrade workflows and reorder website sections

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10
 
@@ -29,9 +29,9 @@ jobs:
     name: Vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -48,9 +48,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -81,9 +81,9 @@ jobs:
           - os: macos-latest
             goos: darwin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -101,9 +101,9 @@ jobs:
     name: Check go.mod tidiness
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,9 +18,9 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -28,14 +28,14 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y gcc
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:go"

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Review
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,11 +15,11 @@ jobs:
     name: Release (Linux & Windows)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -45,11 +45,11 @@ jobs:
     runs-on: macos-latest
     needs: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release, release-macos]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from tag
         id: version
@@ -177,7 +177,7 @@ jobs:
 
           class Openusage < Formula
             desc "Monitor your AI coding tool quotas from a single TUI dashboard"
-            homepage "https://github.com/${REPO}"
+            homepage "https://openusage.sh"
             version "${VERSION}"
             license "MIT"
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -26,9 +26,9 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -43,7 +43,7 @@ jobs:
 
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: website/dist
 
@@ -55,4 +55,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -278,6 +278,46 @@ export default function App() {
         </div>
       </section>
 
+      {/* ── Providers (asymmetric: title left, grid below) ── */}
+      <section className="prov-section" id="providers">
+        <div className="w">
+          <R>
+            <div className="prov-header">
+              <h2 className="prov-header__title">17 providers</h2>
+              <p className="prov-header__sub">
+                Coding agents, API platforms, and local runtimes.<br />One place to watch them all.
+              </p>
+            </div>
+          </R>
+
+          <div className="prov-grid">
+            <div className="prov-col">
+              <R><div className="prov-col__label prov-col__label--agents">Coding Agents &amp; IDEs</div></R>
+              {codingAgents.map((p, i) => (
+                <R key={p.name} delay={i * 0.04}>
+                  <div className="prov-item">
+                    <img className="prov-logo" src={p.icon} alt="" aria-hidden="true" loading="lazy" />
+                    <span className="prov-name">{p.name}</span>
+                  </div>
+                </R>
+              ))}
+            </div>
+
+            <div className="prov-col">
+              <R><div className="prov-col__label prov-col__label--api">API Platforms</div></R>
+              {apiPlatforms.map((p, i) => (
+                <R key={p.name} delay={i * 0.03}>
+                  <div className="prov-item">
+                    <img className="prov-logo" src={p.icon} alt="" aria-hidden="true" loading="lazy" />
+                    <span className="prov-name">{p.name}</span>
+                  </div>
+                </R>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* ── Side-by-side video ────────────────────────────── */}
       <section className="demo">
         <div className="w">
@@ -298,29 +338,6 @@ export default function App() {
             </div>
           </R>
           <R><p className="demo__caption">OpenUsage running alongside OpenCode monitoring live OpenRouter usage.</p></R>
-        </div>
-      </section>
-
-      {/* ── Settings video ───────────────────────────────── */}
-      <section className="demo">
-        <div className="w">
-          <R>
-            <p className="demo__caption" style={{ textAlign: 'left', marginBottom: 16, fontSize: '1rem', color: 'var(--text-2)' }}>
-              Rearrange dashboard sections. Tune detail graphs. Switch time windows. Set thresholds.
-            </p>
-          </R>
-          <R>
-            <div className="demo__frame" style={{ aspectRatio: '16 / 8.56' }}>
-              <LazyVideo
-                style={{ objectFit: 'cover', objectPosition: 'center 48.5%' }}
-                sources={[
-                  { src: `${base}media/tile-config-example.webm`, type: "video/webm" },
-                  { src: `${base}media/tile-config-example.mp4`, type: "video/mp4" },
-                ]}
-              />
-            </div>
-          </R>
-          <R><p className="demo__caption">Settings modal — layout, graphs, thresholds, and live preview</p></R>
         </div>
       </section>
 
@@ -363,43 +380,26 @@ export default function App() {
         </div>
       </section>
 
-      {/* ── Providers (asymmetric: title left, grid below) ── */}
-      <section className="prov-section" id="providers">
+      {/* ── Settings video ───────────────────────────────── */}
+      <section className="demo">
         <div className="w">
           <R>
-            <div className="prov-header">
-              <h2 className="prov-header__title">17 providers</h2>
-              <p className="prov-header__sub">
-                Coding agents, API platforms, and local runtimes.<br />One place to watch them all.
-              </p>
+            <p className="demo__caption" style={{ textAlign: 'left', marginBottom: 16, fontSize: '1rem', color: 'var(--text-2)' }}>
+              Rearrange dashboard sections. Tune detail graphs. Switch time windows. Set thresholds.
+            </p>
+          </R>
+          <R>
+            <div className="demo__frame" style={{ aspectRatio: '16 / 8.56' }}>
+              <LazyVideo
+                style={{ objectFit: 'cover', objectPosition: 'center 48.5%' }}
+                sources={[
+                  { src: `${base}media/tile-config-example.webm`, type: "video/webm" },
+                  { src: `${base}media/tile-config-example.mp4`, type: "video/mp4" },
+                ]}
+              />
             </div>
           </R>
-
-          <div className="prov-grid">
-            <div className="prov-col">
-              <R><div className="prov-col__label prov-col__label--agents">Coding Agents &amp; IDEs</div></R>
-              {codingAgents.map((p, i) => (
-                <R key={p.name} delay={i * 0.04}>
-                  <div className="prov-item">
-                    <img className="prov-logo" src={p.icon} alt="" aria-hidden="true" loading="lazy" />
-                    <span className="prov-name">{p.name}</span>
-                  </div>
-                </R>
-              ))}
-            </div>
-
-            <div className="prov-col">
-              <R><div className="prov-col__label prov-col__label--api">API Platforms</div></R>
-              {apiPlatforms.map((p, i) => (
-                <R key={p.name} delay={i * 0.03}>
-                  <div className="prov-item">
-                    <img className="prov-logo" src={p.icon} alt="" aria-hidden="true" loading="lazy" />
-                    <span className="prov-name">{p.name}</span>
-                  </div>
-                </R>
-              ))}
-            </div>
-          </div>
+          <R><p className="demo__caption">Settings modal — layout, graphs, thresholds, and live preview</p></R>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- upgrade the workflow action wrappers to current major versions across CI, CodeQL, release, dependency review, and website deploy
- remove the remaining Node 20-backed action versions that were showing deprecation warnings in release runs
- reorder the website sections so the page alternates product proof and non-video content more cleanly

## Changes
- bump `actions/checkout` to `v6` across all workflows
- bump `actions/setup-go` to `v6` in CI, CodeQL, and release workflows
- bump `actions/setup-node` to `v6` in the website deploy workflow
- bump `github/codeql-action` from `v3` to `v4`
- bump `golangci/golangci-lint-action` from `v7` to `v9`
- bump Pages actions to `actions/upload-pages-artifact@v5` and `actions/deploy-pages@v5`
- update the Homebrew formula homepage emitted by the release workflow to `https://openusage.sh`
- move the providers section directly after the main demo video
- place the side-by-side OpenUsage/OpenCode/OpenRouter demo before `What it shows`
- move the settings/config demo below the features section

## Test plan
- [x] Parse all workflow YAML locally with Ruby `YAML.load_file`
- [x] Confirm no stale action references remain in `.github/workflows`
- [x] Run `npm run build` in `website/`
- [ ] PR CI passes
- [ ] Next tag-based release run completes without the old Node 20 action warnings

## Additional context
- The GitHub repository homepage has also been updated directly to `https://openusage.sh`
