### PR TITLE
fix: opencode + moonshot tile bugs + browser-session auth design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist/
 *.test
 *.out
 vendor/
-
 # IDE
 .idea/
 .vscode/
@@ -22,11 +21,9 @@ vendor/
 *~
 #.claude/
 #.opencode/
-
 # OS
 .DS_Store
 Thumbs.db
-
 # Debug / temp
 *.har
 *.prof
@@ -47,3 +44,6 @@ website/node_modules/
 website/*.tsbuildinfo
 moonshotkey.txt
 perplexitykey.txt
+# Captured HAR/cookie files for provider reverse-engineering — must never be committed
+perplexity-cookies.txt
+pplx-cookies.txt

--- a/docs/BROWSER_SESSION_AUTH_DESIGN.md
+++ b/docs/BROWSER_SESSION_AUTH_DESIGN.md
@@ -1,16 +1,34 @@
-# Browser-Session Auth for Providers Without Programmatic Tokens
+# Browser-Session Auth: the Universal Solution for Dashboard-Gated Providers
 
 Date: 2026-04-30
 Status: Proposed
 Author: Jan Baraniewski
 
-Driven by issues #79 and #80 fallout — Perplexity and OpenCode (Zen) both hide their billing / usage / account data behind session-cookie SolidStart or NextAuth RPCs that **only accept browser cookies, never bearer tokens**. Their API keys are scoped to chat-only routes. There is no programmatic alternative on either platform today, and nothing we can build to bridge that gap unilaterally.
+Originally driven by issues #79 (Perplexity) and #80 (OpenCode / OpenAI-via-OpenCode-OAuth fallout). Live probing (2026-04-30) confirmed this isn't just an OpenCode/Perplexity quirk — **every modern AI-platform console hides usage / billing / account data behind session-cookie auth, and rejects OAuth tokens explicitly**. OpenAI's billing endpoint literally says so:
+
+> `403: must be made with a session key (browser-only). You made it with: oauth.`
+
+This same pattern was confirmed against `platform.openai.com`, `chatgpt.com`, `console.anthropic.com`, `aistudio.google.com`, `console.opencode.ai`, and `console.perplexity.ai`. All six return 403 / 302-to-login for unauthenticated requests on their dashboard API surface. All six work with a valid session cookie. **Cookie auth is the universal mechanism for full-data parity** across providers — not a workaround for two outliers.
 
 The user has rejected manual cookie-paste UX as "hacky / not secure". This doc designs the alternative.
 
+## Why OAuth doesn't substitute (verified)
+
+OAuth tokens are *delegated* credentials — designed for third-party apps and intentionally scoped to a narrow surface (usually `chat.completions`). Probes against fresh, non-expired tokens issued by OpenCode for OpenAI / Anthropic / Google all confirmed:
+
+- **OpenAI** OAuth (audience-claimed for `/v1`): 403 on `/v1/models` ("Missing scopes: api.model.read"), 401 on `/v1/usage`, 403 on `/v1/dashboard/billing/credit_grants` ("must be made with a session key").
+- **Anthropic** OAuth: 401 on `/v1/messages` ("OAuth authentication is currently not supported"). Even with Claude-Code-style `anthropic-beta: oauth-2025-04-20` header.
+- **Google** access token: 401 on `generativelanguage.googleapis.com` ("Expected OAuth 2 access token … or other valid authentication credential"). The token is opaque, OpenCode-internal.
+
+Session cookies, by contrast, carry **the full identity of the logged-in user** with all the permissions they have in the dashboard. Cookie-authed requests can hit every endpoint the user reaches by clicking through the UI.
+
 ## 1. Problem Statement
 
-Multiple providers expose rich data in their web consoles (balance, monthly usage, tier, subscription, per-model spend) that is unreachable via API key. The credential is a session cookie, set server-side after Google/GitHub OAuth. Openusage cannot mint that cookie — only the user's browser can. We need a way to get the cookie into openusage **without** asking the user to copy/paste it.
+Every major AI-platform console exposes rich data (balance, monthly usage, tier, subscription, per-model spend, organization metadata, payment method, rate-limit caps) **only behind session-cookie auth**. API keys are deliberately scoped to chat-completion / inference routes; OAuth tokens are delegated and similarly scoped. The data we need to populate full-feature provider tiles is simply not reachable from any non-browser credential.
+
+The session cookie itself is set server-side after the user's OAuth dance with Google/GitHub/SSO, and is encrypted with a server-only key. Openusage cannot mint it. Only the user's browser can.
+
+We need a way to get the cookie from the user's existing logged-in browser into openusage **without** asking the user to copy/paste it.
 
 ## 2. Goals
 
@@ -19,8 +37,9 @@ Multiple providers expose rich data in their web consoles (balance, monthly usag
 3. Works for Chrome / Safari / Firefox (the dominant ~95% of browsers).
 4. Cookie storage in openusage is encrypted-at-rest (Keychain / libsecret / DPAPI, NOT plain JSON).
 5. Auth refresh story is honest: when the cookie expires, the tile transitions to AUTH with a clear "log into provider.com to refresh" hint and re-extracts on next poll.
-6. Reusable across providers (OpenCode, Perplexity, future).
+6. **Universal — one infrastructure, every dashboard-gated provider benefits.** Cover at minimum: OpenAI (platform + ChatGPT), Anthropic (console), Google AI Studio, OpenCode (Zen), Perplexity. Cursor already has equivalent local-extraction; same pattern.
 7. Clear, explicit user consent — first time openusage reads a browser cookie, the user is prompted and informed, not surprised.
+8. **Per-provider declaration is minimal.** A provider opts in by declaring `(domain, cookie_name)` in its `ProviderSpec` and writing an API client. The cookie plumbing stays generic.
 
 ## 3. Non-Goals
 
@@ -266,7 +285,22 @@ Description: Document opt-in cookie auth, supported browsers, the privacy postur
 ### Task 7: Perplexity provider integration (separate PR)
 Files: `internal/providers/perplexity/...`
 Depends on: Tasks 1–4
-Description: New provider package that uses the same browser-session machinery against Perplexity's `/rest/pplx-api/v2/groups/...` endpoints. Out of scope for this PR — covered in #79's Perplexity follow-up.
+Description: New provider package that uses the same browser-session machinery against Perplexity's `/rest/pplx-api/v2/groups/...` endpoints.
+
+### Task 8: OpenAI provider browser-session enrichment (separate PR)
+Files: `internal/providers/openai/console_client.go` (new), provider extension
+Depends on: Tasks 1–4
+Description: Closes the issue #80 OpenAI gap. Adds session-cookie-fed RPCs against `platform.openai.com` and `chatgpt.com` to surface usage / billing / per-model breakdown / Plus-or-Team subscription state. Existing API-key probe stays as a separate code path. Pinned cookie name(s): `__Secure-next-auth.session-token` and equivalents.
+
+### Task 9: Anthropic provider browser-session enrichment (separate PR)
+Files: `internal/providers/anthropic/console_client.go` (new), provider extension
+Depends on: Tasks 1–4
+Description: Adds `console.anthropic.com` session-cookie-fed RPCs for organization usage / billing / per-model spend.
+
+### Task 10: Google AI Studio provider browser-session enrichment (separate PR)
+Files: `internal/providers/gemini_api/console_client.go` (new) or new `internal/providers/google_ai_studio/`
+Depends on: Tasks 1–4
+Description: Adds `aistudio.google.com` session-cookie-fed RPCs for free-tier quota state and any billing data exposed there.
 
 ### Dependency Graph
 
@@ -275,9 +309,11 @@ Task 1 ──┐
          ├─→ Task 2 ─┐
          └─→ Task 3 ─┼─→ Task 4 ──┐
                      └─→ Task 5 ──┴─→ Task 6
+                                   ↘
+                                    Tasks 7, 8, 9, 10 (parallel, separate PRs)
 ```
 
-Task 7 is a separate downstream effort.
+Tasks 7–10 are separate downstream provider PRs, all riding on the shared infrastructure from Tasks 1–4. Each is small (one HAR + one provider package + one parser).
 
 ## 8. Open Questions
 

--- a/docs/BROWSER_SESSION_AUTH_DESIGN.md
+++ b/docs/BROWSER_SESSION_AUTH_DESIGN.md
@@ -1,0 +1,287 @@
+# Browser-Session Auth for Providers Without Programmatic Tokens
+
+Date: 2026-04-30
+Status: Proposed
+Author: Jan Baraniewski
+
+Driven by issues #79 and #80 fallout — Perplexity and OpenCode (Zen) both hide their billing / usage / account data behind session-cookie SolidStart or NextAuth RPCs that **only accept browser cookies, never bearer tokens**. Their API keys are scoped to chat-only routes. There is no programmatic alternative on either platform today, and nothing we can build to bridge that gap unilaterally.
+
+The user has rejected manual cookie-paste UX as "hacky / not secure". This doc designs the alternative.
+
+## 1. Problem Statement
+
+Multiple providers expose rich data in their web consoles (balance, monthly usage, tier, subscription, per-model spend) that is unreachable via API key. The credential is a session cookie, set server-side after Google/GitHub OAuth. Openusage cannot mint that cookie — only the user's browser can. We need a way to get the cookie into openusage **without** asking the user to copy/paste it.
+
+## 2. Goals
+
+1. Zero copy-paste UX. The user clicks one thing and is done.
+2. Works on macOS / Linux / Windows.
+3. Works for Chrome / Safari / Firefox (the dominant ~95% of browsers).
+4. Cookie storage in openusage is encrypted-at-rest (Keychain / libsecret / DPAPI, NOT plain JSON).
+5. Auth refresh story is honest: when the cookie expires, the tile transitions to AUTH with a clear "log into provider.com to refresh" hint and re-extracts on next poll.
+6. Reusable across providers (OpenCode, Perplexity, future).
+7. Clear, explicit user consent — first time openusage reads a browser cookie, the user is prompted and informed, not surprised.
+
+## 3. Non-Goals
+
+1. **No bundled headless browser.** Adding a Chromium dependency would balloon the binary by ~100MB and bring fragility (UI changes, headless-detection bot challenges). The user already has a browser; we use theirs.
+2. **No browser extension.** Friction (install in N browsers) and maintenance overhead (review cycles per browser store).
+3. **No openusage-hosted OAuth proxy.** Operational cost, trust implications. We don't want to sit in the middle of users' auth flows.
+4. **No replacing existing API-key auth.** Where a provider's API key already gives all the data we need (Moonshot, OpenAI, etc.), we don't add cookie auth. This is purely additive for providers where the API key is data-poor.
+5. **No automatic browser-cookie extraction without user opt-in.** Reading another app's data is sensitive — gated on explicit consent in the TUI, ~~not~~ never on by default.
+6. **No CSRF-token tracking for mutating endpoints.** We only read (`GET`-style RPCs). If a provider requires CSRF for reads (rare), we revisit.
+
+## 4. Impact Analysis
+
+### Affected Subsystems
+
+| Subsystem | Impact | Summary |
+|-----------|--------|---------|
+| core types | minor | New `ProviderAuthTypeBrowserSession` constant; new `BrowserCookieRef` field on `AccountConfig` for the persisted reference. |
+| providers | moderate | OpenCode + Perplexity gain a cookie-fed code path alongside their existing API-key probe. Other providers untouched. |
+| TUI | moderate | New row type in 5 KEYS for cookie-auth providers, "Connect via browser" action, refresh flow on expiry. |
+| config | minor | Cookie blob stored in the existing credentials store with a new `kind: "browser_session"` discriminator. Same encryption-at-rest as API keys. |
+| detect | minor | Optional: detect "user is logged into provider X in browser Y" passively for the UI hint, not for auto-extraction. |
+| daemon | none | The daemon poll path stays unchanged — it consumes whatever credential the provider hands it. |
+| telemetry | none | |
+| CLI | none | |
+| Dependencies | adds one | `github.com/browserutils/kooky` (cross-platform browser cookie reader) — battle-tested, used by yt-dlp et al., handles Chrome encryption / Safari binarycookies / Firefox SQLite. ~250KB compiled. Apache-2.0. |
+
+### Existing Design Doc Overlap
+
+- `docs/TELEMETRY_INTEGRATIONS.md` — unrelated; this is provider auth, not telemetry.
+- No active design docs overlap.
+
+## 5. Detailed Design
+
+### 5.1 Cookie acquisition: how and from where
+
+We use **`kooky`** (or roll our own thin equivalent if the dep is rejected). It abstracts over:
+
+- **Chrome / Edge / Brave / Vivaldi** — SQLite cookie DB at platform-specific paths. Values are AES-128-CBC encrypted on Linux/macOS (key from libsecret / Keychain) or DPAPI on Windows. Chrome v20+ App-Bound Encryption is *not* yet defeated by kooky on Windows; we accept that limitation and document it (users on Windows + Chrome v20+ can fall back to Firefox or Edge for the cookie source).
+- **Firefox** — plain SQLite, no decryption needed.
+- **Safari** — `Cookies.binarycookies` plist format, Apple's binary spec.
+
+Per provider account config, we record:
+- `BrowserCookieRef.Domain` — e.g. `.opencode.ai`
+- `BrowserCookieRef.CookieName` — e.g. `auth`
+- `BrowserCookieRef.SourceBrowser` — auto-detected on connect, persisted
+
+On every poll, openusage re-reads the cookie fresh from the source browser. If extraction fails (browser DB locked because browser is open, key unavailable, etc.) we fall back to the **last successfully-extracted cookie** stored in our credentials store — which has a known expiry, beyond which we transition the tile to AUTH.
+
+### 5.2 The "Connect via browser" flow
+
+In **Settings → 5 KEYS** for cookie-auth-capable providers, the row shows:
+
+```
+  ▸ opencode-zen     │ STATUS │ <not connected>
+                       press Enter to connect via browser
+```
+
+On Enter:
+
+1. TUI displays a modal:
+   ```
+   ┌── Connect OpenCode (cookie auth) ──────────────────────────┐
+   │ openusage will read your opencode.ai session cookie from   │
+   │ your browser to fetch billing and usage data.              │
+   │                                                            │
+   │ This requires you to be logged into opencode.ai in one of: │
+   │   • Google Chrome / Edge / Brave / Vivaldi                 │
+   │   • Firefox                                                │
+   │   • Safari (macOS only)                                    │
+   │                                                            │
+   │ The cookie is stored encrypted at rest in your             │
+   │ openusage credentials store. It's read fresh from the      │
+   │ browser on every poll.                                     │
+   │                                                            │
+   │   y  open opencode.ai in your default browser              │
+   │   r  read cookie now (already logged in)                   │
+   │   esc cancel                                               │
+   └────────────────────────────────────────────────────────────┘
+   ```
+
+2. User picks `r` (already logged in) — openusage tries each supported browser in turn for `.opencode.ai/auth`. First hit wins, gets stored, tile flips to OK.
+
+3. User picks `y` — openusage `exec.Command("open", "https://opencode.ai/login")` (and platform equivalents), modal shows "Waiting for you to finish logging in… [r] read now [esc] cancel". User logs in, returns to TUI, presses `r`. Same extraction as path (2).
+
+4. **No copy-paste.** No "open DevTools and copy". The user only ever logs into the provider's site like normal.
+
+### 5.3 Cookie storage
+
+Two artifacts:
+
+**Per-account reference** (in the account's config — non-sensitive):
+```json
+{
+  "id": "opencode-zen",
+  "provider": "opencode",
+  "auth": "browser_session",
+  "browser_cookie_ref": {
+    "domain": ".opencode.ai",
+    "cookie_name": "auth",
+    "source_browser": "chrome"
+  }
+}
+```
+Persists in `settings.json` like any other account config.
+
+**Cookie value** (in the credentials store — sensitive):
+- Existing credentials store gains a `kind` field: `"api_key"` (default) or `"browser_session"`.
+- For `browser_session`, the value is the cookie blob plus `expiry`, `last_extracted_at`, `source_browser`.
+- Storage encryption-at-rest stays as it is today (the credentials store already uses keychain on macOS / libsecret / DPAPI per `internal/credentials`). New entries use the same path.
+
+### 5.4 Provider integration pattern
+
+Add `ProviderAuthTypeBrowserSession` to the `core.ProviderAuthSpec` enum. Provider declares which auth types it supports:
+
+```go
+Auth: core.ProviderAuthSpec{
+    Type:                core.ProviderAuthTypeAPIKey,            // primary
+    APIKeyEnv:           "OPENCODE_API_KEY",
+    DefaultAccountID:    "opencode",
+    SupplementalTypes:   []core.ProviderAuthType{core.ProviderAuthTypeBrowserSession},
+    BrowserCookieDomain: ".opencode.ai",
+    BrowserCookieName:   "auth",
+},
+```
+
+The provider's `Fetch()` accepts both: if the account has a usable cookie blob, it makes the cookie-authed RPC calls; otherwise it falls back to API-key-only data. **The merge happens inside `Fetch()`** — no architectural changes needed in the daemon or read-model layers.
+
+### 5.5 Cookie expiry & refresh
+
+Cookies have explicit `Expires`. Openusage:
+
+1. Tracks the expiry alongside the cookie blob.
+2. **On every poll**, before making the RPC, re-extracts from the browser. If the fresh extract is newer (longer expiry, different value), it replaces the stored blob.
+3. If the cookie has expired AND extraction returns nothing newer, the tile transitions to AUTH with message "session expired — re-login at opencode.ai". The user logs in to the provider in their browser; next poll extracts the fresh cookie and the tile flips back to OK.
+
+This is graceful and doesn't require any TUI interaction during the common refresh flow.
+
+### 5.6 Privacy / consent boundary
+
+Reading another app's data is touchy. Mitigations:
+
+1. **Off by default.** Cookie auth is opt-in per-account. The TUI flow above is the only place it gets enabled.
+2. **Scoped by domain.** We only ever ask kooky for `(domain, cookie_name)` — never enumerate cookies, never read other domains.
+3. **First-extraction OS prompt.** On macOS, the first read of Chrome's keychain entry triggers a system dialog ("openusage wants to access Chrome Safe Storage") — the user explicitly approves at the OS level. We don't suppress this; it's the right confirmation.
+4. **Local-only.** The cookie blob never leaves the user's machine. No outbound network calls except to the provider itself.
+5. **Documented in README.** The README provider table will note "cookie auth (read from browser)" so it's not hidden.
+
+### 5.7 Failure modes & how the tile reflects them
+
+| Situation | Tile state | Message |
+|---|---|---|
+| Cookie not configured | normal API-key state (no degradation) | API-key auth only — connect a browser session for billing data |
+| Cookie present, extraction OK, RPC OK | OK | (provider-specific message) |
+| Cookie present, extraction OK, RPC 401 | AUTH | session invalid — re-login at provider.com |
+| Cookie present, extraction failed (browser DB locked) | LAST_KNOWN | extraction failed: browser may be open. Retrying. |
+| Cookie expired AND no fresh one in browser | AUTH | session expired — re-login at provider.com |
+| User on Windows Chrome v20+ (App-Bound Enc.) | UNSUPPORTED | App-Bound Encryption blocks reads. Use Firefox / Edge for this provider. |
+
+### 5.N Backward Compatibility
+
+- Pure additive: existing API-key providers stay as they are. New `ProviderAuthTypeBrowserSession` only opts in providers that declare it.
+- Existing credentials store gains a new `kind` field. Older entries default to `"api_key"`. No migration needed.
+- New `kooky` dependency is the only new import.
+
+## 6. Alternatives Considered
+
+### A: Bundled headless browser (Playwright / Chromedp)
+
+Spawn a controlled Chromium that drives the OAuth flow start to finish, then exfiltrates the cookie via DevTools Protocol. Rejected:
+- Bundle size: ~100MB Chrome + Playwright ~200MB.
+- Brittleness: provider UI changes break automation.
+- User experience: a chrome window opens for a few seconds, feels weird.
+- Bot detection: Cloudflare Turnstile and similar may block headless flows.
+
+### B: Browser extension companion
+
+A tiny extension that listens for relevant logins and posts the cookie to a localhost socket. Rejected:
+- Install friction (Chrome Web Store + Firefox Add-ons + Safari Extension separately).
+- Review-cycle overhead for cross-store updates.
+- Users dislike installing extensions for "trust" reasons.
+
+### C: Hosted OAuth proxy
+
+Openusage runs a backend that initiates OAuth on the user's behalf, captures the callback, and returns the session. Rejected:
+- We don't operate services and don't want to.
+- Trust posture (we sit in the middle of every auth flow). Bad look.
+- Single point of failure for the dashboard.
+
+### D: Reverse-proxy interception
+
+Spawn a local HTTPS proxy with a CA cert the user trusts, intercept the cookie on the next provider login. Rejected:
+- Asking users to install a CA cert is a serious security ask.
+- Browser HSTS pinning blocks this for many providers.
+- Opens a wider attack surface than necessary.
+
+### E: Wait for upstream PATs / bearer-token support
+
+File issues with OpenCode and Perplexity asking for PATs. Track. Don't gate on it.
+
+This is **complementary**, not an alternative. We file the issues regardless. If they ship PATs, we replace cookie auth with PATs and the cookie code becomes dead.
+
+### F: Manual cookie paste
+
+User's stated NO. Documented for completeness only — would have been the simplest implementation but isn't acceptable UX.
+
+## 7. Implementation Tasks
+
+### Task 1: core types + auth spec extension
+Files: `internal/core/provider.go`, `internal/core/provider_spec.go`, tests
+Depends on: none
+Description: Add `ProviderAuthTypeBrowserSession`, `BrowserCookieRef` struct, `SupplementalTypes`/`BrowserCookieDomain`/`BrowserCookieName` on `ProviderAuthSpec`. Backward-compatible defaults.
+Tests: marshalling of new fields, default value semantics.
+
+### Task 2: cookie extractor abstraction
+Files: `internal/browsercookies/cookies.go`, `internal/browsercookies/cookies_test.go`
+Depends on: Task 1
+Description: Thin wrapper over `github.com/browserutils/kooky`. Exposes `ReadCookie(ctx, domain, name) (BrowserCookie, error)` + `ListSourceBrowsers() []string`. Sets a strict timeout (10s) so a slow keychain prompt doesn't block the daemon.
+Tests: mock kooky-like backend, success / not-found / timeout / multi-browser preference order.
+
+### Task 3: credentials store extension
+Files: `internal/credentials/store.go`, `internal/credentials/store_test.go`
+Depends on: Task 1
+Description: `kind` field on stored entries. `kind=browser_session` entries persist `value`, `expiry`, `last_extracted_at`, `source_browser`. Migration: existing entries default `kind=api_key`. Encryption-at-rest unchanged.
+Tests: round-trip with new fields; legacy load.
+
+### Task 4: TUI 5 KEYS extensions
+Files: `internal/tui/settings_modal_input.go`, `internal/tui/settings_modal_preferences.go`, `internal/tui/settings_modal_layout.go`, new `internal/tui/browser_session_picker.go`, tests
+Depends on: Tasks 2, 3
+Description: For accounts with `SupplementalTypes` containing `browser_session`: a new sub-state for connect modal (the "y / r / esc" picker), a `connectBrowserSessionCmd` that calls into the extractor, status updates on the row.
+Tests: modal open / read action / cancel / extraction failure handling.
+
+### Task 5: OpenCode provider integration
+Files: `internal/providers/opencode/console_rpc.go` (new), `internal/providers/opencode/seroval.go` (new), `internal/providers/opencode/provider.go` (extend Fetch), tests + fixtures
+Depends on: Tasks 1, 2, 3
+Description: Mini Seroval parser (~150 LOC), thin RPC client that POSTs to `/_server` with the cookie + `x-server-id`, four pinned action IDs (billing.get, queryUsage, queryUsageMonth, queryKeys) with comments dating them. Map results into existing tile metric keys: `balance`, `monthly_usage`, `monthly_limit`, `payment_method_last4`, `subscription_plan`, etc.
+Tests: Seroval parser round-trips for our concrete fixtures from the captured HAR; extractor injection so tests don't touch a real browser; tile metrics populated correctly with both cookies-only and api-key-only paths; cookie-expired transitions to AUTH.
+
+### Task 6: docs + README
+Files: `README.md`, `docs/providers.md`, `docs/BROWSER_SESSION_AUTH_DESIGN.md` (this), `configs/example_settings.json`
+Depends on: Task 5
+Description: Document opt-in cookie auth, supported browsers, the privacy posture, failure modes. Add a row in providers.md for OpenCode noting "cookie auth available for billing data".
+
+### Task 7: Perplexity provider integration (separate PR)
+Files: `internal/providers/perplexity/...`
+Depends on: Tasks 1–4
+Description: New provider package that uses the same browser-session machinery against Perplexity's `/rest/pplx-api/v2/groups/...` endpoints. Out of scope for this PR — covered in #79's Perplexity follow-up.
+
+### Dependency Graph
+
+```
+Task 1 ──┐
+         ├─→ Task 2 ─┐
+         └─→ Task 3 ─┼─→ Task 4 ──┐
+                     └─→ Task 5 ──┴─→ Task 6
+```
+
+Task 7 is a separate downstream effort.
+
+## 8. Open Questions
+
+1. **Chrome App-Bound Encryption on Windows v20+.** Is a workable path. Worth confirming kooky's current state before committing; if dead, document as "use Firefox/Edge on Windows for cookie source".
+2. **Should the cookie ref store the source browser or auto-rediscover each poll?** Storing it is faster; rediscovering is more resilient if the user switches browsers. Default to storing with a "rediscover if not found" fallback.
+3. **What if the user has multiple Chrome profiles?** kooky reads the default profile. v1 limitation; document.
+4. **Do we want to expire cookies proactively or lazily?** Lazy (on next poll) is simpler; proactive (background timer) refreshes faster after a re-login. Lazy for v1.

--- a/internal/providers/moonshot/moonshot.go
+++ b/internal/providers/moonshot/moonshot.go
@@ -229,11 +229,45 @@ func (p *Provider) fetchBalance(ctx context.Context, url, apiKey string, snap *c
 	voucher := bal.Data.VoucherBalance
 	cash := bal.Data.CashBalance
 
-	snap.Metrics["available_balance"] = core.Metric{Remaining: &available, Unit: currency, Window: "current"}
-	snap.Metrics["cash_balance"] = core.Metric{Remaining: &cash, Unit: currency, Window: "current"}
-	snap.Metrics["voucher_balance"] = core.Metric{Remaining: &voucher, Unit: currency, Window: "current"}
+	// Moonshot's API only returns the currently-remaining balance — there's
+	// no lifetime-deposit or lifetime-spend field. To render gauges with a
+	// real denominator we persist a per-account high-water-mark of each
+	// balance dimension and use that as the Limit. A new top-up bumps the
+	// peak; spend-down then fills the gauge between Limit and Remaining.
+	peaks := updatePeaks(snap.AccountID, peakState{
+		PeakAvailable: available,
+		PeakCash:      cash,
+		PeakVoucher:   voucher,
+	})
+
+	snap.Metrics["available_balance"] = balanceMetric(peaks.PeakAvailable, available, currency)
+	snap.Metrics["cash_balance"] = balanceMetric(peaks.PeakCash, cash, currency)
+	snap.Metrics["voucher_balance"] = balanceMetric(peaks.PeakVoucher, voucher, currency)
 
 	return nil
+}
+
+// balanceMetric builds a fully-populated balance Metric from a persisted peak
+// (Limit) and the current remaining value. Used = Limit - Remaining is the
+// implicit spend since the peak. When peak == 0 (first poll, account never
+// observed in this state file) we still set Limit so the gauge shows full;
+// the peak is simultaneously updated so subsequent polls have proper data.
+func balanceMetric(peak, remaining float64, currency string) core.Metric {
+	limit := peak
+	if limit < remaining {
+		limit = remaining
+	}
+	used := limit - remaining
+	if used < 0 {
+		used = 0
+	}
+	return core.Metric{
+		Limit:     core.Float64Ptr(limit),
+		Remaining: core.Float64Ptr(remaining),
+		Used:      core.Float64Ptr(used),
+		Unit:      currency,
+		Window:    "current",
+	}
 }
 
 // applyBalanceStatus promotes Status / Message based on remaining available balance.

--- a/internal/providers/moonshot/moonshot_test.go
+++ b/internal/providers/moonshot/moonshot_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -83,6 +84,9 @@ func startFake(t *testing.T, opts fakeServerOpts) *httptest.Server {
 func setKey(t *testing.T, value string) {
 	t.Helper()
 	t.Setenv("TEST_MOONSHOT_KEY", value)
+	// Each test gets an isolated state file so peak-tracking from previous
+	// runs (or from another running daemon on the dev box) can't leak in.
+	t.Setenv("OPENUSAGE_MOONSHOT_STATE_PATH", filepath.Join(t.TempDir(), "moonshot-state.json"))
 }
 
 func newAcct(server, accountID string) core.AccountConfig {
@@ -131,6 +135,14 @@ func TestFetch_Success_International(t *testing.T) {
 	}
 	if avail.Unit != "USD" {
 		t.Errorf("available_balance unit = %q, want USD", avail.Unit)
+	}
+	// First poll: peak == observed, so Limit = 15, Used = 0. Gauge
+	// renders at 0% — accurate, and it'll fill as the user spends.
+	if avail.Limit == nil || *avail.Limit != 15 {
+		t.Errorf("available_balance Limit = %+v, want 15", avail.Limit)
+	}
+	if avail.Used == nil || *avail.Used != 0 {
+		t.Errorf("available_balance Used = %+v, want 0", avail.Used)
 	}
 
 	rpm, ok := snap.Metrics["rpm"]

--- a/internal/providers/moonshot/state.go
+++ b/internal/providers/moonshot/state.go
@@ -1,0 +1,156 @@
+package moonshot
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// peakState tracks the highest balance value ever observed per account, per
+// balance dimension. Moonshot's API exposes only the *remaining* balance;
+// without the deposit total, gauges can't render. We derive the deposit
+// approximation by remembering the maximum balance we've ever seen.
+//
+// Self-corrects: on the next top-up the peak is bumped to the new high. Worst
+// case (openusage installed mid-cycle, no top-up since) is a stable
+// "essentially full" gauge until the next top-up — which is honest about what
+// we actually know.
+type peakState struct {
+	PeakAvailable float64   `json:"peak_available_balance"`
+	PeakCash      float64   `json:"peak_cash_balance"`
+	PeakVoucher   float64   `json:"peak_voucher_balance"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// stateFile maps accountID → peakState. Loaded/saved as a single JSON blob to
+// keep IO simple. The file lives next to the telemetry SQLite so it inherits
+// the same state-dir conventions.
+type stateFile struct {
+	Version  int                  `json:"version"`
+	Accounts map[string]peakState `json:"accounts"`
+}
+
+const stateFileVersion = 1
+
+var stateMu sync.Mutex
+
+// stateFilePath returns the canonical location for the provider's peak state.
+// Override via OPENUSAGE_MOONSHOT_STATE_PATH for tests.
+func stateFilePath() (string, error) {
+	if override := os.Getenv("OPENUSAGE_MOONSHOT_STATE_PATH"); override != "" {
+		return override, nil
+	}
+	dir, err := stateBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "provider_state", "moonshot.json"), nil
+}
+
+func stateBaseDir() (string, error) {
+	switch runtime.GOOS {
+	case "windows":
+		appData := os.Getenv("LOCALAPPDATA")
+		if appData == "" {
+			appData = os.Getenv("APPDATA")
+		}
+		if appData == "" {
+			return "", fmt.Errorf("no LOCALAPPDATA/APPDATA in environment")
+		}
+		return filepath.Join(appData, "openusage"), nil
+	default:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".local", "state", "openusage"), nil
+	}
+}
+
+func loadState() (stateFile, error) {
+	path, err := stateFilePath()
+	if err != nil {
+		return stateFile{Version: stateFileVersion, Accounts: map[string]peakState{}}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return stateFile{Version: stateFileVersion, Accounts: map[string]peakState{}}, nil
+		}
+		return stateFile{Version: stateFileVersion, Accounts: map[string]peakState{}}, err
+	}
+	var sf stateFile
+	if err := json.Unmarshal(data, &sf); err != nil {
+		// Corrupt file — start fresh rather than blow up. The loss is one
+		// historical peak, which self-heals on the next top-up.
+		return stateFile{Version: stateFileVersion, Accounts: map[string]peakState{}}, nil
+	}
+	if sf.Accounts == nil {
+		sf.Accounts = map[string]peakState{}
+	}
+	if sf.Version == 0 {
+		sf.Version = stateFileVersion
+	}
+	return sf, nil
+}
+
+func saveState(sf stateFile) error {
+	path, err := stateFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(sf, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// updatePeaks loads the persisted state for accountID, bumps any peak whose
+// observed value exceeds the stored value, persists if anything changed, and
+// returns the resulting peaks. On any IO error it falls back to "peaks =
+// observed" so gauges still render — preserving correctness over persistence.
+func updatePeaks(accountID string, observed peakState) peakState {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	sf, _ := loadState()
+	current := sf.Accounts[accountID]
+
+	merged := peakState{
+		PeakAvailable: maxFloat(current.PeakAvailable, observed.PeakAvailable),
+		PeakCash:      maxFloat(current.PeakCash, observed.PeakCash),
+		PeakVoucher:   maxFloat(current.PeakVoucher, observed.PeakVoucher),
+	}
+	changed := merged.PeakAvailable != current.PeakAvailable ||
+		merged.PeakCash != current.PeakCash ||
+		merged.PeakVoucher != current.PeakVoucher
+	if changed {
+		merged.UpdatedAt = time.Now().UTC()
+		sf.Accounts[accountID] = merged
+		_ = saveState(sf)
+	} else {
+		// Preserve the old timestamp when nothing changed, so the file isn't
+		// rewritten on every poll just to bump UpdatedAt.
+		merged.UpdatedAt = current.UpdatedAt
+	}
+	return merged
+}
+
+func maxFloat(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/providers/moonshot/state_test.go
+++ b/internal/providers/moonshot/state_test.go
@@ -1,0 +1,162 @@
+package moonshot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// On a series of polls where the balance only goes down, the gauge's Limit
+// must stay pinned at the original peak — that's the whole point of the
+// high-water-mark mechanism. Otherwise gauges would always show 0% used.
+func TestPeak_PinsLimitAcrossSpend(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "moonshot-state.json")
+	t.Setenv("TEST_MOONSHOT_KEY", "sk-test")
+	t.Setenv("OPENUSAGE_MOONSHOT_STATE_PATH", statePath)
+
+	// Ramp the server's "current balance" down across polls.
+	balances := []float64{15.0, 14.5, 12.0, 10.0}
+	step := 0
+	server := httptest.NewServer(handlerStub(t, func() string {
+		i := step
+		if i >= len(balances) {
+			i = len(balances) - 1
+		}
+		return balanceBody(balances[i], 5, balances[i]-5)
+	}))
+	defer server.Close()
+
+	acct := core.AccountConfig{
+		ID:        "moonshot-ai",
+		Provider:  "moonshot",
+		APIKeyEnv: "TEST_MOONSHOT_KEY",
+		BaseURL:   server.URL,
+	}
+
+	for ; step < len(balances); step++ {
+		snap, err := New().Fetch(context.Background(), acct)
+		if err != nil {
+			t.Fatalf("step %d Fetch error: %v", step, err)
+		}
+		bal := snap.Metrics["available_balance"]
+		if bal.Limit == nil || *bal.Limit != 15.0 {
+			t.Errorf("step %d Limit = %v, want 15 (peak should be pinned)", step, bal.Limit)
+		}
+		if bal.Remaining == nil || *bal.Remaining != balances[step] {
+			t.Errorf("step %d Remaining = %v, want %v", step, bal.Remaining, balances[step])
+		}
+		wantUsed := 15.0 - balances[step]
+		if bal.Used == nil || *bal.Used != wantUsed {
+			t.Errorf("step %d Used = %v, want %v", step, bal.Used, wantUsed)
+		}
+	}
+}
+
+// A top-up bumps the peak. The gauge's Limit grows to match the new high.
+func TestPeak_TopUpRaisesLimit(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "moonshot-state.json")
+	t.Setenv("TEST_MOONSHOT_KEY", "sk-test")
+	t.Setenv("OPENUSAGE_MOONSHOT_STATE_PATH", statePath)
+
+	currentBalance := 15.0
+	server := httptest.NewServer(handlerStub(t, func() string {
+		return balanceBody(currentBalance, 5, currentBalance-5)
+	}))
+	defer server.Close()
+
+	acct := core.AccountConfig{
+		ID:        "moonshot-ai",
+		Provider:  "moonshot",
+		APIKeyEnv: "TEST_MOONSHOT_KEY",
+		BaseURL:   server.URL,
+	}
+
+	// First poll: peak = 15
+	snap, err := New().Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := *snap.Metrics["available_balance"].Limit; got != 15 {
+		t.Fatalf("initial Limit = %v, want 15", got)
+	}
+
+	// Spend down to 5, peak still 15
+	currentBalance = 5.0
+	snap, err = New().Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := *snap.Metrics["available_balance"].Limit; got != 15 {
+		t.Fatalf("post-spend Limit = %v, want 15 (peak pinned)", got)
+	}
+
+	// Top-up to 50 — peak must follow.
+	currentBalance = 50.0
+	snap, err = New().Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := *snap.Metrics["available_balance"].Limit; got != 50 {
+		t.Fatalf("post-topup Limit = %v, want 50", got)
+	}
+	if got := *snap.Metrics["available_balance"].Used; got != 0 {
+		t.Errorf("post-topup Used = %v, want 0 (full balance)", got)
+	}
+}
+
+// Per-account peaks are isolated — one account's top-up doesn't bleed into
+// another account's gauge.
+func TestPeak_PerAccountIsolation(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "moonshot-state.json")
+	t.Setenv("TEST_MOONSHOT_KEY", "sk-test")
+	t.Setenv("OPENUSAGE_MOONSHOT_STATE_PATH", statePath)
+
+	balances := map[string]float64{
+		"moonshot-ai": 100,
+		"moonshot-cn": 5,
+	}
+	currentAccount := ""
+	server := httptest.NewServer(handlerStub(t, func() string {
+		return balanceBody(balances[currentAccount], 0, balances[currentAccount])
+	}))
+	defer server.Close()
+
+	for _, accountID := range []string{"moonshot-ai", "moonshot-cn"} {
+		currentAccount = accountID
+		acct := core.AccountConfig{
+			ID:        accountID,
+			Provider:  "moonshot",
+			APIKeyEnv: "TEST_MOONSHOT_KEY",
+			BaseURL:   server.URL,
+		}
+		snap, err := New().Fetch(context.Background(), acct)
+		if err != nil {
+			t.Fatalf("%s: %v", accountID, err)
+		}
+		want := balances[accountID]
+		if got := *snap.Metrics["available_balance"].Limit; got != want {
+			t.Errorf("%s peak Limit = %v, want %v", accountID, got, want)
+		}
+	}
+}
+
+// handlerStub returns a request handler that responds with userInfoBody for
+// /v1/users/me and the result of bodyFn() for /v1/users/me/balance.
+func handlerStub(t *testing.T, bodyFn func() string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case userInfoPath:
+			_, _ = w.Write([]byte(userInfoBody()))
+		case balancePath:
+			_, _ = w.Write([]byte(bodyFn()))
+		default:
+			w.WriteHeader(404)
+		}
+	})
+}

--- a/internal/providers/moonshot/widget.go
+++ b/internal/providers/moonshot/widget.go
@@ -6,13 +6,15 @@ func dashboardWidget() core.DashboardWidget {
 	cfg := core.DefaultDashboardWidget()
 	cfg.ColorRole = core.DashboardColorRoleMauve
 
-	// Moonshot doesn't return per-request Remaining for rate limits, so gauges
-	// surface the balance breakdown — which has both a meaningful value and
-	// an implicit cap (the cumulative deposit).
-	cfg.GaugePriority = []string{
-		"available_balance", "cash_balance", "voucher_balance",
-	}
-	cfg.GaugeMaxLines = 2
+	// One gauge — total spent vs cumulative deposit (high-water-mark of the
+	// observed available balance). Cash/voucher breakdown lives in compact
+	// rows below; surfacing them as gauges too would be redundant noise
+	// (cash + voucher == available by construction).
+	//
+	// Gauge fill semantics in this codebase = "% used" — see
+	// internal/core/metric_semantics.go. Labels below match that.
+	cfg.GaugePriority = []string{"available_balance"}
+	cfg.GaugeMaxLines = 1
 
 	cfg.CompactRows = []core.DashboardCompactRow{
 		{Label: "Balance", Keys: []string{"available_balance", "cash_balance", "voucher_balance"}, MaxSegments: 4},
@@ -23,16 +25,17 @@ func dashboardWidget() core.DashboardWidget {
 	}
 
 	cfg.MetricLabelOverrides = map[string]string{
-		"available_balance": "Available",
-		"cash_balance":      "Cash",
-		"voucher_balance":   "Vouchers",
+		// Detail-panel labels — "Spent" matches the "% used" gauge fill.
+		"available_balance": "Spent",
+		"cash_balance":      "Cash spent",
+		"voucher_balance":   "Voucher spent",
 		"rpm":               "Req / min",
 		"tpm":               "Tokens / min",
 		"concurrency_max":   "Concurrency",
-		"total_token_quota": "Token Quota",
+		"total_token_quota": "Token quota",
 	}
 	cfg.CompactMetricLabelOverrides = map[string]string{
-		"available_balance": "avail",
+		"available_balance": "spent",
 		"cash_balance":      "cash",
 		"voucher_balance":   "vouch",
 		"concurrency_max":   "conc",

--- a/internal/providers/opencode/provider.go
+++ b/internal/providers/opencode/provider.go
@@ -2,15 +2,33 @@ package opencode
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/janekbaraniewski/openusage/internal/core"
-	"github.com/janekbaraniewski/openusage/internal/providers/openrouter"
 	"github.com/janekbaraniewski/openusage/internal/providers/providerbase"
+	"github.com/janekbaraniewski/openusage/internal/providers/shared"
+)
+
+// OpenCode Zen exposes only OpenAI-compatible chat/messages/models endpoints
+// behind its API-key auth (verified via reverse-engineering against the
+// upstream source at github.com/anomalyco/opencode). Billing, usage history,
+// and key management live behind session-cookie SolidStart RPCs that this
+// provider does not (yet) authenticate against — those would need a separate
+// cookie-based code path.
+//
+// As a result, the only signal we get from a poll is "is this key valid?".
+// Tile metrics (token spend, model burn, project breakdown, tool usage,
+// activity totals) come from the OpenCode telemetry plugin and flow in via
+// the telemetry pipeline once an account with provider_id=opencode exists.
+const (
+	defaultBaseURL = "https://opencode.ai"
+	modelsPath     = "/zen/v1/models"
 )
 
 type Provider struct {
 	providerbase.Base
-	delegate core.UsageProvider
 }
 
 func New() *Provider {
@@ -19,8 +37,8 @@ func New() *Provider {
 			ID: "opencode",
 			Info: core.ProviderInfo{
 				Name:         "OpenCode",
-				Capabilities: []string{"openrouter_compatible", "credits_endpoint", "activity_endpoint", "generation_stats"},
-				DocURL:       "https://opencode.ai/",
+				Capabilities: []string{"zen_models_endpoint", "telemetry_driven_metrics"},
+				DocURL:       "https://opencode.ai/docs/",
 			},
 			Auth: core.ProviderAuthSpec{
 				Type:             core.ProviderAuthTypeAPIKey,
@@ -29,20 +47,63 @@ func New() *Provider {
 			},
 			Setup: core.ProviderSetupSpec{
 				Quickstart: []string{
-					"Set OPENCODE_API_KEY (or ZEN_API_KEY) with your OpenCode gateway key.",
-					"Optionally set a custom account base URL if your gateway endpoint differs.",
+					"Set OPENCODE_API_KEY (or ZEN_API_KEY) with your OpenCode Zen key.",
+					"Tile spend / model / activity metrics are populated from the OpenCode telemetry plugin; see Settings → 7 INTEG.",
 				},
 			},
 		}),
-		delegate: openrouter.New(),
 	}
 }
 
+type modelsResponse struct {
+	Object string `json:"object"`
+	Data   []struct {
+		ID      string `json:"id"`
+		OwnedBy string `json:"owned_by"`
+	} `json:"data"`
+}
+
 func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.UsageSnapshot, error) {
-	snap, err := p.delegate.Fetch(ctx, acct)
-	if err != nil {
-		return snap, err
+	apiKey, authSnap := shared.RequireAPIKey(acct, p.ID())
+	if authSnap != nil {
+		return *authSnap, nil
 	}
-	snap.ProviderID = p.ID()
+
+	baseURL := shared.ResolveBaseURL(acct, defaultBaseURL)
+	snap := core.NewUsageSnapshot(p.ID(), acct.ID)
+	snap.SetAttribute("auth_scope", "zen")
+	snap.SetAttribute("api_base_url", baseURL)
+
+	var models modelsResponse
+	statusCode, _, err := shared.FetchJSON(ctx, baseURL+modelsPath, apiKey, &models, p.Client())
+	if err != nil {
+		switch statusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			snap.Status = core.StatusAuth
+			snap.Message = fmt.Sprintf("HTTP %d – check OPENCODE_API_KEY", statusCode)
+			return snap, nil
+		case http.StatusTooManyRequests:
+			snap.Status = core.StatusLimited
+			snap.Message = "rate limited (HTTP 429)"
+			return snap, nil
+		}
+		return snap, fmt.Errorf("opencode zen models: %w", err)
+	}
+
+	if len(models.Data) > 0 {
+		ids := make([]string, 0, len(models.Data))
+		for _, m := range models.Data {
+			if id := strings.TrimSpace(m.ID); id != "" {
+				ids = append(ids, id)
+			}
+		}
+		snap.SetAttribute("available_models", strings.Join(ids, ", "))
+		snap.SetAttribute("available_models_count", fmt.Sprintf("%d", len(ids)))
+	}
+
+	shared.FinalizeStatus(&snap)
+	if snap.Status == core.StatusOK {
+		snap.Message = fmt.Sprintf("Auth OK · %d Zen models", len(models.Data))
+	}
 	return snap, nil
 }

--- a/internal/providers/opencode/provider_test.go
+++ b/internal/providers/opencode/provider_test.go
@@ -1,0 +1,124 @@
+package opencode
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+func zenModelsBody() string {
+	return `{
+		"object": "list",
+		"data": [
+			{"id": "minimax-m2.7", "object": "model", "created": 1, "owned_by": "opencode"},
+			{"id": "kimi-k2.6",   "object": "model", "created": 1, "owned_by": "opencode"},
+			{"id": "glm-5",       "object": "model", "created": 1, "owned_by": "opencode"}
+		]
+	}`
+}
+
+func startFakeZen(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != modelsPath {
+			http.NotFound(w, r)
+			return
+		}
+		// Verify the request carries Bearer auth — the provider would lose its
+		// reason for existing if it forgot to attach it.
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			http.Error(w, "missing bearer", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func newAcct(t *testing.T, baseURL string) core.AccountConfig {
+	t.Helper()
+	t.Setenv("TEST_OPENCODE_KEY", "sk-zen-test-1234567890")
+	return core.AccountConfig{
+		ID:        "opencode",
+		Provider:  "opencode",
+		APIKeyEnv: "TEST_OPENCODE_KEY",
+		BaseURL:   baseURL,
+	}
+}
+
+func TestFetch_Success_AuthOKExposesModels(t *testing.T) {
+	server := startFakeZen(t, http.StatusOK, zenModelsBody())
+	defer server.Close()
+
+	snap, err := New().Fetch(context.Background(), newAcct(t, server.URL))
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if snap.Status != core.StatusOK {
+		t.Fatalf("status = %s (msg=%q), want OK", snap.Status, snap.Message)
+	}
+	if got := snap.Attributes["available_models_count"]; got != "3" {
+		t.Errorf("available_models_count = %q, want 3", got)
+	}
+	if got := snap.Attributes["available_models"]; !strings.Contains(got, "minimax-m2.7") || !strings.Contains(got, "glm-5") {
+		t.Errorf("available_models missing expected ids: %q", got)
+	}
+	if got := snap.Attributes["auth_scope"]; got != "zen" {
+		t.Errorf("auth_scope = %q, want zen", got)
+	}
+	if !strings.Contains(snap.Message, "3") {
+		t.Errorf("message should reference the model count: %q", snap.Message)
+	}
+}
+
+func TestFetch_AuthRequired_NoKey(t *testing.T) {
+	acct := core.AccountConfig{
+		ID:        "opencode",
+		Provider:  "opencode",
+		APIKeyEnv: "TEST_OPENCODE_MISSING",
+	}
+	snap, err := New().Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if snap.Status != core.StatusAuth {
+		t.Errorf("status = %s, want AUTH_REQUIRED", snap.Status)
+	}
+}
+
+func TestFetch_AuthFailed_401(t *testing.T) {
+	server := startFakeZen(t, http.StatusUnauthorized, `{"error":"unauthorized"}`)
+	defer server.Close()
+
+	snap, err := New().Fetch(context.Background(), newAcct(t, server.URL))
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if snap.Status != core.StatusAuth {
+		t.Errorf("status = %s, want AUTH on 401", snap.Status)
+	}
+	if !strings.Contains(snap.Message, "401") {
+		t.Errorf("message = %q, expected to mention 401", snap.Message)
+	}
+}
+
+func TestFetch_RateLimited_429(t *testing.T) {
+	server := startFakeZen(t, http.StatusTooManyRequests, `{}`)
+	defer server.Close()
+
+	snap, err := New().Fetch(context.Background(), newAcct(t, server.URL))
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if snap.Status != core.StatusLimited {
+		t.Errorf("status = %s, want LIMITED on 429", snap.Status)
+	}
+}

--- a/internal/tui/model_display_info.go
+++ b/internal/tui/model_display_info.go
@@ -76,6 +76,43 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 		snap.Metrics["today_api_cost"].Used != nil,
 		snap.Metrics["spend_limit"].Limit != nil)
 
+	// available_balance with Used + Limit (e.g. Moonshot via high-water-mark
+	// tracking): cursor-style "$0.13 / $15.00 spent" + "$14.87 remaining".
+	// Must come before the spend_limit / plan_spend branches so providers that
+	// surface a peak-derived balance get the rich header instead of falling
+	// through to the bare "$X.XX available" total_balance branch.
+	if m, ok := snap.Metrics["available_balance"]; ok && m.Limit != nil && m.Used != nil {
+		remaining := *m.Limit - *m.Used
+		if m.Remaining != nil {
+			remaining = *m.Remaining
+		}
+		unit := m.Unit
+		if unit == "" {
+			unit = "USD"
+		}
+		// Currency symbol for USD/CNY; everything else gets the unit string.
+		sym := unit
+		switch unit {
+		case "USD":
+			sym = "$"
+		case "CNY":
+			sym = "¥"
+		}
+		info.tagEmoji = "💰"
+		info.tagLabel = "Credits"
+		info.reason = "available_balance"
+		info.summary = fmt.Sprintf("%s%.2f / %s%.2f spent", sym, *m.Used, sym, *m.Limit)
+		info.detail = fmt.Sprintf("%s%.2f remaining", sym, remaining)
+		// m.Percent() returns *remaining* percentage; gauges in this codebase
+		// fill with *used* percentage. Same convention as the spend_limit and
+		// plan_spend branches above.
+		if pct := m.Percent(); pct >= 0 {
+			info.gaugePercent = 100 - pct
+		}
+		core.Tracef("[display] %s: branch=available_balance used=%.4f limit=%.4f gauge=%.1f", snap.ProviderID, *m.Used, *m.Limit, info.gaugePercent)
+		return info
+	}
+
 	if m, ok := snap.Metrics["spend_limit"]; ok && m.Limit != nil && m.Used != nil {
 		remaining := *m.Limit - *m.Used
 		if m.Remaining != nil {

--- a/internal/tui/model_display_test.go
+++ b/internal/tui/model_display_test.go
@@ -144,6 +144,58 @@ func TestSnapshotsReady(t *testing.T) {
 	}
 }
 
+// available_balance is set by Moonshot (and any future provider that derives
+// a peak/limit from a high-water-mark). Display info should produce the
+// cursor-style "$X.XX / $Y.YY spent" + "$Z.ZZ remaining" header so the user
+// sees consumed/total/available at a glance, not just a bare gauge percent.
+func TestComputeDisplayInfo_AvailableBalanceWithPeak_USD(t *testing.T) {
+	limit := 15.0
+	used := 0.13
+	remaining := 14.87
+	snap := core.UsageSnapshot{
+		ProviderID: "moonshot",
+		Status:     core.StatusOK,
+		Metrics: map[string]core.Metric{
+			"available_balance": {Limit: &limit, Used: &used, Remaining: &remaining, Unit: "USD"},
+		},
+	}
+
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	if got.tagLabel != "Credits" {
+		t.Fatalf("tagLabel = %q, want Credits", got.tagLabel)
+	}
+	if !strings.Contains(got.summary, "$0.13 / $15.00 spent") {
+		t.Errorf("summary = %q, want '$0.13 / $15.00 spent'", got.summary)
+	}
+	if !strings.Contains(got.detail, "$14.87 remaining") {
+		t.Errorf("detail = %q, want '$14.87 remaining'", got.detail)
+	}
+	if got.gaugePercent < 0.5 || got.gaugePercent > 1.5 {
+		t.Errorf("gaugePercent = %.2f, want ~0.87 (=%.2f%% of $15)", got.gaugePercent, used/limit*100)
+	}
+}
+
+// Currency-aware formatting: Moonshot.cn variants use CNY, must render with ¥.
+func TestComputeDisplayInfo_AvailableBalanceWithPeak_CNY(t *testing.T) {
+	limit := 100.0
+	used := 5.0
+	remaining := 95.0
+	snap := core.UsageSnapshot{
+		ProviderID: "moonshot",
+		Status:     core.StatusOK,
+		Metrics: map[string]core.Metric{
+			"available_balance": {Limit: &limit, Used: &used, Remaining: &remaining, Unit: "CNY"},
+		},
+	}
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	if !strings.Contains(got.summary, "¥5.00 / ¥100.00 spent") {
+		t.Errorf("summary = %q, want '¥5.00 / ¥100.00 spent'", got.summary)
+	}
+	if !strings.Contains(got.detail, "¥95.00 remaining") {
+		t.Errorf("detail = %q, want '¥95.00 remaining'", got.detail)
+	}
+}
+
 func TestComputeDisplayInfo_SpendLimitWithoutIndividualSpend(t *testing.T) {
 	used := 488.0
 	limit := 3600.0


### PR DESCRIPTION
## Summary

Three bug fixes touching live tile rendering, plus the design doc for the next major piece of work (browser-session auth as the universal solution for dashboard-gated providers).

### Bug fixes

**`fix(opencode)` — replace OpenRouter delegate with Zen models probe** (`cd48fee`)

The opencode provider was delegating Fetch to `openrouter.New()`, hitting `https://openrouter.ai/api/v1` with the OpenCode Zen key. Always 401, surfaced as red "AUTH" on the tile despite a valid key. The "openrouter_compatible" capability tag was an old assumption that doesn't match reality — verified against upstream source ([anomalyco/opencode](https://github.com/anomalyco/opencode)) that OpenCode Zen exposes only OpenAI-compatible endpoints under `/zen/v1/*`.

Replaced the delegate with a focused Fetch that GETs `/zen/v1/models` for auth verification and exposes the available model list. Telemetry continues populating the rich tile metrics (model burn, project, tools).

**`fix(moonshot)` — persist balance high-water-mark for proper gauge rendering** (`653ebce`)

Moonshot's API only returns the *currently-remaining* balance — no lifetime-deposit field, no cumulative usage counter populated for fresh accounts. Setting `Remaining` without `Limit` meant gauges had no denominator and rendered as empty shimmer placeholders.

Persists a per-account high-water-mark of each balance dimension at `~/.local/state/openusage/provider_state/moonshot.json`. Each top-up bumps the peak; spend-down fills the gauge between Limit (peak) and Remaining (current). State file is per-account-keyed, atomic-rename-on-write, falls back to "peak = observed" on any IO error so gauges still render. Self-corrects: if openusage is installed mid-cycle, the next top-up restores accuracy.

**`fix(moonshot)` — rename gauge labels to match "% spent" semantics** (`704d760`)

Gauge fill in this codebase is percent USED (per `metric_semantics.go`). Labels "Available / Cash / Vouchers" implied the inverse — at 0.9% fill they read as "0.9% available" rather than "0.9% spent". Now labels say "Spent / Cash spent / Voucher spent" and there's only one gauge instead of three (cash + voucher == available by construction; redundant).

### Design doc

**`docs: browser-session auth as the universal solution`** (`f923977` + `09cb223`)

Confirmed via live probing that ALL major dashboard-gated providers (OpenAI / ChatGPT / Anthropic / Google AI Studio / OpenCode / Perplexity) hide billing/usage data behind session-cookie auth. OpenAI's own 403 message names the alternative auth class as "session key (browser-only)", explicitly flagging that OAuth tokens cannot reach the surface.

OAuth-token reuse from OpenCode's `auth.json` was tested against fresh tokens and rejected with `Missing scopes: api.model.read`, `OAuth authentication is currently not supported`, etc. — confirming OAuth is structurally insufficient for dashboard data.

Doc designs the universal cookie-auth path (one infrastructure, six providers benefit), with explicit non-goals (no bundled headless browser, no extension, no manual paste, no hosted proxy). Uses `kooky` for cross-platform browser cookie extraction. Per-poll re-extraction handles refresh transparently.

Tasks 8/9/10 added for OpenAI / Anthropic / Google AI Studio downstream provider PRs riding on the shared infrastructure (Tasks 1–4). Closes issue #80's OpenAI gap completely with real platform data, not telemetry-only fallback.

### Chore

`chore: gitignore captured cookie/HAR files` (`df2bafa`) — local protection for provider reverse-engineering artefacts.

## Test plan

- [x] `make build` clean
- [x] `make vet` clean
- [x] `make lint` clean
- [x] `go test ./... -count=1` — all packages green
- [x] OpenCode provider: new tests cover success / no-key / 401 / 429 paths
- [x] Moonshot provider: new tests cover peak-pin-across-spend, top-up-raises-peak, per-account-isolation; existing 10 tests still pass
- [x] Live verified moonshot tile against author's real key — gauges now render correctly with proper Limit/Used/Remaining triples (e.g. `available_balance: $14.87 / $15 (peak)`)

## Out of scope (deliberate)

- Cookie-auth implementation itself — design only in this PR. Implementation lands in a separate branch built on top of this once HARs for all six target providers are captured.
- OAuth-token adoption from `auth.json` — verified unworkable; document closed in design doc rationale section.
- Telemetry-only tiles — separate piece of work; cookie-auth is the better fix for the OpenAI-via-OpenCode case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)