### PR TITLE
feat(detect): adopt API keys from OpenCode auth.json

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -96,6 +96,24 @@ Tracks subscription info and usage endpoints.
 
 Tracks rate limits and account balance.
 
+### OpenCode credential adoption (cross-provider)
+
+If [OpenCode](https://opencode.ai) is installed and you've authed any
+of its providers, openusage will read `~/.local/share/opencode/auth.json`
+on startup and adopt the API keys it finds. Currently maps:
+
+| OpenCode entry | openusage account |
+|---|---|
+| `moonshotai` (api) | `moonshot-ai` (provider `moonshot`) |
+| `openrouter` (api) | `openrouter` |
+| `zai` (api) | `zai` |
+| `opencode` (api) | `opencode` |
+| `ollama-cloud` (api) | `ollama-cloud` (provider `ollama`) |
+
+OAuth-typed entries (`anthropic`, `openai`, `google`, `cursor`) are skipped:
+they're chat-scoped tokens, not the API-key shape openusage's poll-time probes
+expect. Env-var detection runs first; if both are present the env var wins.
+
 ### Moonshot (Kimi)
 
 **Detection:** `MOONSHOT_API_KEY` environment variable

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -42,6 +42,7 @@ func AutoDetect() Result {
 	detectGeminiCLI(&result)
 
 	detectEnvKeys(&result)
+	detectOpenCodeAuth(&result)
 
 	return result
 }

--- a/internal/detect/opencode_auth.go
+++ b/internal/detect/opencode_auth.go
@@ -1,0 +1,138 @@
+package detect
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// opencodeAuthEntry mirrors one provider's slot inside OpenCode's auth.json.
+// OpenCode stores either OAuth credentials (refresh + access + expires) or a
+// raw API key under the same dict key. We only care about API-key entries
+// here; OAuth handling for openai/anthropic/google would require token-
+// exchange against opencode.ai's auth server and is a separate piece of work.
+type opencodeAuthEntry struct {
+	Type string `json:"type"`
+	Key  string `json:"key"`
+}
+
+// opencodeAuthMapping maps an OpenCode auth.json provider key to the matching
+// openusage provider id and the canonical account id we want the credential
+// to land on. The account id is intentionally aligned with what
+// detectEnvKeys produces — addAccount() de-dupes by id, so when the user
+// has both an env var and an OpenCode-stored key the env-var path wins
+// (it runs first in AutoDetect).
+var opencodeAuthMapping = map[string]struct {
+	Provider  string
+	AccountID string
+}{
+	"moonshotai":   {"moonshot", "moonshot-ai"},
+	"openrouter":   {"openrouter", "openrouter"},
+	"zai":          {"zai", "zai"},
+	"opencode":     {"opencode", "opencode"},
+	"ollama-cloud": {"ollama", "ollama-cloud"},
+}
+
+// opencodeAuthPath returns the platform-appropriate path to OpenCode's
+// auth.json. macOS and Linux use ~/.local/share/opencode/auth.json (the
+// XDG state path OpenCode picks regardless of XDG_DATA_HOME on darwin).
+// Windows isn't supported by OpenCode officially yet but if the file exists
+// at %APPDATA%/opencode/auth.json we'll read it.
+func opencodeAuthPath() string {
+	home := homeDir()
+	if home == "" {
+		return ""
+	}
+	switch runtime.GOOS {
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData != "" {
+			return filepath.Join(appData, "opencode", "auth.json")
+		}
+		return filepath.Join(home, "AppData", "Roaming", "opencode", "auth.json")
+	default:
+		return filepath.Join(home, ".local", "share", "opencode", "auth.json")
+	}
+}
+
+// detectOpenCodeAuth reads OpenCode's auth.json and registers an account for
+// every provider whose entry is an API key (type=="api"). OAuth entries are
+// skipped: openusage's anthropic/openai/google providers expect API keys for
+// their poll-time probes; using OpenCode's chat-scoped OAuth tokens against
+// /v1/usage / rate-limit endpoints would mostly 401.
+func detectOpenCodeAuth(result *Result) {
+	path := opencodeAuthPath()
+	if path == "" {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("[detect] OpenCode auth.json read error: %v", err)
+		}
+		return
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		log.Printf("[detect] OpenCode auth.json parse error: %v", err)
+		return
+	}
+
+	matched := 0
+	skipped := 0
+	for opencodeKey, target := range opencodeAuthMapping {
+		slot, ok := raw[opencodeKey]
+		if !ok {
+			continue
+		}
+		var entry opencodeAuthEntry
+		if err := json.Unmarshal(slot, &entry); err != nil {
+			log.Printf("[detect] OpenCode auth.json[%s] parse error: %v", opencodeKey, err)
+			continue
+		}
+		if entry.Type != "api" {
+			// OAuth or unrecognised; surface counts but don't try to use it.
+			skipped++
+			continue
+		}
+		if entry.Key == "" {
+			continue
+		}
+
+		// Token is a runtime-only field (json:"-"); it lives in the account
+		// in-memory and is re-populated on each AutoDetect run.
+		acct := core.AccountConfig{
+			ID:       target.AccountID,
+			Provider: target.Provider,
+			Auth:     "api_key",
+			Token:    entry.Key,
+		}
+		acct.SetHint("credential_source", "opencode_auth_json")
+
+		// addAccount de-dupes by ID, so if env-var detection already put
+		// something on the same slot, this is a no-op — env var wins.
+		before := len(result.Accounts)
+		addAccount(result, acct)
+		if len(result.Accounts) > before {
+			matched++
+			masked := maskKey(entry.Key)
+			log.Printf("[detect] OpenCode auth.json: %s → %s/%s (key=%s)",
+				opencodeKey, target.Provider, target.AccountID, masked)
+		}
+	}
+	if matched > 0 || skipped > 0 {
+		log.Printf("[detect] OpenCode auth.json: %d api-key accounts adopted, %d oauth/other entries skipped", matched, skipped)
+	}
+}
+
+func maskKey(key string) string {
+	if len(key) <= 12 {
+		return "****"
+	}
+	return key[:4] + "..." + key[len(key)-4:]
+}

