### PR TITLE
fix(tui): "unknown provider" when adding API key for unconfigured row

### DIFF
--- a/internal/tui/api_keys_validate_test.go
+++ b/internal/tui/api_keys_validate_test.go
@@ -1,0 +1,39 @@
+package tui
+
+import "testing"
+
+// Regression: when validating an API key for a provider that has NOT been
+// auto-detected (no env var set, no account in config), the API Keys tab
+// must still resolve providerID for the row via the static provider-spec
+// list. Previously the validate path read providerID directly from
+// m.accountProviders, which is empty for such rows, and the resulting
+// empty providerID caused the daemon's ValidateAPIKey to return
+// "unknown provider".
+func TestProviderForAccountID_FallsBackToSpecsForUnconfiguredAccount(t *testing.T) {
+	// Empty map mirrors the runtime case for a provider whose env var isn't
+	// set. The function under test must still resolve the provider id.
+	empty := map[string]string{}
+
+	cases := map[string]string{
+		"moonshot-ai": "moonshot",
+		"openai":      "openai",
+		"deepseek":    "deepseek",
+	}
+	for accountID, wantProviderID := range cases {
+		got := providerForAccountID(accountID, empty)
+		if got != wantProviderID {
+			t.Errorf("providerForAccountID(%q, empty) = %q, want %q", accountID, got, wantProviderID)
+		}
+	}
+}
+
+// Sanity: when a provider HAS been auto-detected, the configured map's
+// entry should win over the static spec lookup.
+func TestProviderForAccountID_PrefersAccountProvidersMap(t *testing.T) {
+	configured := map[string]string{
+		"moonshot-ai": "moonshot-custom-override",
+	}
+	if got := providerForAccountID("moonshot-ai", configured); got != "moonshot-custom-override" {
+		t.Errorf("providerForAccountID with override = %q, want moonshot-custom-override", got)
+	}
+}

--- a/internal/tui/settings_modal_input.go
+++ b/internal/tui/settings_modal_input.go
@@ -414,7 +414,7 @@ func (m Model) handleAPIKeyEditKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		id := m.settings.apiKeyEditAccountID
-		providerID := m.accountProviders[id]
+		providerID := providerForAccountID(id, m.accountProviders)
 		m.settings.apiKeyStatus = "validating..."
 		return m, m.validateKeyCmd(id, providerID, m.settings.apiKeyInput)
 	case "backspace":


### PR DESCRIPTION
## Summary

Adding a key in **Settings → 5 KEYS** for any provider whose env var wasn't already set returned **\"unknown provider\"** on Enter. Reproduced cleanest with Moonshot (newest, most likely to be entered cold) but the bug applies to every API-key provider with no auto-detected account.

## Root cause

`internal/tui/settings_modal_input.go:417` resolved `providerID` from `m.accountProviders[id]`. That map only contains entries for accounts the runtime already created (env var set, or already in `settings.json`). For unconfigured rows the lookup returned `\"\"`, which `dashboardapp.Service.ValidateAPIKey` (`internal/dashboardapp/service.go:70`) flagged as unknown.

The renderer (`apiKeysTabIDs`, `renderSettingsAPIKeysBody`) already had a `providerForAccountID` helper doing the right thing — falling back to the static provider-spec list (`apiKeyProviderEntries`). The input handler just wasn't using it.

## Fix

Two-line change to call `providerForAccountID(id, m.accountProviders)` instead of the bare map lookup.

## Test plan

- [x] `go test ./internal/tui/ -count=1` — green
- [x] New regression test `TestProviderForAccountID_FallsBackToSpecsForUnconfiguredAccount` covering moonshot/openai/deepseek with an empty `accountProviders` map
- [x] New `TestProviderForAccountID_PrefersAccountProvidersMap` to lock in that explicit overrides still win over the spec fallback
- [x] Manually reproducible: open the TUI without `MOONSHOT_API_KEY` set → 5 KEYS → moonshot-ai → paste a key → Enter

🤖 Generated with [Claude Code](https://claude.com/claude-code)