--- a/internal/detect/opencode_auth_test.go
+++ b/internal/detect/opencode_auth_test.go
@@ -1,0 +1,135 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// withFakeOpenCodeAuth writes an auth.json under a temp HOME and rewires
+// HOME so detectOpenCodeAuth picks it up. Returns the temp dir; t.Cleanup
+// restores the previous environment.
+func withFakeOpenCodeAuth(t *testing.T, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("opencode auth path test is unix-shaped")
+	}
+	tmp := t.TempDir()
+	authDir := filepath.Join(tmp, ".local", "share", "opencode")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	t.Setenv("HOME", tmp)
+	return tmp
+}
+
+func TestDetectOpenCodeAuth_AdoptsAPIKeyEntries(t *testing.T) {
+	withFakeOpenCodeAuth(t, `{
+		"moonshotai": {"type": "api", "key": "sk-moonshot-1234567890abcdef"},
+		"openrouter": {"type": "api", "key": "sk-or-v1-aaaaaaaaaaaa"},
+		"zai":        {"type": "api", "key": "zai-aaaa.bbbb"},
+		"anthropic":  {"type": "oauth", "refresh": "r", "access": "a", "expires": 1},
+		"openai":     {"type": "oauth", "refresh": "r", "access": "a", "expires": 1, "accountId": "id"}
+	}`)
+
+	var result Result
+	detectOpenCodeAuth(&result)
+
+	want := map[string]string{
+		"moonshot-ai": "moonshot",
+		"openrouter":  "openrouter",
+		"zai":         "zai",
+	}
+	got := map[string]string{}
+	for _, a := range result.Accounts {
+		got[a.ID] = a.Provider
+	}
+	for accountID, providerID := range want {
+		if got[accountID] != providerID {
+			t.Errorf("account %q provider = %q, want %q (full result: %+v)", accountID, got[accountID], providerID, got)
+		}
+	}
+	// OAuth-typed slots must NOT create accounts (we don't support OAuth-as-API-key).
+	for _, a := range result.Accounts {
+		if a.Provider == "anthropic" || a.Provider == "openai" || a.Provider == "google" {
+			t.Errorf("unexpected oauth-derived account: %+v", a)
+		}
+	}
+	// Tokens must land on the account so Fetch() can use them at runtime.
+	for _, a := range result.Accounts {
+		if a.ID == "moonshot-ai" && a.Token != "sk-moonshot-1234567890abcdef" {
+			t.Errorf("moonshot Token = %q, want the api key from auth.json", a.Token)
+		}
+	}
+	// Provenance hint should be set so we can debug where the key came from.
+	for _, a := range result.Accounts {
+		if a.Hint("credential_source", "") != "opencode_auth_json" {
+			t.Errorf("account %q missing credential_source hint", a.ID)
+		}
+	}
+}
+
+func TestDetectOpenCodeAuth_EnvVarWins(t *testing.T) {
+	// Existing env-var-derived account must NOT be overwritten by opencode auth.
+	withFakeOpenCodeAuth(t, `{
+		"moonshotai": {"type": "api", "key": "from-opencode"}
+	}`)
+
+	var result Result
+	// Simulate detectEnvKeys having already populated the slot.
+	addAccount(&result, core.AccountConfig{
+		ID:        "moonshot-ai",
+		Provider:  "moonshot",
+		Auth:      "api_key",
+		APIKeyEnv: "MOONSHOT_API_KEY",
+	})
+
+	detectOpenCodeAuth(&result)
+
+	for _, a := range result.Accounts {
+		if a.ID == "moonshot-ai" {
+			if a.APIKeyEnv != "MOONSHOT_API_KEY" {
+				t.Errorf("env-var account got overwritten: %+v", a)
+			}
+			if a.Token == "from-opencode" {
+				t.Errorf("opencode token leaked into env-var account: %+v", a)
+			}
+		}
+	}
+}
+
+func TestDetectOpenCodeAuth_MissingFileIsSilent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	var result Result
+	detectOpenCodeAuth(&result) // must not panic, must not add accounts
+	if len(result.Accounts) != 0 {
+		t.Errorf("expected no accounts when auth.json missing, got %+v", result.Accounts)
+	}
+}
+
+func TestDetectOpenCodeAuth_MalformedJSONLogsAndContinues(t *testing.T) {
+	withFakeOpenCodeAuth(t, `{not-json`)
+
+	var result Result
+	detectOpenCodeAuth(&result) // must not panic
+	if len(result.Accounts) != 0 {
+		t.Errorf("expected no accounts on malformed json, got %+v", result.Accounts)
+	}
+}
+
+func TestMaskKey(t *testing.T) {
+	if got := maskKey("sk-moonshot-1234567890abcdef"); got != "sk-m...cdef" {
+		t.Errorf("maskKey long = %q, want sk-m...cdef", got)
+	}
+	if got := maskKey("short"); got != "****" {
+		t.Errorf("maskKey short = %q, want ****", got)
+	}
+}


### PR DESCRIPTION
## Summary

Many users land on openusage with OpenCode already authed against several providers, but no env var set — and end up exporting envs or hand-pasting keys into the 5 KEYS tab one provider at a time. The credentials are already sitting in `~/.local/share/opencode/auth.json`. We just read them.

Adds an `AutoDetect()` pass that adopts every API-key-typed entry from OpenCode's auth file:

| OpenCode entry | openusage account |
|---|---|
| `moonshotai` (api) | `moonshot-ai` (provider `moonshot`) |
| `openrouter` (api) | `openrouter` |
| `zai` (api) | `zai` |
| `opencode` (api) | `opencode` |
| `ollama-cloud` (api) | `ollama-cloud` (provider `ollama`) |

OAuth-typed slots (`anthropic`, `openai`, `google`, `cursor`) are deliberately skipped — those are chat-scoped tokens, not the API-key shape our poll-time probes (rate-limit headers, balance endpoints) expect. Token exchange against `opencode.ai`'s auth server to mint usable creds is a separate piece of work, tracked as a follow-up.

## Behavior on overlap

- Account IDs match what `detectEnvKeys` produces. The `addAccount` de-duper collapses both into one tile.
- `detectEnvKeys` runs before `detectOpenCodeAuth` in `AutoDetect`, so if the user has both an env var and an OpenCode key, the env var wins. Explicit intent beats inferred.
- Adopted accounts carry a `credential_source=opencode_auth_json` runtime hint (visible in the detail panel) so the source is debuggable when there's a mismatch.
- `Token` is `json:\"-\"` — keys never land in `settings.json`, only live in memory for the runtime, and re-populate on the next `AutoDetect` cycle.

## Live-tested locally

Author's actual `auth.json` had moonshotai + openrouter + zai + opencode + ollama-cloud as API entries plus anthropic/google/openai/cursor as OAuth. Output:

```
opencode      provider=opencode    source=opencode_auth_json  token=yes (len=67)
ollama-cloud  provider=ollama      source=opencode_auth_json  token=yes (len=57)
moonshot-ai   provider=moonshot    source=opencode_auth_json  token=yes (len=51)
openrouter    provider=openrouter  source=opencode_auth_json  token=yes (len=73)
zai           provider=zai         source=opencode_auth_json  token=yes (len=49)
[detect] OpenCode auth.json: 5 api-key accounts adopted, 0 oauth/other entries skipped
```

OAuth slots correctly skipped, no spurious anthropic/openai accounts created.

## Test plan

- [x] `go test ./... -count=1` — green
- [x] `make vet` clean
- [x] `make lint` clean
- [x] New tests in `internal/detect/opencode_auth_test.go`:
  - `TestDetectOpenCodeAuth_AdoptsAPIKeyEntries` — confirms 3 api keys adopted, 2 oauth slots skipped, tokens land on accounts, `credential_source` hint set
  - `TestDetectOpenCodeAuth_EnvVarWins` — env-var-derived account is not overwritten by an OpenCode key on the same slot
  - `TestDetectOpenCodeAuth_MissingFileIsSilent` — no panic, no spurious accounts when auth.json doesn't exist
  - `TestDetectOpenCodeAuth_MalformedJSONLogsAndContinues` — gracefully handles broken JSON
  - `TestMaskKey` — log redaction helper
- [x] Live tested against author's real auth.json (output above)

## Out of scope (deliberate)

- **OAuth-typed entries** (anthropic, openai, google, cursor). Would require token-exchange against opencode.ai's auth server. Separate design + PR if we want it.
- **Reading from MCP auth files** (`~/.local/share/opencode/mcp-auth.json`). Different shape, only relevant for MCP servers, not provider tracking.
- **Removing accounts when their OpenCode entry disappears**. Currently the runtime keeps an in-memory account until the next `AutoDetect` cycle clears it. Acceptable; revisit if it causes confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)