### PR TITLE
feat(detect): extract API keys from shell rc, aider, codex auth, and keychain

### DIFF
--- a/cmd/openusage/detect.go
+++ b/cmd/openusage/detect.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -115,11 +114,11 @@ func displayAuth(a core.AccountConfig) string {
 // or "-" for accounts that don't carry a secret (CLI/local providers).
 func displayCredential(a core.AccountConfig) string {
 	if a.Token != "" {
-		return maskToken(a.Token)
+		return detect.MaskKey(a.Token)
 	}
 	if a.APIKeyEnv != "" {
 		if value := os.Getenv(a.APIKeyEnv); value != "" {
-			return fmt.Sprintf("$%s=%s", a.APIKeyEnv, maskToken(value))
+			return fmt.Sprintf("$%s=%s", a.APIKeyEnv, detect.MaskKey(value))
 		}
 		return fmt.Sprintf("$%s (unset)", a.APIKeyEnv)
 	}
@@ -135,16 +134,6 @@ func displaySource(a core.AccountConfig) string {
 		return "env"
 	}
 	return "-"
-}
-
-// maskToken redacts a secret for display: first/last 4 chars surrounding "...".
-// Mirrors the masking convention used by the detect package's logging.
-func maskToken(s string) string {
-	s = strings.TrimSpace(s)
-	if len(s) <= 12 {
-		return "****"
-	}
-	return s[:4] + "..." + s[len(s)-4:]
 }
 
 // providersWithoutAccount returns the list of provider IDs registered in the

--- a/cmd/openusage/detect.go
+++ b/cmd/openusage/detect.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/janekbaraniewski/openusage/internal/detect"
+	"github.com/janekbaraniewski/openusage/internal/providers"
+)
+
+// newDetectCommand returns the `openusage detect` cobra subcommand. It runs
+// the full credential auto-detection pipeline (without persisting anything)
+// and prints a human-readable report of:
+//
+//   - tools discovered on this workstation,
+//   - accounts and where each credential was sourced from,
+//   - providers we know how to handle but have no credential for yet.
+//
+// Tokens are masked. Use this command to debug "why doesn't openusage see
+// my key?" before opening an issue.
+func newDetectCommand() *cobra.Command {
+	var showAll bool
+	cmd := &cobra.Command{
+		Use:   "detect",
+		Short: "Run the credential auto-detection pipeline and print a report",
+		Long: `Runs the same auto-detection logic openusage uses on startup and prints
+what it found, including which file, env var, or keychain entry each
+credential came from. Tokens are masked. Nothing is written to disk.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			result := detect.AutoDetect()
+			detect.ApplyCredentials(&result)
+			return printDetectReport(os.Stdout, result, showAll)
+		},
+	}
+	cmd.Flags().BoolVar(&showAll, "all", false,
+		"include providers with no credentials in the report")
+	return cmd
+}
+
+func printDetectReport(out io.Writer, result detect.Result, showAll bool) error {
+	// Tools section.
+	fmt.Fprintln(out, "Tools detected:")
+	if len(result.Tools) == 0 {
+		fmt.Fprintln(out, "  (none)")
+	} else {
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		for _, t := range result.Tools {
+			fmt.Fprintf(w, "  %s\t%s\t%s\n", t.Name, t.Type, t.BinaryPath)
+		}
+		_ = w.Flush()
+	}
+
+	// Accounts section.
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Accounts detected:")
+	if len(result.Accounts) == 0 {
+		fmt.Fprintln(out, "  (none)")
+	} else {
+		// Sort by provider then account ID for stable output.
+		sorted := append([]core.AccountConfig(nil), result.Accounts...)
+		sort.Slice(sorted, func(i, j int) bool {
+			if sorted[i].Provider != sorted[j].Provider {
+				return sorted[i].Provider < sorted[j].Provider
+			}
+			return sorted[i].ID < sorted[j].ID
+		})
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "  PROVIDER\tACCOUNT\tAUTH\tCREDENTIAL\tSOURCE")
+		for _, a := range sorted {
+			fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n",
+				a.Provider, a.ID, displayAuth(a), displayCredential(a), displaySource(a))
+		}
+		_ = w.Flush()
+	}
+
+	// Coverage section.
+	fmt.Fprintln(out)
+	missing := providersWithoutAccount(result.Accounts)
+	if len(missing) > 0 {
+		fmt.Fprintln(out, "No credentials found for:")
+		for _, p := range missing {
+			fmt.Fprintf(out, "  - %s\n", p)
+		}
+	} else {
+		fmt.Fprintln(out, "Every registered provider has at least one account.")
+	}
+
+	if showAll {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "All registered providers:")
+		for _, p := range providers.AllProviders() {
+			fmt.Fprintf(out, "  - %s\n", p.ID())
+		}
+	}
+	return nil
+}
+
+// displayAuth returns the visible auth-mode label for a row.
+func displayAuth(a core.AccountConfig) string {
+	if a.Auth == "" {
+		return "-"
+	}
+	return a.Auth
+}
+
+// displayCredential returns a one-word indicator of where the secret lives:
+// a masked Token if we have one, the env-var name we'll resolve at fetch time,
+// or "-" for accounts that don't carry a secret (CLI/local providers).
+func displayCredential(a core.AccountConfig) string {
+	if a.Token != "" {
+		return maskToken(a.Token)
+	}
+	if a.APIKeyEnv != "" {
+		if value := os.Getenv(a.APIKeyEnv); value != "" {
+			return fmt.Sprintf("$%s=%s", a.APIKeyEnv, maskToken(value))
+		}
+		return fmt.Sprintf("$%s (unset)", a.APIKeyEnv)
+	}
+	return "-"
+}
+
+// displaySource returns the credential_source hint, falling back to "-".
+func displaySource(a core.AccountConfig) string {
+	if v := a.Hint("credential_source", ""); v != "" {
+		return v
+	}
+	if a.APIKeyEnv != "" {
+		return "env"
+	}
+	return "-"
+}
+
+// maskToken redacts a secret for display: first/last 4 chars surrounding "...".
+// Mirrors the masking convention used by the detect package's logging.
+func maskToken(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= 12 {
+		return "****"
+	}
+	return s[:4] + "..." + s[len(s)-4:]
+}
+
+// providersWithoutAccount returns the list of provider IDs registered in the
+// global registry that have no detected account.
+func providersWithoutAccount(accounts []core.AccountConfig) []string {
+	have := make(map[string]struct{}, len(accounts))
+	for _, a := range accounts {
+		have[a.Provider] = struct{}{}
+	}
+	var missing []string
+	for _, p := range providers.AllProviders() {
+		if _, ok := have[p.ID()]; !ok {
+			missing = append(missing, p.ID())
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}

--- a/cmd/openusage/detect_test.go
+++ b/cmd/openusage/detect_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/janekbaraniewski/openusage/internal/detect"
 )
 
+// MaskKey behaviour is covered in internal/detect/mask_test.go. The test
+// below just smoke-tests that maskKey is reachable through the report path.
+
 func TestPrintDetectReport_RendersAccountsAndMissing(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 	t.Setenv("ANTHROPIC_API_KEY", "")
@@ -86,7 +89,7 @@ func TestPrintDetectReport_EmptyResult(t *testing.T) {
 	}
 }
 
-func TestMaskToken(t *testing.T) {
+func TestMaskKeyEndToEnd(t *testing.T) {
 	cases := []struct {
 		in, want string
 	}{
@@ -96,8 +99,8 @@ func TestMaskToken(t *testing.T) {
 		{"   sk-test1234567890   ", "sk-t...7890"},
 	}
 	for _, tc := range cases {
-		if got := maskToken(tc.in); got != tc.want {
-			t.Errorf("maskToken(%q) = %q, want %q", tc.in, got, tc.want)
+		if got := detect.MaskKey(tc.in); got != tc.want {
+			t.Errorf("detect.MaskKey(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }

--- a/cmd/openusage/detect_test.go
+++ b/cmd/openusage/detect_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/janekbaraniewski/openusage/internal/detect"
+)
+
+func TestPrintDetectReport_RendersAccountsAndMissing(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	a1 := core.AccountConfig{
+		ID:        "openai",
+		Provider:  "openai",
+		Auth:      "api_key",
+		APIKeyEnv: "OPENAI_API_KEY",
+		Token:     "sk-test1234567890abcdef",
+	}
+	a1.SetHint("credential_source", "shell_rc:/home/u/.zshrc")
+
+	a2 := core.AccountConfig{
+		ID:        "anthropic",
+		Provider:  "anthropic",
+		Auth:      "api_key",
+		APIKeyEnv: "ANTHROPIC_API_KEY",
+	}
+
+	result := detect.Result{
+		Tools: []detect.DetectedTool{
+			{Name: "Cursor IDE", Type: "ide", BinaryPath: "/usr/local/bin/cursor"},
+		},
+		Accounts: []core.AccountConfig{a1, a2},
+	}
+
+	var buf bytes.Buffer
+	if err := printDetectReport(&buf, result, false); err != nil {
+		t.Fatalf("printDetectReport: %v", err)
+	}
+	out := buf.String()
+
+	mustContain := []string{
+		"Tools detected:",
+		"Cursor IDE",
+		"/usr/local/bin/cursor",
+		"Accounts detected:",
+		"openai",
+		"sk-t...cdef",
+		"shell_rc:/home/u/.zshrc",
+		"$ANTHROPIC_API_KEY (unset)",
+		"No credentials found for:",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+
+	// Tokens must NOT appear in clear text.
+	if strings.Contains(out, "sk-test1234567890abcdef") {
+		t.Errorf("clear-text token leaked into report:\n%s", out)
+	}
+}
+
+func TestPrintDetectReport_EmptyResult(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printDetectReport(&buf, detect.Result{}, false); err != nil {
+		t.Fatalf("printDetectReport: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Tools detected:") || !strings.Contains(out, "(none)") {
+		t.Errorf("expected (none) for tools, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Accounts detected:") || !strings.Contains(out, "(none)") {
+		t.Errorf("expected (none) for accounts, got:\n%s", out)
+	}
+	// With no accounts, every registered provider should be in the missing list.
+	if !strings.Contains(out, "No credentials found for:") {
+		t.Errorf("expected missing-providers section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "openai") || !strings.Contains(out, "anthropic") {
+		t.Errorf("expected missing list to include known providers, got:\n%s", out)
+	}
+}
+
+func TestMaskToken(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"sk-test1234567890abcdef", "sk-t...cdef"},
+		{"short", "****"},
+		{"", "****"},
+		{"   sk-test1234567890   ", "sk-t...7890"},
+	}
+	for _, tc := range cases {
+		if got := maskToken(tc.in); got != tc.want {
+			t.Errorf("maskToken(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cmd/openusage/main.go
+++ b/cmd/openusage/main.go
@@ -43,6 +43,7 @@ func main() {
 	})
 	root.AddCommand(newTelemetryCommand())
 	root.AddCommand(newIntegrationsCommand())
+	root.AddCommand(newDetectCommand())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)

--- a/docs/site/docs/concepts/auto-detection.md
+++ b/docs/site/docs/concepts/auto-detection.md
@@ -7,11 +7,15 @@ The first time you run `openusage`, no config file is required. The detector ins
 
 ## What gets scanned
 
-Detection runs three passes:
+Detection runs in four phases. Earlier phases win when the same provider/account ID would be produced twice; the process environment beats every file source.
 
-### 1. Environment variables (API platforms)
+### 1. Tool detectors
 
-For each supported provider, the detector checks whether a known env var is set in the current shell:
+Tool-specific local stores: Cursor's `state.vscdb` (extracts the auth token), Z.AI Coding Helper's `~/.chelper/config.yaml`, Codex's `~/.codex/auth.json` (extracts the top-level `OPENAI_API_KEY` written when you sign in via API key, plus email/plan metadata from the ID token), and the binary+config-dir checks for Claude Code, GitHub Copilot, Gemini CLI, Aider, and Ollama.
+
+### 2. Environment variables (API platforms)
+
+For each supported provider, the detector checks whether a known env var is set in the running process environment:
 
 | Env var | Provider |
 |---|---|
@@ -31,41 +35,56 @@ For each supported provider, the detector checks whether a known env var is set 
 
 If the env var is present, an account is created with `api_key_env` set to that variable name. The actual key value is read at fetch time, never persisted.
 
-### 2. Local binaries and config dirs (coding agents)
+### 3. File-based credential adoption
 
-For coding agents, the detector looks for the CLI binary on `$PATH` plus a config directory that signals the tool has been used:
+When an env var isn't set in the running process — for example because OpenUsage was launched from Spotlight, the Dock, or a desktop launcher that didn't source your shell startup files — the detector falls back to a small set of well-defined credential files:
 
-| Tool | Signals |
-|---|---|
-| Claude Code | `claude` binary + `~/.claude/` |
-| Codex CLI | `~/.codex/` directory |
-| Cursor IDE | App Support directory (`~/Library/Application Support/Cursor`, `~/.config/Cursor`, or `%APPDATA%\Cursor`) |
-| GitHub Copilot | `gh` CLI with Copilot extension, or standalone `copilot` binary + `~/.copilot/` |
-| Gemini CLI | `gemini` binary + `~/.gemini/` |
+| Source | Where | What's adopted |
+|---|---|---|
+| Shell rc files | `~/.zshenv`, `~/.zprofile`, `~/.zshrc`, `~/.bash_profile`, `~/.bashrc`, `~/.profile`, `~/.config/fish/config.fish`, plus modular `~/.zshrc.d/*.zsh`, `~/.bashrc.d/*.sh`, `~/.config/fish/conf.d/*.fish` | `export VAR=...`, plain `VAR=...`, and fish `set -gx VAR ...` lines whose name matches one of the API key envs above. Lines that contain shell substitutions (`$VAR`, `$(...)`, backticks) are skipped — we never invoke a shell. |
+| OpenCode | `~/.local/share/opencode/auth.json` (`%APPDATA%\opencode\auth.json` on Windows) | API-key entries for Moonshot, OpenRouter, Z.AI, OpenCode (Zen), and Ollama Cloud. OAuth-typed entries are recognised but not adopted. |
+| Aider | `.aider.conf.yml` and `.env` in `$HOME`, the closest git repo root, and the current working directory (Aider's documented search path) | Dedicated `openai-api-key`/`anthropic-api-key` YAML scalars, list-form `api-key:` entries (`gemini=...`, `openrouter=...`, etc.), and any standard provider env vars present in the `.env` files. |
 
-### 3. Local services
+A discovered key always sets the account's `credential_source` runtime hint with a precise locator (`shell_rc:/path`, `aider_yaml:/path`, `aider_dotenv:/path`, `opencode_auth_json`, `codex_auth_json`) so you can audit where a credential came from with `openusage detect`.
+
+### 4. OS keychain probes
+
+| Source | Where | What it does |
+|---|---|---|
+| macOS keychain | `Claude Code-credentials` generic password (Anthropic's Claude Code CLI) | Annotates the existing `claude-code` account with `credential_source: keychain:Claude Code-credentials`, or creates a minimal one if file detection missed it (e.g. when the binary isn't on `$PATH` over SSH). The secret value itself is read by the `claude_code` provider at fetch time, not at detect time. |
+
+### Local services
 
 | Service | Signal |
 |---|---|
 | Ollama | local server reachable on `127.0.0.1:11434`, or `OLLAMA_API_KEY` set |
 
-## First-run output
+## Inspecting what was detected
 
-A typical first run looks like this:
+Run the dedicated subcommand to see exactly what the pipeline found, including which file, env var, or keychain entry every credential came from. Tokens are masked; nothing is written to disk.
 
 ```
-$ openusage
-[detect] OPENAI_API_KEY found      → account openai-default
-[detect] ANTHROPIC_API_KEY found   → account anthropic-default
-[detect] claude binary at /usr/local/bin/claude
-[detect] ~/.claude found           → account claude_code-default
-[detect] cursor support dir found  → account cursor-default
-[detect] ollama reachable on :11434 → account ollama-default
+$ openusage detect
+Tools detected:
+  Cursor IDE               ide  /usr/local/bin/cursor
+  Claude Code CLI          cli  /usr/local/bin/claude
+  Ollama                   cli  /usr/local/bin/ollama
 
-5 providers active. Press ? for help.
+Accounts detected:
+  PROVIDER     ACCOUNT       AUTH     CREDENTIAL                   SOURCE
+  claude_code  claude-code   local    -                            keychain:Claude Code-credentials
+  cursor       cursor-ide    token    eyJh...hjIs                  -
+  openai       openai        api_key  $OPENAI_API_KEY=sk-t...cdef  env
+  openrouter   openrouter    api_key  sk-o...24ff                  opencode_auth_json
+  zai          zai           api_key  45e4...cakq                  opencode_auth_json
+
+No credentials found for:
+  - anthropic
+  - groq
+  …
 ```
 
-(Detection messages only appear when `OPENUSAGE_DEBUG=1` is set; the dashboard otherwise launches silently.)
+Pass `--all` to also list every provider in the registry. The same logic runs on dashboard startup; set `OPENUSAGE_DEBUG=1 openusage` to see the per-source `[detect]` log lines instead.
 
 ## Merging with manual configuration
 
@@ -101,15 +120,18 @@ In the example above, auto-detection still creates `openai-default` from `OPENAI
 
 If a provider you expected does not show up, walk through:
 
-1. Is the env var actually exported in the shell that launched OpenUsage? `echo $OPENAI_API_KEY` should print it.
-2. Is the binary on the same `$PATH` OpenUsage sees? `which claude` from the same shell.
-3. Did the tool's config dir get created? Run the tool once before relaunching.
-4. Run `OPENUSAGE_DEBUG=1 openusage` and look at stderr for skipped detections.
+1. Run `openusage detect` and check the "No credentials found for:" list — that's the authoritative inventory of what's missing.
+2. Is the env var either exported in your shell *or* present in one of the file sources above? `openusage detect` will show the `SOURCE` column when something is picked up.
+3. Is the binary on the same `$PATH` OpenUsage sees? `which claude` from the same shell.
+4. Did the tool's config dir get created? Run the tool once before relaunching.
+5. Run `OPENUSAGE_DEBUG=1 openusage` and look at stderr for skipped detections — every adoption logs `[detect] credential_source=...`.
 
 See [provider not detected](../troubleshooting/provider-not-detected.md) for a per-provider checklist.
 
-## What detection does not do
+## What detection does and does not do
 
-- It never reads or stores the value of an API key.
-- It never makes network calls during detection itself; that only happens when a provider's `Fetch()` runs.
-- It does not modify any tool's config (only the integration installer does that).
+- It **does** read raw API key values from a small set of documented locations: shell rc files, Aider config, OpenCode `auth.json`, Codex `auth.json`, Z.AI's `~/.chelper/config.yaml`, Cursor's `state.vscdb`. Adopted values live only in memory under the runtime-only `Token` field (`json:"-"`) — they are never written to `settings.json`.
+- It **does not** invoke any shell or run any user code; shell rc parsing skips lines that would require expansion.
+- It **does not** make network calls during detection itself; that only happens when a provider's `Fetch()` runs.
+- It **does not** read the secret value of OS keychain entries — only their presence. The `claude_code` provider performs the actual keychain read at fetch time.
+- It **does not** modify any tool's config (only the integration installer does that).

--- a/docs/site/docs/getting-started/first-run.md
+++ b/docs/site/docs/getting-started/first-run.md
@@ -14,10 +14,10 @@ You don't need a config file. OpenUsage will create `~/.config/openusage/setting
 
 The more of the following you have on your machine, the more populated the dashboard will be:
 
-- **Coding tools**: `claude` CLI, `cursor`, `codex`, `gemini`, `gh` (with Copilot extension), `ollama`
-- **API keys** in your environment: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, `DEEPSEEK_API_KEY`, `MOONSHOT_API_KEY`, `XAI_API_KEY`, `ZAI_API_KEY`, `GEMINI_API_KEY`, `ALIBABA_CLOUD_API_KEY`
+- **Coding tools**: `claude` CLI, `cursor`, `codex`, `gemini`, `gh` (with Copilot extension), `ollama`, `aider`
+- **API keys** — set as env vars in your shell (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, `DEEPSEEK_API_KEY`, `MOONSHOT_API_KEY`, `XAI_API_KEY`, `ZAI_API_KEY`, `GEMINI_API_KEY`, `ALIBABA_CLOUD_API_KEY`), exported in your shell rc files (`~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish`, modular `~/.zshrc.d/*`), or stored by Aider/OpenCode/Codex in their config files. macOS keychain entries from the Claude Code CLI are also picked up.
 
-A complete list lives in [Environment variables](../reference/env-vars.md).
+A complete list of env-var names lives in [Environment variables](../reference/env-vars.md). To preview what will be detected before launch, run `openusage detect`.
 
 ## Step 1 — Launch
 

--- a/docs/site/docs/reference/cli.md
+++ b/docs/site/docs/reference/cli.md
@@ -12,6 +12,7 @@ The `openusage` binary is the dashboard, the daemon, the hook receiver, and the 
 ```
 openusage                                       # run the dashboard (default)
 openusage version                               # print version and build info
+openusage detect [--all]                        # print credential auto-detection report
 openusage telemetry hook <source> [flags]       # forward an event from a tool hook
 openusage telemetry daemon <subcommand> [flags] # daemon lifecycle
 openusage integrations <subcommand> [flags]     # tool integration management
@@ -32,6 +33,21 @@ openusage version
 ```
 
 Prints the binary version, commit, and build date. Useful for bug reports.
+
+## `openusage detect`
+
+Runs the same auto-detection pipeline used at dashboard startup and prints a report:
+
+- **Tools detected** — name, type (`ide` / `cli`), and binary path.
+- **Accounts detected** — provider, account ID, auth mode, masked credential, and a `SOURCE` column with the precise locator (`env`, `shell_rc:/path`, `aider_yaml:/path`, `aider_dotenv:/path`, `opencode_auth_json`, `codex_auth_json`, `keychain:Claude Code-credentials`, etc.).
+- **No credentials found for** — every registered provider that produced no account.
+
+```
+openusage detect
+openusage detect --all      # also list every registered provider, even those already covered
+```
+
+Tokens are masked (`first4...last4`); nothing is written to disk. Use this to debug "why doesn't OpenUsage see my key?" before opening an issue. See [Auto-detection](../concepts/auto-detection.md) for the full source order.
 
 ## `openusage telemetry hook`
 

--- a/docs/site/docs/reference/env-vars.md
+++ b/docs/site/docs/reference/env-vars.md
@@ -45,6 +45,10 @@ Each provider's account references its key via `api_key_env` — the name of the
 The TUI reads env vars on startup. After exporting a new key, press <kbd>q</kbd> to quit and re-launch — or use the API Keys settings tab (<kbd>,</kbd> then <kbd>5</kbd>) to enter the value at runtime, which writes it to your shell session for future processes only.
 :::
 
+:::info GUI launches and shell rc files
+If OpenUsage is launched from Spotlight, the Dock, or another launcher that doesn't inherit your shell environment, it will still pick up keys exported in `~/.zshrc`, `~/.bashrc`, `~/.zshrc.d/*.zsh`, fish `config.fish`, and similar files — the auto-detector parses them directly. Lines that contain shell substitutions (`$VAR`, `$(...)`, backticks) are intentionally skipped. Run `openusage detect` to see exactly which file each adopted key came from.
+:::
+
 ## CLI tool / local file providers
 
 Some providers don't use API keys; they read local files or shell out to a tool binary. Their `accounts` entries use `binary` rather than `api_key_env`.

--- a/docs/site/docs/troubleshooting/provider-not-detected.md
+++ b/docs/site/docs/troubleshooting/provider-not-detected.md
@@ -5,37 +5,52 @@ description: Per-detection-style checklists for finding why a provider isn't sho
 
 Auto-detection runs in three styles. Use the checklist for the style that matches the missing provider.
 
+The fastest way to see what was found and what's missing is the dedicated subcommand:
+
+```bash
+openusage detect          # show tools, accounts (with masked tokens) and source provenance
+openusage detect --all    # also list every registered provider
+```
+
+The `SOURCE` column tells you exactly where each credential came from (`env`, `shell_rc:/path`, `aider_yaml:/path`, `opencode_auth_json`, `keychain:…`). The trailing "No credentials found for:" list is the authoritative inventory of what's still missing.
+
 ## Style A: env var providers
 
 Affected: `openai`, `anthropic`, `openrouter`, `groq`, `mistral`, `deepseek`, `xai`, `gemini_api`, `alibaba_cloud`, `moonshot`, `zai`, `opencode`.
 
+OpenUsage looks for these keys in this order: process environment → shell rc files (`~/.zshrc`, `~/.bashrc`, fish, modular `~/.zshrc.d/*` etc.) → tool config files (Aider's `.aider.conf.yml`/`.env`, OpenCode's `auth.json`, Codex's `auth.json` `OPENAI_API_KEY` field).
+
 ### Checklist
 
-1. **Is the env var set in the shell that launches OpenUsage?**
+1. **Run `openusage detect`** — if your provider appears with a `SOURCE` column entry, detection is working and the issue is elsewhere (open a [GitHub issue](https://github.com/janekbaraniewski/openusage/issues)).
+
+2. **Is the env var set in the shell that launches OpenUsage, *or* in one of the supported file sources?**
    ```bash
    echo "${OPENAI_API_KEY+set}"
+   grep -E "^(export +)?OPENAI_API_KEY=" ~/.zshrc ~/.zshenv ~/.zshrc.d/*.zsh 2>/dev/null
    ```
-   Empty output means the variable is not exported in this process.
+   If neither prints anything, OpenUsage will not find the key.
 
-2. **Is it `export`ed, not just assigned?**
+3. **Is it `export`ed, not just assigned?** Plain `VAR=value` lines are detected too, but they need to be at the start of a line and not embedded in shell logic.
    ```bash
-   # Wrong (visible only in the current shell, not subprocesses):
-   OPENAI_API_KEY=sk-...
-   # Right:
+   # Both of these are picked up from a rc file:
    export OPENAI_API_KEY=sk-...
+   OPENAI_API_KEY=sk-...
    ```
 
-3. **Is the variable name spelled exactly right?** Case matters. `Openai_Api_Key` will not be picked up.
+4. **Are there shell substitutions in the value?** Lines like `export OPENAI_API_KEY=$(pass openai)` or `export FOO="$BAR"` are intentionally skipped — OpenUsage never invokes a shell. Either pre-resolve the value or set it via the process environment.
 
-4. **For providers with multiple accepted names** (Z.AI accepts `ZAI_API_KEY` or `ZHIPUAI_API_KEY`; OpenCode accepts `OPENCODE_API_KEY` or `ZEN_API_KEY`), at least one must be set.
+5. **Is the variable name spelled exactly right?** Case matters. `Openai_Api_Key` will not be picked up.
 
-5. **Is `auto_detect` enabled?** In `settings.json`:
+6. **For providers with multiple accepted names** (Z.AI accepts `ZAI_API_KEY` or `ZHIPUAI_API_KEY`; OpenCode accepts `OPENCODE_API_KEY` or `ZEN_API_KEY`), at least one must be set.
+
+7. **Is `auto_detect` enabled?** In `settings.json`:
    ```json
    { "auto_detect": true }
    ```
-   If false, no env-var detection happens.
+   If false, no auto-detection happens.
 
-6. **Did you launch from a GUI app launcher?** macOS Finder / Dock launches don't inherit your shell `~/.zshrc` exports. Run `openusage` from a terminal, or move exports into `~/.config/zsh/.zshenv` / launchd.
+8. **GUI launches still work** for shell-rc-stored keys: OpenUsage parses `~/.zshrc` and friends directly, so launching from Spotlight/Dock no longer requires re-exporting in launchd. macOS keychain entries (Claude Code) are also picked up regardless of how you launched.
 
 ## Style B: local binary + config dir
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.50.0
 	golang.org/x/mod v0.35.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,7 @@ golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
 gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -405,7 +405,10 @@ func normalizeDetailWidgetSections(in []DetailWidgetSection) []DetailWidgetSecti
 	return normalized
 }
 
-// saveMu guards read-modify-write cycles on the config file.
+// saveMu guards every code path that writes the config file. Both modifyConfig
+// (read-modify-write helpers like SaveTheme) and direct Save/SaveTo callers
+// must take it; otherwise a Save() can race a concurrent modifyConfig and
+// roll back the modification.
 var saveMu sync.Mutex
 
 func Save(cfg Config) error {
@@ -413,6 +416,13 @@ func Save(cfg Config) error {
 }
 
 func SaveTo(path string, cfg Config) error {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+	return saveLocked(path, cfg)
+}
+
+// saveLocked is the actual write path; callers MUST hold saveMu.
+func saveLocked(path string, cfg Config) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
@@ -445,7 +455,7 @@ func modifyConfig(path string, mutate func(*Config)) error {
 		cfg = DefaultConfig()
 	}
 	mutate(&cfg)
-	return SaveTo(path, cfg)
+	return saveLocked(path, cfg)
 }
 
 // SaveTheme persists a theme name into the config file (read-modify-write).

--- a/internal/core/provider.go
+++ b/internal/core/provider.go
@@ -41,12 +41,12 @@ type AccountConfig struct {
 	Paths map[string]string `json:"paths,omitempty"`
 
 	Token        string            `json:"-"` // runtime-only: access token (never persisted)
-	RuntimeHints map[string]string `json:"-"` // runtime-only: non-persisted local/runtime hints
-	ExtraData    map[string]string `json:"-"` // runtime-only: extra detection metadata (never persisted)
+	RuntimeHints map[string]string `json:"-"` // runtime-only: detection metadata + local hints (never persisted)
 }
 
-// Path returns the named provider-specific path. It checks ProviderPaths first,
-// then legacy Paths, then runtime hints, then legacy ExtraData fallbacks, then the fallback.
+// Path returns the named provider-specific path. It checks ProviderPaths
+// first, then the legacy Paths field, then RuntimeHints (which detectors use
+// for transient locators), and finally the caller's fallback.
 func (c AccountConfig) Path(key, fallback string) string {
 	if c.ProviderPaths != nil {
 		if v, ok := c.ProviderPaths[key]; ok && v != "" {
@@ -60,11 +60,6 @@ func (c AccountConfig) Path(key, fallback string) string {
 	}
 	if c.RuntimeHints != nil {
 		if v, ok := c.RuntimeHints[key]; ok && v != "" {
-			return v
-		}
-	}
-	if c.ExtraData != nil {
-		if v, ok := c.ExtraData[key]; ok && v != "" {
 			return v
 		}
 	}
@@ -88,11 +83,6 @@ func (c *AccountConfig) SetPath(key, value string) {
 func (c AccountConfig) Hint(key, fallback string) string {
 	if c.RuntimeHints != nil {
 		if v, ok := c.RuntimeHints[key]; ok && v != "" {
-			return v
-		}
-	}
-	if c.ExtraData != nil {
-		if v, ok := c.ExtraData[key]; ok && v != "" {
 			return v
 		}
 	}

--- a/internal/daemon/accounts.go
+++ b/internal/daemon/accounts.go
@@ -30,10 +30,16 @@ func ResolveAccounts(cfg *config.Config) []core.AccountConfig {
 			}
 		}
 
-		cfg.AutoDetectedAccounts = autoDetected
-		if err := config.SaveAutoDetected(autoDetected); err != nil {
-			log.Printf("Warning: could not persist auto-detected accounts: %v", err)
+		// Only persist when the auto-detected set actually changed. Without
+		// this guard we'd take saveMu and rewrite settings.json on every
+		// poll cycle (~30s), even when nothing about the workstation has
+		// moved.
+		if !sameAutoDetectedAccounts(cfg.AutoDetectedAccounts, autoDetected) {
+			if err := config.SaveAutoDetected(autoDetected); err != nil {
+				log.Printf("Warning: could not persist auto-detected accounts: %v", err)
+			}
 		}
+		cfg.AutoDetectedAccounts = autoDetected
 
 		allAccounts = core.MergeAccounts(cfg.Accounts, cfg.AutoDetectedAccounts)
 
@@ -51,6 +57,47 @@ func ApplyCredentials(accounts []core.AccountConfig) []core.AccountConfig {
 	credResult := detect.Result{Accounts: accounts}
 	detect.ApplyCredentials(&credResult)
 	return credResult.Accounts
+}
+
+// sameAutoDetectedAccounts compares two slices of auto-detected accounts by
+// the persisted-fields subset (ID, Provider, Auth, APIKeyEnv, BaseURL, Binary,
+// ProviderPaths, Paths). Runtime-only fields (Token, RuntimeHints) are
+// ignored — they change every run for sources like Cursor's vscdb token.
+func sameAutoDetectedAccounts(a, b []core.AccountConfig) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	keyOf := func(acc core.AccountConfig) string {
+		return acc.ID + "|" + acc.Provider + "|" + acc.Auth + "|" + acc.APIKeyEnv +
+			"|" + acc.BaseURL + "|" + acc.Binary
+	}
+	indexA := make(map[string]core.AccountConfig, len(a))
+	for _, acc := range a {
+		indexA[keyOf(acc)] = acc
+	}
+	for _, acc := range b {
+		other, ok := indexA[keyOf(acc)]
+		if !ok {
+			return false
+		}
+		if !samePathMap(other.PathMap(), acc.PathMap()) {
+			return false
+		}
+	}
+	return true
+}
+
+// samePathMap reports map-equality, treating nil and empty as equal.
+func samePathMap(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func ResolveSocketPath() string {

--- a/internal/daemon/server_http.go
+++ b/internal/daemon/server_http.go
@@ -144,6 +144,11 @@ func (s *Service) handleReadModel(w http.ResponseWriter, r *http.Request) {
 		s.warnf("read_model_cache_miss_compute_error", "error=%v", err)
 	}
 
+	// Re-arm the data-ingested flag so the periodic refresh loop tries
+	// again instead of sticking on stale empty templates. Without this,
+	// a single failed compute can leave the read-model cache permanently
+	// empty until the next ingest event.
+	s.dataIngested.Store(true)
 	s.refreshReadModelCacheAsync(s.serviceContext(r.Context()), cacheKey, req, 60*time.Second)
 	snapshots = ReadModelTemplatesFromRequest(req, DisabledAccountsFromConfig())
 	writeJSON(w, http.StatusOK, ReadModelResponse{Snapshots: snapshots})

--- a/internal/daemon/server_poll.go
+++ b/internal/daemon/server_poll.go
@@ -59,6 +59,16 @@ func (s *Service) pollProviders(ctx context.Context) {
 		go func(account core.AccountConfig) {
 			defer wg.Done()
 
+			// Honour shutdown immediately so we don't run a fresh fetch on
+			// an account when the parent ctx has already been cancelled.
+			// Without this check the per-fetch 8s timeout (below) is the
+			// only ceiling on shutdown — N goroutines × 8s on big setups.
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
 			provider, ok := s.providerByID[account.Provider]
 			if !ok {
 				results <- providerResult{

--- a/internal/daemon/server_watch.go
+++ b/internal/daemon/server_watch.go
@@ -60,13 +60,17 @@ func (s *Service) runWatchLoop(ctx context.Context) {
 			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
 				continue
 			}
-			// Reset debounce timer on each event.
+			// Reset debounce timer on each event. Capture the event's
+			// fields by value into the closure — a literal `event` capture
+			// is by reference and would only print whichever event the loop
+			// landed on when the timer fires.
 			if debounceTimer != nil {
 				debounceTimer.Stop()
 			}
+			eventName, eventOp := event.Name, event.Op
 			debounceTimer = time.AfterFunc(debounceInterval, func() {
 				s.dataIngested.Store(true) // trigger read model refresh
-				core.Tracef("[watch] change detected: %s op=%s", event.Name, event.Op)
+				core.Tracef("[watch] change detected: %s op=%s", eventName, eventOp)
 			})
 
 		case err, ok := <-watcher.Errors:

--- a/internal/daemon/source_collectors_test.go
+++ b/internal/daemon/source_collectors_test.go
@@ -13,7 +13,7 @@ func TestBuildCollectors_ScopesConfiguredAccount(t *testing.T) {
 		{
 			ID:       "codex-main",
 			Provider: "codex",
-			ExtraData: map[string]string{
+			RuntimeHints: map[string]string{
 				"sessions_dir": "/tmp/codex-main",
 			},
 		},
@@ -62,14 +62,14 @@ func TestResolveTelemetrySourceOptionsFromAccounts_UsesExplicitAccount(t *testin
 		{
 			ID:       "codex-a",
 			Provider: "codex",
-			ExtraData: map[string]string{
+			RuntimeHints: map[string]string{
 				"sessions_dir": "/tmp/codex-a",
 			},
 		},
 		{
 			ID:       "codex-b",
 			Provider: "codex",
-			ExtraData: map[string]string{
+			RuntimeHints: map[string]string{
 				"sessions_dir": "/tmp/codex-b",
 			},
 		},

--- a/internal/detect/aider.go
+++ b/internal/detect/aider.go
@@ -212,4 +212,3 @@ func adoptAiderDotenv(result *Result, path string) {
 		log.Printf("[detect] aider %s scan error: %v", path, err)
 	}
 }
-

--- a/internal/detect/aider.go
+++ b/internal/detect/aider.go
@@ -174,7 +174,12 @@ func adoptAiderYAML(result *Result, path string) {
 		value := strings.TrimSpace(entry[eq+1:])
 		mapping, ok := envKeyByAiderShortName[shortName]
 		if !ok {
-			log.Printf("[detect] aider %s: unknown provider %q in api-key list, skipping", path, shortName)
+			// Don't echo the user's untrusted entry token back into the log
+			// (CodeQL flags APIKeyList → log as a clear-text-secret flow even
+			// for the left-of-`=` provider tag, since tainting is coarse).
+			// A generic message is enough; the path is already in the log
+			// for users who want to inspect the file directly.
+			log.Printf("[detect] aider %s: unknown provider in api-key list, skipping", path)
 			continue
 		}
 		if value == "" {

--- a/internal/detect/aider.go
+++ b/internal/detect/aider.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
-
-	"github.com/janekbaraniewski/openusage/internal/core"
 )
 
 // detectAiderConfig parses Aider's documented credential locations and adopts
@@ -24,37 +22,63 @@ import (
 //     plus list-form `api-key:` with `<provider>=<value>` strings.
 //   - .env files use the standard provider env-var names (OPENAI_API_KEY etc.).
 //
+// Privacy: this detector ONLY runs if detectAider has registered the Aider
+// binary in this run. Without that gate we'd be scanning every `.env` in any
+// cwd or git root we happen to be launched from, which is too broad for a
+// user who has never installed Aider.
+//
 // We treat env vars as absolute truth: any var set in os.Getenv wins and we
-// skip adopting the value from a file. Within files, we honour Aider's
-// last-loaded-wins precedence (cwd → git-root → home reversed).
+// skip adopting the value from a file. Within files we honour Aider's
+// last-loaded-wins precedence by walking cwd first; addAccount's id-dedupe
+// makes earlier scope's value win. We interleave .aider.conf.yml and .env at
+// each scope so cwd/.env beats home/.aider.conf.yml (Aider treats them as
+// equivalent at the same scope).
 func detectAiderConfig(result *Result) {
+	if !aiderToolDetected(result) {
+		return
+	}
+
 	home := homeDir()
 	if home == "" {
 		return
 	}
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Printf("[detect] aider: cwd unavailable: %v", err)
+		cwd = ""
+	}
 	gitRoot := nearestGitRoot(cwd)
 
-	// Aider's documented order is "home, git-root, cwd; later wins". We walk
-	// in reverse (cwd first) so the first hit per var also wins; later hits
-	// are no-ops because addAccount de-dupes by ID.
-	yamlPaths := uniqueExisting([]string{
-		filepath.Join(cwd, ".aider.conf.yml"),
-		filepath.Join(gitRoot, ".aider.conf.yml"),
-		filepath.Join(home, ".aider.conf.yml"),
-	})
-	envPaths := uniqueExisting([]string{
-		filepath.Join(cwd, ".env"),
-		filepath.Join(gitRoot, ".env"),
-		filepath.Join(home, ".env"),
-	})
+	var paths []string
+	for _, scope := range []string{cwd, gitRoot, home} {
+		if scope == "" {
+			continue
+		}
+		paths = append(paths,
+			filepath.Join(scope, ".aider.conf.yml"),
+			filepath.Join(scope, ".env"),
+		)
+	}
 
-	for _, p := range yamlPaths {
-		adoptAiderYAML(result, p)
+	for _, p := range uniqueExisting(paths) {
+		switch filepath.Base(p) {
+		case ".aider.conf.yml":
+			adoptAiderYAML(result, p)
+		case ".env":
+			adoptAiderDotenv(result, p)
+		}
 	}
-	for _, p := range envPaths {
-		adoptAiderDotenv(result, p)
+}
+
+// aiderToolDetected reports whether detectAider already added the Aider
+// binary to result.Tools in this run.
+func aiderToolDetected(result *Result) bool {
+	for _, t := range result.Tools {
+		if t.Name == "Aider" {
+			return true
+		}
 	}
+	return false
 }
 
 // nearestGitRoot walks up from start until it finds a directory containing
@@ -119,38 +143,44 @@ func adoptAiderYAML(result *Result, path string) {
 		log.Printf("[detect] aider %s parse error: %v", path, err)
 		return
 	}
+	source := "aider_yaml:" + path
 
-	dedicated := []struct {
+	for _, d := range []struct {
 		envVar string
 		value  string
 	}{
 		{"OPENAI_API_KEY", cfg.OpenAIAPIKey},
 		{"ANTHROPIC_API_KEY", cfg.AnthropicAPIKey},
-	}
-	for _, d := range dedicated {
+	} {
 		if d.value == "" {
 			continue
 		}
-		registerAiderKey(result, path, "aider_yaml", d.envVar, d.value)
+		mapping, ok := envKeyByVar[d.envVar]
+		if !ok {
+			continue
+		}
+		adoptAPIKey(result, mapping, d.value, source)
 	}
 
-	// List form: each entry is "<provider>=<key>". The provider name is
-	// Aider's own taxonomy (e.g. "gemini", "openrouter") which we map back
-	// to our env-var-name table. Provider names without a known mapping are
-	// silently skipped — we'd have nowhere to store them.
+	// List form: each entry is "<provider>=<key>" where <provider> is
+	// Aider's own short name. envKeyByAiderShortName indexes those names.
 	for _, entry := range cfg.APIKeyList {
 		entry = strings.TrimSpace(entry)
 		eq := strings.IndexByte(entry, '=')
 		if eq <= 0 {
 			continue
 		}
-		provider := strings.TrimSpace(entry[:eq])
+		shortName := strings.ToLower(strings.TrimSpace(entry[:eq]))
 		value := strings.TrimSpace(entry[eq+1:])
-		envVar := aiderProviderToEnvVar(provider)
-		if envVar == "" || value == "" {
+		mapping, ok := envKeyByAiderShortName[shortName]
+		if !ok {
+			log.Printf("[detect] aider %s: unknown provider %q in api-key list, skipping", path, shortName)
 			continue
 		}
-		registerAiderKey(result, path, "aider_yaml", envVar, value)
+		if value == "" {
+			continue
+		}
+		adoptAPIKey(result, mapping, value, source)
 	}
 }
 
@@ -163,11 +193,7 @@ func adoptAiderDotenv(result *Result, path string) {
 		return
 	}
 	defer f.Close()
-
-	knownVars := make(map[string]struct{}, len(envKeyMapping))
-	for _, m := range envKeyMapping {
-		knownVars[m.EnvVar] = struct{}{}
-	}
+	source := "aider_dotenv:" + path
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 64*1024), 1<<20)
@@ -176,76 +202,14 @@ func adoptAiderDotenv(result *Result, path string) {
 		if !ok {
 			continue
 		}
-		if _, known := knownVars[name]; !known {
+		mapping, known := envKeyByVar[name]
+		if !known {
 			continue
 		}
-		registerAiderKey(result, path, "aider_dotenv", name, value)
+		adoptAPIKey(result, mapping, value, source)
 	}
 	if err := scanner.Err(); err != nil {
 		log.Printf("[detect] aider %s scan error: %v", path, err)
 	}
 }
 
-// registerAiderKey adopts a (var, value) pair as a provider account, honouring
-// the "env var wins" rule. Idempotent on account id via addAccount.
-func registerAiderKey(result *Result, path, source, envVar, value string) {
-	if os.Getenv(envVar) != "" {
-		return
-	}
-	mapping, ok := mappingForEnvVar(envVar)
-	if !ok {
-		return
-	}
-	acct := core.AccountConfig{
-		ID:        mapping.AccountID,
-		Provider:  mapping.Provider,
-		Auth:      "api_key",
-		APIKeyEnv: envVar,
-		Token:     value,
-	}
-	acct.SetHint("credential_source", source+":"+path)
-	before := len(result.Accounts)
-	addAccount(result, acct)
-	if len(result.Accounts) > before {
-		log.Printf("[detect] aider %s → %s/%s (%s=%s)",
-			path, mapping.Provider, mapping.AccountID, envVar, maskKey(value))
-	}
-}
-
-// mappingForEnvVar looks up the (provider, account-id) for an env var. Returns
-// false if the env var is not in our known map.
-func mappingForEnvVar(envVar string) (envKeyMappingEntry, bool) {
-	for _, m := range envKeyMapping {
-		if m.EnvVar == envVar {
-			return envKeyMappingEntry{EnvVar: m.EnvVar, Provider: m.Provider, AccountID: m.AccountID}, true
-		}
-	}
-	return envKeyMappingEntry{}, false
-}
-
-// aiderProviderToEnvVar maps Aider's provider taxonomy (used in `api-key:`
-// list entries like `gemini=...`) back to the standard env-var name we use
-// elsewhere. Aider names tend to be the LiteLLM short form.
-func aiderProviderToEnvVar(name string) string {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "openai":
-		return "OPENAI_API_KEY"
-	case "anthropic":
-		return "ANTHROPIC_API_KEY"
-	case "gemini", "google":
-		return "GEMINI_API_KEY"
-	case "openrouter":
-		return "OPENROUTER_API_KEY"
-	case "deepseek":
-		return "DEEPSEEK_API_KEY"
-	case "groq":
-		return "GROQ_API_KEY"
-	case "mistral":
-		return "MISTRAL_API_KEY"
-	case "xai", "grok":
-		return "XAI_API_KEY"
-	case "moonshot", "moonshotai":
-		return "MOONSHOT_API_KEY"
-	}
-	return ""
-}

--- a/internal/detect/aider.go
+++ b/internal/detect/aider.go
@@ -1,0 +1,251 @@
+package detect
+
+import (
+	"bufio"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// detectAiderConfig parses Aider's documented credential locations and adopts
+// any keys it finds as standard provider accounts.
+//
+// Aider's documented behaviour (https://aider.chat/docs/config/api-keys.html):
+//   - .aider.conf.yml is searched in $HOME, the closest git repo root, and
+//     the current working directory; later files override earlier ones.
+//   - .env is searched in the same three locations with the same precedence.
+//   - YAML keys: `openai-api-key`, `anthropic-api-key` (dedicated scalars),
+//     plus list-form `api-key:` with `<provider>=<value>` strings.
+//   - .env files use the standard provider env-var names (OPENAI_API_KEY etc.).
+//
+// We treat env vars as absolute truth: any var set in os.Getenv wins and we
+// skip adopting the value from a file. Within files, we honour Aider's
+// last-loaded-wins precedence (cwd → git-root → home reversed).
+func detectAiderConfig(result *Result) {
+	home := homeDir()
+	if home == "" {
+		return
+	}
+	cwd, _ := os.Getwd()
+	gitRoot := nearestGitRoot(cwd)
+
+	// Aider's documented order is "home, git-root, cwd; later wins". We walk
+	// in reverse (cwd first) so the first hit per var also wins; later hits
+	// are no-ops because addAccount de-dupes by ID.
+	yamlPaths := uniqueExisting([]string{
+		filepath.Join(cwd, ".aider.conf.yml"),
+		filepath.Join(gitRoot, ".aider.conf.yml"),
+		filepath.Join(home, ".aider.conf.yml"),
+	})
+	envPaths := uniqueExisting([]string{
+		filepath.Join(cwd, ".env"),
+		filepath.Join(gitRoot, ".env"),
+		filepath.Join(home, ".env"),
+	})
+
+	for _, p := range yamlPaths {
+		adoptAiderYAML(result, p)
+	}
+	for _, p := range envPaths {
+		adoptAiderDotenv(result, p)
+	}
+}
+
+// nearestGitRoot walks up from start until it finds a directory containing
+// a `.git` entry (file or dir — git worktrees use a regular file). Returns
+// "" if none found or start is empty.
+func nearestGitRoot(start string) string {
+	if start == "" {
+		return ""
+	}
+	dir := start
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// uniqueExisting returns the input paths in order, dropping duplicates and
+// non-existent files. Empty entries are ignored.
+func uniqueExisting(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		if !fileExists(p) {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// aiderYAML matches the subset of .aider.conf.yml fields we care about.
+// Aider has many other fields; we ignore them.
+type aiderYAML struct {
+	OpenAIAPIKey    string   `yaml:"openai-api-key"`
+	AnthropicAPIKey string   `yaml:"anthropic-api-key"`
+	APIKeyList      []string `yaml:"api-key"`
+}
+
+func adoptAiderYAML(result *Result, path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Printf("[detect] aider %s read error: %v", path, err)
+		}
+		return
+	}
+	var cfg aiderYAML
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		log.Printf("[detect] aider %s parse error: %v", path, err)
+		return
+	}
+
+	dedicated := []struct {
+		envVar string
+		value  string
+	}{
+		{"OPENAI_API_KEY", cfg.OpenAIAPIKey},
+		{"ANTHROPIC_API_KEY", cfg.AnthropicAPIKey},
+	}
+	for _, d := range dedicated {
+		if d.value == "" {
+			continue
+		}
+		registerAiderKey(result, path, "aider_yaml", d.envVar, d.value)
+	}
+
+	// List form: each entry is "<provider>=<key>". The provider name is
+	// Aider's own taxonomy (e.g. "gemini", "openrouter") which we map back
+	// to our env-var-name table. Provider names without a known mapping are
+	// silently skipped — we'd have nowhere to store them.
+	for _, entry := range cfg.APIKeyList {
+		entry = strings.TrimSpace(entry)
+		eq := strings.IndexByte(entry, '=')
+		if eq <= 0 {
+			continue
+		}
+		provider := strings.TrimSpace(entry[:eq])
+		value := strings.TrimSpace(entry[eq+1:])
+		envVar := aiderProviderToEnvVar(provider)
+		if envVar == "" || value == "" {
+			continue
+		}
+		registerAiderKey(result, path, "aider_yaml", envVar, value)
+	}
+}
+
+func adoptAiderDotenv(result *Result, path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Printf("[detect] aider %s read error: %v", path, err)
+		}
+		return
+	}
+	defer f.Close()
+
+	knownVars := make(map[string]struct{}, len(envKeyMapping))
+	for _, m := range envKeyMapping {
+		knownVars[m.EnvVar] = struct{}{}
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1<<20)
+	for scanner.Scan() {
+		name, value, ok := parseExportLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		if _, known := knownVars[name]; !known {
+			continue
+		}
+		registerAiderKey(result, path, "aider_dotenv", name, value)
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("[detect] aider %s scan error: %v", path, err)
+	}
+}
+
+// registerAiderKey adopts a (var, value) pair as a provider account, honouring
+// the "env var wins" rule. Idempotent on account id via addAccount.
+func registerAiderKey(result *Result, path, source, envVar, value string) {
+	if os.Getenv(envVar) != "" {
+		return
+	}
+	mapping, ok := mappingForEnvVar(envVar)
+	if !ok {
+		return
+	}
+	acct := core.AccountConfig{
+		ID:        mapping.AccountID,
+		Provider:  mapping.Provider,
+		Auth:      "api_key",
+		APIKeyEnv: envVar,
+		Token:     value,
+	}
+	acct.SetHint("credential_source", source+":"+path)
+	before := len(result.Accounts)
+	addAccount(result, acct)
+	if len(result.Accounts) > before {
+		log.Printf("[detect] aider %s → %s/%s (%s=%s)",
+			path, mapping.Provider, mapping.AccountID, envVar, maskKey(value))
+	}
+}
+
+// mappingForEnvVar looks up the (provider, account-id) for an env var. Returns
+// false if the env var is not in our known map.
+func mappingForEnvVar(envVar string) (envKeyMappingEntry, bool) {
+	for _, m := range envKeyMapping {
+		if m.EnvVar == envVar {
+			return envKeyMappingEntry{EnvVar: m.EnvVar, Provider: m.Provider, AccountID: m.AccountID}, true
+		}
+	}
+	return envKeyMappingEntry{}, false
+}
+
+// aiderProviderToEnvVar maps Aider's provider taxonomy (used in `api-key:`
+// list entries like `gemini=...`) back to the standard env-var name we use
+// elsewhere. Aider names tend to be the LiteLLM short form.
+func aiderProviderToEnvVar(name string) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "openai":
+		return "OPENAI_API_KEY"
+	case "anthropic":
+		return "ANTHROPIC_API_KEY"
+	case "gemini", "google":
+		return "GEMINI_API_KEY"
+	case "openrouter":
+		return "OPENROUTER_API_KEY"
+	case "deepseek":
+		return "DEEPSEEK_API_KEY"
+	case "groq":
+		return "GROQ_API_KEY"
+	case "mistral":
+		return "MISTRAL_API_KEY"
+	case "xai", "grok":
+		return "XAI_API_KEY"
+	case "moonshot", "moonshotai":
+		return "MOONSHOT_API_KEY"
+	}
+	return ""
+}

--- a/internal/detect/aider_test.go
+++ b/internal/detect/aider_test.go
@@ -7,18 +7,32 @@ import (
 	"testing"
 )
 
-// withAiderHome rewires HOME to a fresh temp dir, neutralises PATH, and clears
-// the env vars our aider detector might compete with so tests don't leak.
+// withAiderHome rewires HOME to a fresh temp dir, drops a fake `aider` binary
+// onto PATH (so detectAiderConfig's "Aider installed?" gate passes), and
+// clears the env vars our aider detector might compete with so tests don't
+// leak. Returns the home dir path.
 func withAiderHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "aider"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake aider bin: %v", err)
+	}
 	t.Setenv("HOME", home)
-	t.Setenv("PATH", "")
-	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", "")
+	t.Setenv("PATH", binDir)
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", binDir)
 	for _, m := range envKeyMapping {
 		t.Setenv(m.EnvVar, "")
 	}
 	return home
+}
+
+// detectAiderConfigForTest runs detectAider so result.Tools is populated,
+// then runs detectAiderConfig. Production AutoDetect does this in order; the
+// privacy gate in detectAiderConfig requires it.
+func detectAiderConfigForTest(result *Result) {
+	detectAider(result)
+	detectAiderConfig(result)
 }
 
 // chdirTo changes cwd for the duration of the test and restores it after.
@@ -51,7 +65,7 @@ model: gpt-4o
 	}
 
 	var result Result
-	detectAiderConfig(&result)
+	detectAiderConfigForTest(&result)
 
 	want := map[string]string{
 		"openai":    "sk-aider-yaml-12345",
@@ -85,7 +99,7 @@ func TestDetectAiderConfig_ListFormKeys(t *testing.T) {
 	}
 
 	var result Result
-	detectAiderConfig(&result)
+	detectAiderConfigForTest(&result)
 
 	want := map[string]string{
 		"gemini_api": "gem-aider-yaml-12345",
@@ -116,7 +130,7 @@ GROQ_API_KEY="gsk-quoted-67890"
 	}
 
 	var result Result
-	detectAiderConfig(&result)
+	detectAiderConfigForTest(&result)
 
 	got := map[string]string{}
 	for _, a := range result.Accounts {
@@ -143,7 +157,7 @@ func TestDetectAiderConfig_EnvVarBeatsFile(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "sk-from-env-12345")
 
 	var result Result
-	detectAiderConfig(&result)
+	detectAiderConfigForTest(&result)
 
 	for _, a := range result.Accounts {
 		if a.Provider == "openai" {
@@ -168,7 +182,7 @@ func TestDetectAiderConfig_CwdConfigBeatsHome(t *testing.T) {
 	}
 
 	var result Result
-	detectAiderConfig(&result)
+	detectAiderConfigForTest(&result)
 
 	var openai string
 	for _, a := range result.Accounts {
@@ -201,7 +215,7 @@ func TestDetectAiderConfig_GitRootConfig(t *testing.T) {
 	_ = home
 
 	var result Result
-	detectAiderConfig(&result)
+	detectAiderConfigForTest(&result)
 
 	var openai string
 	for _, a := range result.Accounts {
@@ -214,12 +228,70 @@ func TestDetectAiderConfig_GitRootConfig(t *testing.T) {
 	}
 }
 
+func TestDetectAiderConfig_DotenvBeatsHomeYAML(t *testing.T) {
+	// Aider treats .aider.conf.yml and .env as equivalent at the same scope,
+	// with deeper scopes overriding shallower ones. cwd/.env must beat
+	// home/.aider.conf.yml — earlier code processed all YAML before any
+	// .env, which broke this.
+	home := withAiderHome(t)
+	project := t.TempDir()
+	chdirTo(t, project)
+
+	if err := os.WriteFile(filepath.Join(home, ".aider.conf.yml"),
+		[]byte("openai-api-key: sk-from-home-yaml-12345\n"), 0o600); err != nil {
+		t.Fatalf("write home yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".env"),
+		[]byte("OPENAI_API_KEY=sk-from-project-env-67890\n"), 0o600); err != nil {
+		t.Fatalf("write project env: %v", err)
+	}
+
+	var result Result
+	detectAiderConfigForTest(&result)
+
+	var openai string
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" {
+			openai = a.Token
+		}
+	}
+	if openai != "sk-from-project-env-67890" {
+		t.Errorf("openai Token = %q, want sk-from-project-env-67890 (cwd/.env must beat home/.aider.conf.yml)", openai)
+	}
+}
+
+func TestDetectAiderConfig_NotInstalledIsNoOp(t *testing.T) {
+	// Privacy gate: if Aider isn't installed, .env files in cwd/git-root must
+	// NOT be scanned even if they exist with our known env-var names.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", "")
+	for _, m := range envKeyMapping {
+		t.Setenv(m.EnvVar, "")
+	}
+	if err := os.WriteFile(filepath.Join(home, ".env"),
+		[]byte("OPENAI_API_KEY=sk-private-do-not-adopt\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	chdirTo(t, home)
+
+	var result Result
+	detectAiderConfig(&result) // direct call — no detectAider runs first
+
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" {
+			t.Errorf("Aider not installed; .env should not have been adopted, got %+v", a)
+		}
+	}
+}
+
 func TestDetectAiderConfig_NoConfigIsSafe(t *testing.T) {
 	withAiderHome(t)
 	chdirTo(t, t.TempDir())
 
 	var result Result
-	detectAiderConfig(&result) // must not panic
+	detectAiderConfigForTest(&result) // must not panic
 	if len(result.Accounts) != 0 {
 		t.Errorf("expected 0 accounts with no config, got %+v", result.Accounts)
 	}
@@ -234,5 +306,5 @@ func TestDetectAiderConfig_MalformedYAMLIsSafe(t *testing.T) {
 	}
 
 	var result Result
-	detectAiderConfig(&result) // must not panic
+	detectAiderConfigForTest(&result) // must not panic
 }

--- a/internal/detect/aider_test.go
+++ b/internal/detect/aider_test.go
@@ -1,0 +1,238 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withAiderHome rewires HOME to a fresh temp dir, neutralises PATH, and clears
+// the env vars our aider detector might compete with so tests don't leak.
+func withAiderHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", "")
+	for _, m := range envKeyMapping {
+		t.Setenv(m.EnvVar, "")
+	}
+	return home
+}
+
+// chdirTo changes cwd for the duration of the test and restores it after.
+// detectAiderConfig pulls cwd via os.Getwd, so we need to control it.
+func chdirTo(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prev)
+	})
+}
+
+func TestDetectAiderConfig_DedicatedYAMLKeys(t *testing.T) {
+	home := withAiderHome(t)
+	chdirTo(t, home)
+
+	body := `# my aider config
+openai-api-key: sk-aider-yaml-12345
+anthropic-api-key: sk-ant-aider-yaml-67890
+model: gpt-4o
+`
+	if err := os.WriteFile(filepath.Join(home, ".aider.conf.yml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var result Result
+	detectAiderConfig(&result)
+
+	want := map[string]string{
+		"openai":    "sk-aider-yaml-12345",
+		"anthropic": "sk-ant-aider-yaml-67890",
+	}
+	got := map[string]string{}
+	for _, a := range result.Accounts {
+		got[a.Provider] = a.Token
+		if !strings.HasPrefix(a.Hint("credential_source", ""), "aider_yaml:") {
+			t.Errorf("%s credential_source = %q, want aider_yaml: prefix", a.Provider, a.Hint("credential_source", ""))
+		}
+	}
+	for provider, want := range want {
+		if got[provider] != want {
+			t.Errorf("provider %s Token = %q, want %q", provider, got[provider], want)
+		}
+	}
+}
+
+func TestDetectAiderConfig_ListFormKeys(t *testing.T) {
+	home := withAiderHome(t)
+	chdirTo(t, home)
+
+	body := `api-key:
+  - gemini=gem-aider-yaml-12345
+  - openrouter=or-aider-yaml-67890
+  - deepseek=ds-aider-yaml-abcde
+`
+	if err := os.WriteFile(filepath.Join(home, ".aider.conf.yml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var result Result
+	detectAiderConfig(&result)
+
+	want := map[string]string{
+		"gemini_api": "gem-aider-yaml-12345",
+		"openrouter": "or-aider-yaml-67890",
+		"deepseek":   "ds-aider-yaml-abcde",
+	}
+	got := map[string]string{}
+	for _, a := range result.Accounts {
+		got[a.Provider] = a.Token
+	}
+	for provider, want := range want {
+		if got[provider] != want {
+			t.Errorf("provider %s Token = %q, want %q (full: %+v)", provider, got[provider], want, got)
+		}
+	}
+}
+
+func TestDetectAiderConfig_DotenvKeys(t *testing.T) {
+	home := withAiderHome(t)
+	chdirTo(t, home)
+
+	body := `# project secrets
+OPENAI_API_KEY=sk-from-dotenv-12345
+GROQ_API_KEY="gsk-quoted-67890"
+`
+	if err := os.WriteFile(filepath.Join(home, ".env"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var result Result
+	detectAiderConfig(&result)
+
+	got := map[string]string{}
+	for _, a := range result.Accounts {
+		got[a.Provider] = a.Token
+		if !strings.HasPrefix(a.Hint("credential_source", ""), "aider_dotenv:") {
+			t.Errorf("%s credential_source = %q, want aider_dotenv: prefix", a.Provider, a.Hint("credential_source", ""))
+		}
+	}
+	if got["openai"] != "sk-from-dotenv-12345" {
+		t.Errorf("openai Token = %q", got["openai"])
+	}
+	if got["groq"] != "gsk-quoted-67890" {
+		t.Errorf("groq Token = %q", got["groq"])
+	}
+}
+
+func TestDetectAiderConfig_EnvVarBeatsFile(t *testing.T) {
+	home := withAiderHome(t)
+	chdirTo(t, home)
+
+	if err := os.WriteFile(filepath.Join(home, ".env"), []byte("OPENAI_API_KEY=sk-from-file\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Setenv("OPENAI_API_KEY", "sk-from-env-12345")
+
+	var result Result
+	detectAiderConfig(&result)
+
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" {
+			t.Fatalf("env should win; got file-derived account: %+v", a)
+		}
+	}
+}
+
+func TestDetectAiderConfig_CwdConfigBeatsHome(t *testing.T) {
+	home := withAiderHome(t)
+	project := t.TempDir()
+	chdirTo(t, project)
+
+	// home config has one key, project config has another for the same provider.
+	if err := os.WriteFile(filepath.Join(home, ".aider.conf.yml"),
+		[]byte("openai-api-key: sk-from-home-12345\n"), 0o600); err != nil {
+		t.Fatalf("write home: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".aider.conf.yml"),
+		[]byte("openai-api-key: sk-from-project-67890\n"), 0o600); err != nil {
+		t.Fatalf("write project: %v", err)
+	}
+
+	var result Result
+	detectAiderConfig(&result)
+
+	var openai string
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" {
+			openai = a.Token
+		}
+	}
+	if openai != "sk-from-project-67890" {
+		t.Errorf("openai Token = %q, want sk-from-project-67890 (cwd should beat home)", openai)
+	}
+}
+
+func TestDetectAiderConfig_GitRootConfig(t *testing.T) {
+	home := withAiderHome(t)
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	subdir := filepath.Join(repo, "src", "deep")
+	if err := os.MkdirAll(subdir, 0o700); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+	chdirTo(t, subdir)
+
+	if err := os.WriteFile(filepath.Join(repo, ".aider.conf.yml"),
+		[]byte("openai-api-key: sk-from-git-root-12345\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_ = home
+
+	var result Result
+	detectAiderConfig(&result)
+
+	var openai string
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" {
+			openai = a.Token
+		}
+	}
+	if openai != "sk-from-git-root-12345" {
+		t.Errorf("openai Token = %q, want sk-from-git-root-12345 (git-root should be searched)", openai)
+	}
+}
+
+func TestDetectAiderConfig_NoConfigIsSafe(t *testing.T) {
+	withAiderHome(t)
+	chdirTo(t, t.TempDir())
+
+	var result Result
+	detectAiderConfig(&result) // must not panic
+	if len(result.Accounts) != 0 {
+		t.Errorf("expected 0 accounts with no config, got %+v", result.Accounts)
+	}
+}
+
+func TestDetectAiderConfig_MalformedYAMLIsSafe(t *testing.T) {
+	home := withAiderHome(t)
+	chdirTo(t, home)
+
+	if err := os.WriteFile(filepath.Join(home, ".aider.conf.yml"), []byte("not: valid: yaml: ::"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var result Result
+	detectAiderConfig(&result) // must not panic
+}

--- a/internal/detect/codex.go
+++ b/internal/detect/codex.go
@@ -49,10 +49,10 @@ func detectCodex(result *Result) {
 	log.Printf("[detect] Codex CLI data found (sessions=%v, auth=%v)", hasSessions, hasAuth)
 
 	acct := core.AccountConfig{
-		ID:        "codex-cli",
-		Provider:  "codex",
-		Auth:      "local",
-		Binary:    bin,
+		ID:           "codex-cli",
+		Provider:     "codex",
+		Auth:         "local",
+		Binary:       bin,
 		RuntimeHints: make(map[string]string),
 	}
 

--- a/internal/detect/codex.go
+++ b/internal/detect/codex.go
@@ -11,6 +11,11 @@ import (
 	"github.com/janekbaraniewski/openusage/internal/core"
 )
 
+// codexOpenAIAccountID is the account ID we use when adopting an OPENAI_API_KEY
+// stored in ~/.codex/auth.json. It matches the canonical id used by
+// detectEnvKeys so addAccount() de-dupes consistently with the env-var path.
+const codexOpenAIAccountID = "openai"
+
 func detectCodex(result *Result) {
 	bin := findBinary("codex")
 	if bin == "" {
@@ -62,7 +67,7 @@ func detectCodex(result *Result) {
 	if hasAuth {
 		acct.SetHint("auth_file", authFile)
 		acct.ExtraData["auth_file"] = authFile
-		email, accountID, planType := extractCodexAuth(authFile)
+		email, accountID, planType, openaiAPIKey := extractCodexAuth(authFile)
 		if email != "" {
 			acct.ExtraData["email"] = email
 			log.Printf("[detect] Codex account: %s", email)
@@ -74,14 +79,35 @@ func detectCodex(result *Result) {
 			acct.ExtraData["plan_type"] = planType
 			log.Printf("[detect] Codex plan: %s", planType)
 		}
+		// When the user logged in via API key, codex stores the raw
+		// OPENAI_API_KEY at the top level of auth.json (Rust struct field
+		// `#[serde(rename = "OPENAI_API_KEY")] api_key`). Adopt it as a
+		// standard openai account so the openai provider can use it.
+		// Skip if the env var is already set — env wins over file.
+		if openaiAPIKey != "" && os.Getenv("OPENAI_API_KEY") == "" {
+			openai := core.AccountConfig{
+				ID:       codexOpenAIAccountID,
+				Provider: "openai",
+				Auth:     "api_key",
+				Token:    openaiAPIKey,
+			}
+			openai.SetHint("credential_source", "codex_auth_json")
+			before := len(result.Accounts)
+			addAccount(result, openai)
+			if len(result.Accounts) > before {
+				log.Printf("[detect] Adopted OPENAI_API_KEY from %s (key=%s)",
+					authFile, maskKey(openaiAPIKey))
+			}
+		}
 	}
 
 	addAccount(result, acct)
 }
 
 type codexAuthFile struct {
-	Tokens    codexTokens `json:"tokens"`
-	AccountID string      `json:"account_id"`
+	Tokens       codexTokens `json:"tokens"`
+	AccountID    string      `json:"account_id"`
+	OpenAIAPIKey string      `json:"OPENAI_API_KEY"`
 }
 
 type codexTokens struct {
@@ -90,20 +116,21 @@ type codexTokens struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
-func extractCodexAuth(authFile string) (email, accountID, planType string) {
+func extractCodexAuth(authFile string) (email, accountID, planType, openaiAPIKey string) {
 	data, err := os.ReadFile(authFile)
 	if err != nil {
 		log.Printf("[detect] Cannot read Codex auth.json: %v", err)
-		return "", "", ""
+		return "", "", "", ""
 	}
 
 	var auth codexAuthFile
 	if err := json.Unmarshal(data, &auth); err != nil {
 		log.Printf("[detect] Cannot parse Codex auth.json: %v", err)
-		return "", "", ""
+		return "", "", "", ""
 	}
 
 	accountID = auth.AccountID
+	openaiAPIKey = strings.TrimSpace(auth.OpenAIAPIKey)
 
 	if auth.Tokens.IDToken != "" {
 		claims := decodeJWTPayload(auth.Tokens.IDToken)
@@ -119,7 +146,7 @@ func extractCodexAuth(authFile string) (email, accountID, planType string) {
 		}
 	}
 
-	return email, accountID, planType
+	return email, accountID, planType, openaiAPIKey
 }
 
 func decodeJWTPayload(token string) map[string]interface{} {

--- a/internal/detect/codex.go
+++ b/internal/detect/codex.go
@@ -53,30 +53,30 @@ func detectCodex(result *Result) {
 		Provider:  "codex",
 		Auth:      "local",
 		Binary:    bin,
-		ExtraData: make(map[string]string),
+		RuntimeHints: make(map[string]string),
 	}
 
 	acct.SetHint("config_dir", configDir)
-	acct.ExtraData["config_dir"] = configDir
+	acct.RuntimeHints["config_dir"] = configDir
 
 	if hasSessions {
 		acct.SetHint("sessions_dir", sessionsDir)
-		acct.ExtraData["sessions_dir"] = sessionsDir
+		acct.RuntimeHints["sessions_dir"] = sessionsDir
 	}
 
 	if hasAuth {
 		acct.SetHint("auth_file", authFile)
-		acct.ExtraData["auth_file"] = authFile
+		acct.RuntimeHints["auth_file"] = authFile
 		email, accountID, planType, openaiAPIKey := extractCodexAuth(authFile)
 		if email != "" {
-			acct.ExtraData["email"] = email
+			acct.RuntimeHints["email"] = email
 			log.Printf("[detect] Codex account: %s", email)
 		}
 		if accountID != "" {
-			acct.ExtraData["account_id"] = accountID
+			acct.RuntimeHints["account_id"] = accountID
 		}
 		if planType != "" {
-			acct.ExtraData["plan_type"] = planType
+			acct.RuntimeHints["plan_type"] = planType
 			log.Printf("[detect] Codex plan: %s", planType)
 		}
 		// When the user logged in via API key, codex stores the raw

--- a/internal/detect/codex_test.go
+++ b/internal/detect/codex_test.go
@@ -110,11 +110,11 @@ func TestDetectCodex_NoAPIKey_StillEmitsCodexAccount(t *testing.T) {
 	if a.ID != "codex-cli" {
 		t.Errorf("ID = %q, want codex-cli", a.ID)
 	}
-	if a.ExtraData["email"] != "user@example.com" {
-		t.Errorf("email = %q, want user@example.com", a.ExtraData["email"])
+	if a.RuntimeHints["email"] != "user@example.com" {
+		t.Errorf("email = %q, want user@example.com", a.RuntimeHints["email"])
 	}
-	if a.ExtraData["plan_type"] != "plus" {
-		t.Errorf("plan_type = %q, want plus", a.ExtraData["plan_type"])
+	if a.RuntimeHints["plan_type"] != "plus" {
+		t.Errorf("plan_type = %q, want plus", a.RuntimeHints["plan_type"])
 	}
 }
 

--- a/internal/detect/codex_test.go
+++ b/internal/detect/codex_test.go
@@ -1,0 +1,140 @@
+package detect
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withFakeCodexAuth writes ~/.codex/auth.json + a fake `codex` binary on PATH,
+// then rewires HOME so detectCodex picks them up.
+func withFakeCodexAuth(t *testing.T, authBody string) (home string) {
+	t.Helper()
+	home = t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(filepath.Join(codexDir, "sessions"), 0o700); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(authBody), 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "codex"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write codex bin: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", binDir)
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", binDir)
+	t.Setenv("OPENAI_API_KEY", "")
+	return home
+}
+
+// makeFakeIDToken returns a JWT with the given claims base64-encoded in the payload.
+// The header and signature are dummies — extractCodexAuth only decodes the payload.
+func makeFakeIDToken(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	return "eyJhbGciOiJIUzI1NiJ9." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+func TestDetectCodex_ExtractsOpenAIAPIKey(t *testing.T) {
+	body := `{
+		"OPENAI_API_KEY": "sk-codex-stored-key-1234567890",
+		"tokens": {"id_token": "", "access_token": "", "refresh_token": ""},
+		"account_id": "acc_abc"
+	}`
+	withFakeCodexAuth(t, body)
+
+	var result Result
+	detectCodex(&result)
+
+	var openai, codex bool
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" && a.ID == "openai" {
+			openai = true
+			if a.Token != "sk-codex-stored-key-1234567890" {
+				t.Errorf("openai Token = %q, want sk-codex-stored-key-1234567890", a.Token)
+			}
+			if a.Hint("credential_source", "") != "codex_auth_json" {
+				t.Errorf("openai credential_source = %q, want codex_auth_json", a.Hint("credential_source", ""))
+			}
+		}
+		if a.Provider == "codex" && a.ID == "codex-cli" {
+			codex = true
+		}
+	}
+	if !openai {
+		t.Errorf("expected openai account from codex auth.json, got accounts: %+v", result.Accounts)
+	}
+	if !codex {
+		t.Errorf("expected codex-cli account, got accounts: %+v", result.Accounts)
+	}
+}
+
+func TestDetectCodex_EnvVarBeatsAuthJSON(t *testing.T) {
+	body := `{"OPENAI_API_KEY": "sk-from-file", "tokens": {}, "account_id": "x"}`
+	withFakeCodexAuth(t, body)
+	t.Setenv("OPENAI_API_KEY", "sk-from-env-1234567890")
+
+	var result Result
+	detectCodex(&result)
+
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" {
+			t.Errorf("expected detectCodex to skip openai when OPENAI_API_KEY env is set; got %+v", a)
+		}
+	}
+}
+
+func TestDetectCodex_NoAPIKey_StillEmitsCodexAccount(t *testing.T) {
+	body := `{"tokens": {"id_token": "` + makeFakeIDToken(t, map[string]interface{}{
+		"email": "user@example.com",
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_plan_type": "plus",
+		},
+	}) + `"}, "account_id": "acc_xyz"}`
+	withFakeCodexAuth(t, body)
+
+	var result Result
+	detectCodex(&result)
+
+	if len(result.Accounts) != 1 {
+		t.Fatalf("expected 1 account (codex-cli only), got %d: %+v", len(result.Accounts), result.Accounts)
+	}
+	a := result.Accounts[0]
+	if a.ID != "codex-cli" {
+		t.Errorf("ID = %q, want codex-cli", a.ID)
+	}
+	if a.ExtraData["email"] != "user@example.com" {
+		t.Errorf("email = %q, want user@example.com", a.ExtraData["email"])
+	}
+	if a.ExtraData["plan_type"] != "plus" {
+		t.Errorf("plan_type = %q, want plus", a.ExtraData["plan_type"])
+	}
+}
+
+func TestDetectCodex_MalformedAuthJSONIsSafe(t *testing.T) {
+	withFakeCodexAuth(t, `{not json`)
+
+	var result Result
+	detectCodex(&result) // must not panic
+
+	// codex-cli should still be registered (binary + sessions dir exist).
+	var found bool
+	for _, a := range result.Accounts {
+		if a.ID == "codex-cli" {
+			found = true
+		}
+		if a.Provider == "openai" {
+			t.Errorf("malformed auth.json should not produce openai account: %+v", a)
+		}
+	}
+	if !found {
+		t.Errorf("expected codex-cli account even with malformed auth.json")
+	}
+}

--- a/internal/detect/credential_files.go
+++ b/internal/detect/credential_files.go
@@ -1,0 +1,207 @@
+package detect
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// detectCredentialFiles probes a small set of well-known credential files
+// that AI CLIs and adjacent tools write outside our existing tool detectors:
+//
+//   - Claude Code CLI on Linux/Windows: ~/.claude/.credentials.json (JSON
+//     with accessToken/refreshToken) — the file equivalent of the macOS
+//     "Claude Code-credentials" keychain entry, used on platforms without a
+//     local keychain daemon. Confirmed via Anthropic's authentication docs.
+//   - GitHub CLI: ~/.config/gh/hosts.yml (Linux/macOS) or
+//     %APPDATA%/GitHub CLI/hosts.yml (Windows). Plaintext fallback when the
+//     system keychain is unavailable; contains a usable OAuth token.
+//   - Google Cloud ADC: ~/.config/gcloud/application_default_credentials.json
+//     (or %APPDATA%/gcloud/...) — refresh token usable for Gemini / Vertex.
+//
+// We never extract OAuth refresh values into Token here — those need a
+// provider-specific refresh exchange before they're usable. We surface
+// presence with a credential_source hint so the user can see "yes, OpenUsage
+// found your credential" via `openusage detect`.
+func detectCredentialFiles(result *Result) {
+	probeClaudeCodeCredentialsFile(result)
+	probeGHHostsFile(result)
+	probeGcloudADCFile(result)
+}
+
+// probeClaudeCodeCredentialsFile annotates / creates a claude-code account
+// when the OAuth credentials file is present. Skipped on macOS — the
+// keychain probe in keychain_darwin.go covers that platform.
+func probeClaudeCodeCredentialsFile(result *Result) {
+	if runtime.GOOS == "darwin" {
+		return
+	}
+	home := homeDir()
+	if home == "" {
+		return
+	}
+	path := filepath.Join(home, ".claude", ".credentials.json")
+	if !fileExists(path) {
+		return
+	}
+
+	// Quick parse to confirm it has an accessToken — avoids annotating on a
+	// truncated / aborted-login file. We don't expose the value.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Printf("[detect] claude code credentials read error: %v", err)
+		return
+	}
+	var creds struct {
+		AccessToken string `json:"accessToken"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil || creds.AccessToken == "" {
+		return
+	}
+
+	source := "file:" + path
+	annotateOrCreateAccount(result, "claude-code", "claude_code", "local", source,
+		filepath.Join(home, ".claude"))
+	log.Printf("[detect] claude code credentials present at %s", path)
+}
+
+// probeGHHostsFile annotates / creates a copilot account when the gh CLI
+// stored an OAuth token in plaintext (no system keychain available, e.g.
+// CI / SSH boxes).
+func probeGHHostsFile(result *Result) {
+	home := homeDir()
+	if home == "" {
+		return
+	}
+	path := ghHostsPath(home)
+	if path == "" || !fileExists(path) {
+		return
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Printf("[detect] gh hosts.yml read error: %v", err)
+		return
+	}
+	// hosts.yml is keyed by hostname; we only care about github.com having
+	// an oauth_token. Top-level structure is `<host>: { oauth_token: ..., user: ... }`.
+	var hosts map[string]struct {
+		OAuthToken string `yaml:"oauth_token"`
+	}
+	if err := yaml.Unmarshal(data, &hosts); err != nil {
+		log.Printf("[detect] gh hosts.yml parse error: %v", err)
+		return
+	}
+	github, ok := hosts["github.com"]
+	if !ok || github.OAuthToken == "" {
+		return
+	}
+
+	source := "file:" + path
+	annotateOrCreateAccount(result, "copilot", "copilot", "cli", source, "")
+	log.Printf("[detect] gh hosts.yml github.com oauth_token present (%s)", MaskKey(github.OAuthToken))
+}
+
+// probeGcloudADCFile surfaces presence of Application Default Credentials
+// (refresh token usable for Gemini / Vertex). We don't currently auto-create
+// a Vertex provider account — the file's mere presence is informational.
+// When the gemini_api or gemini_cli account is already registered we
+// annotate it with "you also have ADC" so users can see the relationship in
+// `openusage detect`.
+func probeGcloudADCFile(result *Result) {
+	home := homeDir()
+	if home == "" {
+		return
+	}
+	path := gcloudADCPath(home)
+	if path == "" || !fileExists(path) {
+		return
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Printf("[detect] gcloud ADC read error: %v", err)
+		return
+	}
+	var creds struct {
+		Type         string `json:"type"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		log.Printf("[detect] gcloud ADC parse error: %v", err)
+		return
+	}
+	if creds.Type != "authorized_user" || creds.RefreshToken == "" {
+		// Service-account JSON or partial file; skip.
+		return
+	}
+
+	hint := "file:" + path
+	annotated := false
+	for i := range result.Accounts {
+		if result.Accounts[i].Provider == "gemini_api" || result.Accounts[i].Provider == "gemini_cli" {
+			result.Accounts[i].SetHint("gcloud_adc", hint)
+			annotated = true
+		}
+	}
+	if annotated {
+		log.Printf("[detect] gcloud ADC present at %s (annotated existing gemini account)", path)
+	} else {
+		log.Printf("[detect] gcloud ADC present at %s (no gemini account to annotate)", path)
+	}
+}
+
+// ghHostsPath returns the platform-specific path to gh CLI's hosts.yml.
+func ghHostsPath(home string) string {
+	switch runtime.GOOS {
+	case "windows":
+		if v := os.Getenv("APPDATA"); v != "" {
+			return filepath.Join(v, "GitHub CLI", "hosts.yml")
+		}
+		return filepath.Join(home, "AppData", "Roaming", "GitHub CLI", "hosts.yml")
+	default:
+		return filepath.Join(home, ".config", "gh", "hosts.yml")
+	}
+}
+
+// gcloudADCPath returns the platform-specific path to the gcloud ADC file.
+func gcloudADCPath(home string) string {
+	switch runtime.GOOS {
+	case "windows":
+		if v := os.Getenv("APPDATA"); v != "" {
+			return filepath.Join(v, "gcloud", "application_default_credentials.json")
+		}
+		return filepath.Join(home, "AppData", "Roaming", "gcloud", "application_default_credentials.json")
+	default:
+		return filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+	}
+}
+
+// annotateOrCreateAccount sets credential_source on an existing account with
+// the given ID, or registers a minimal new account if none exists. Used by
+// file-based and keychain-style detectors that surface presence without a
+// directly-usable Token.
+func annotateOrCreateAccount(result *Result, accountID, provider, auth, source, defaultConfigDir string) {
+	for i := range result.Accounts {
+		if result.Accounts[i].ID == accountID {
+			result.Accounts[i].SetHint("credential_source", source)
+			return
+		}
+	}
+	acct := core.AccountConfig{
+		ID:       accountID,
+		Provider: provider,
+		Auth:     auth,
+	}
+	acct.SetHint("credential_source", source)
+	if defaultConfigDir != "" {
+		acct.SetPath("config_dir", defaultConfigDir)
+	}
+	addAccount(result, acct)
+}

--- a/internal/detect/credential_files_test.go
+++ b/internal/detect/credential_files_test.go
@@ -1,0 +1,204 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// withCleanCredentialEnv resets HOME / APPDATA / known env vars to safe
+// defaults so credential-file probes only see what tests deliberately set up.
+func withCleanCredentialEnv(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+	t.Setenv("PATH", "")
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", "")
+	for _, m := range envKeyMapping {
+		t.Setenv(m.EnvVar, "")
+	}
+	return home
+}
+
+func TestProbeClaudeCodeCredentialsFile_AnnotatesExistingAccount(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("macOS uses the keychain probe instead of this file path")
+	}
+	home := withCleanCredentialEnv(t)
+
+	credPath := filepath.Join(home, ".claude", ".credentials.json")
+	if err := os.MkdirAll(filepath.Dir(credPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `{"accessToken": "ya29.fake-claude-access-token", "refreshToken": "rt-fake", "expiresAt": 9999999999}`
+	if err := os.WriteFile(credPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var result Result
+	probeClaudeCodeCredentialsFile(&result)
+
+	if len(result.Accounts) != 1 {
+		t.Fatalf("expected 1 account, got %+v", result.Accounts)
+	}
+	a := result.Accounts[0]
+	if a.ID != "claude-code" {
+		t.Errorf("ID = %q", a.ID)
+	}
+	if a.Provider != "claude_code" {
+		t.Errorf("Provider = %q", a.Provider)
+	}
+	if got := a.Hint("credential_source", ""); got == "" {
+		t.Errorf("credential_source not set")
+	}
+}
+
+func TestProbeClaudeCodeCredentialsFile_DarwinIsNoOp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only assertion")
+	}
+	home := withCleanCredentialEnv(t)
+	credPath := filepath.Join(home, ".claude", ".credentials.json")
+	if err := os.MkdirAll(filepath.Dir(credPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(credPath, []byte(`{"accessToken":"x"}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var result Result
+	probeClaudeCodeCredentialsFile(&result)
+	for _, a := range result.Accounts {
+		if a.ID == "claude-code" {
+			t.Errorf("on darwin, file probe should defer to keychain probe; got %+v", a)
+		}
+	}
+}
+
+func TestProbeGHHostsFile_AnnotatesExistingCopilot(t *testing.T) {
+	home := withCleanCredentialEnv(t)
+	hostsDir := filepath.Join(home, ".config", "gh")
+	if runtime.GOOS == "windows" {
+		hostsDir = filepath.Join(home, "AppData", "Roaming", "GitHub CLI")
+	}
+	if err := os.MkdirAll(hostsDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `github.com:
+    user: test-user
+    oauth_token: ghu_fake12345abcdef67890
+    git_protocol: https
+`
+	if err := os.WriteFile(filepath.Join(hostsDir, "hosts.yml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var result Result
+	probeGHHostsFile(&result)
+
+	var found bool
+	for _, a := range result.Accounts {
+		if a.ID == "copilot" && a.Provider == "copilot" {
+			found = true
+			if a.Hint("credential_source", "") == "" {
+				t.Errorf("credential_source not set")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected copilot account to be created, got %+v", result.Accounts)
+	}
+}
+
+func TestProbeGHHostsFile_NoOAuthTokenIsNoOp(t *testing.T) {
+	home := withCleanCredentialEnv(t)
+	hostsDir := filepath.Join(home, ".config", "gh")
+	if runtime.GOOS == "windows" {
+		hostsDir = filepath.Join(home, "AppData", "Roaming", "GitHub CLI")
+	}
+	if err := os.MkdirAll(hostsDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// hosts.yml without oauth_token (e.g. only user field, or alt host).
+	body := `github.com:
+    user: test-user
+    git_protocol: https
+`
+	if err := os.WriteFile(filepath.Join(hostsDir, "hosts.yml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var result Result
+	probeGHHostsFile(&result)
+	if len(result.Accounts) != 0 {
+		t.Errorf("expected 0 accounts when oauth_token absent, got %+v", result.Accounts)
+	}
+}
+
+func TestProbeGcloudADCFile_AnnotatesGeminiAccount(t *testing.T) {
+	home := withCleanCredentialEnv(t)
+	adcDir := filepath.Join(home, ".config", "gcloud")
+	if runtime.GOOS == "windows" {
+		adcDir = filepath.Join(home, "AppData", "Roaming", "gcloud")
+	}
+	if err := os.MkdirAll(adcDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `{
+		"type": "authorized_user",
+		"client_id": "fake.apps.googleusercontent.com",
+		"client_secret": "fake-secret",
+		"refresh_token": "1//fake-refresh-token"
+	}`
+	if err := os.WriteFile(filepath.Join(adcDir, "application_default_credentials.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Pre-existing gemini_api account that the probe should annotate.
+	result := Result{Accounts: []core.AccountConfig{{
+		ID:       "gemini-api",
+		Provider: "gemini_api",
+		Auth:     "api_key",
+	}}}
+	probeGcloudADCFile(&result)
+
+	if len(result.Accounts) != 1 {
+		t.Fatalf("expected 1 account (annotation, no new), got %d", len(result.Accounts))
+	}
+	if result.Accounts[0].Hint("gcloud_adc", "") == "" {
+		t.Errorf("gcloud_adc hint not set on gemini account")
+	}
+}
+
+func TestProbeGcloudADCFile_ServiceAccountSkipped(t *testing.T) {
+	home := withCleanCredentialEnv(t)
+	adcDir := filepath.Join(home, ".config", "gcloud")
+	if runtime.GOOS == "windows" {
+		adcDir = filepath.Join(home, "AppData", "Roaming", "gcloud")
+	}
+	if err := os.MkdirAll(adcDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `{"type": "service_account", "client_email": "sa@p.iam.gserviceaccount.com"}`
+	if err := os.WriteFile(filepath.Join(adcDir, "application_default_credentials.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	result := Result{Accounts: []core.AccountConfig{{ID: "gemini-api", Provider: "gemini_api"}}}
+	probeGcloudADCFile(&result)
+	if v := result.Accounts[0].Hint("gcloud_adc", ""); v != "" {
+		t.Errorf("service-account JSON should not annotate; got %q", v)
+	}
+}
+
+func TestProbeAllFiles_NoFilesPresent_NoOp(t *testing.T) {
+	withCleanCredentialEnv(t)
+	var result Result
+	detectCredentialFiles(&result) // must not panic
+	if len(result.Accounts) != 0 {
+		t.Errorf("expected 0 accounts, got %+v", result.Accounts)
+	}
+}

--- a/internal/detect/cursor.go
+++ b/internal/detect/cursor.go
@@ -45,9 +45,9 @@ func detectCursor(result *Result) {
 	log.Printf("[detect] Cursor tracking data found (tracking_db=%v, state_db=%v)", hasTracking, hasState)
 
 	acct := core.AccountConfig{
-		ID:        "cursor-ide",
-		Provider:  "cursor",
-		Auth:      "local",
+		ID:           "cursor-ide",
+		Provider:     "cursor",
+		Auth:         "local",
 		RuntimeHints: make(map[string]string),
 	}
 

--- a/internal/detect/cursor.go
+++ b/internal/detect/cursor.go
@@ -48,18 +48,18 @@ func detectCursor(result *Result) {
 		ID:        "cursor-ide",
 		Provider:  "cursor",
 		Auth:      "local",
-		ExtraData: make(map[string]string),
+		RuntimeHints: make(map[string]string),
 	}
 
 	if hasTracking {
 		acct.SetPath("tracking_db", trackingDB)
 		acct.SetHint("tracking_db", trackingDB)
-		acct.ExtraData["tracking_db"] = trackingDB
+		acct.RuntimeHints["tracking_db"] = trackingDB
 	}
 	if hasState {
 		acct.SetPath("state_db", stateDB)
 		acct.SetHint("state_db", stateDB)
-		acct.ExtraData["state_db"] = stateDB
+		acct.RuntimeHints["state_db"] = stateDB
 	}
 
 	if hasState {
@@ -70,11 +70,11 @@ func detectCursor(result *Result) {
 			log.Printf("[detect] Extracted Cursor auth token for API access")
 		}
 		if email != "" {
-			acct.ExtraData["email"] = email
+			acct.RuntimeHints["email"] = email
 			log.Printf("[detect] Cursor account: %s", email)
 		}
 		if membership != "" {
-			acct.ExtraData["membership"] = membership
+			acct.RuntimeHints["membership"] = membership
 			log.Printf("[detect] Cursor membership: %s", membership)
 		}
 	}

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -32,6 +32,10 @@ type Result struct {
 func AutoDetect() Result {
 	var result Result
 
+	// Phase 1: tool-binding detectors. These may populate Token directly
+	// from local stores (Cursor state.vscdb, Codex auth.json, Z.AI YAML)
+	// and register a per-tool account ID that subsequent detectors won't
+	// duplicate.
 	detectCursor(&result)
 	detectClaudeCode(&result)
 	detectCodex(&result)
@@ -41,8 +45,21 @@ func AutoDetect() Result {
 	detectGHCopilot(&result)
 	detectGeminiCLI(&result)
 
+	// Phase 2: process env vars. Most authoritative; runs before any
+	// file-based credential adoption so a freshly-set env var always
+	// overrides stale values found in dotfiles.
 	detectEnvKeys(&result)
+
+	// Phase 3: file-based credential adoption. Each detector here
+	// re-checks os.Getenv per-var so it skips anything Phase 2 already
+	// adopted, and addAccount is idempotent on account ID.
+	detectShellRC(&result)
 	detectOpenCodeAuth(&result)
+	detectAiderConfig(&result)
+
+	// Phase 4: OS keychain probes. We only annotate accounts here — the
+	// providers themselves still read the secret value at fetch time.
+	detectMacOSKeychainCredentials(&result)
 
 	return result
 }

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -273,10 +273,6 @@ func detectGHCopilot(result *Result) {
 		Provider: "copilot",
 		Auth:     "cli",
 		Binary:   binaryPath,
-		ExtraData: map[string]string{
-			"copilot_binary": copilotBin,
-			"config_dir":     copilotDir,
-		},
 		RuntimeHints: map[string]string{
 			"copilot_binary": copilotBin,
 			"config_dir":     copilotDir,
@@ -326,10 +322,10 @@ func detectGeminiCLI(result *Result) {
 		Provider:  "gemini_cli",
 		Auth:      "oauth",
 		Binary:    bin,
-		ExtraData: make(map[string]string),
+		RuntimeHints: make(map[string]string),
 	}
 	acct.SetHint("config_dir", configDir)
-	acct.ExtraData["config_dir"] = configDir
+	acct.RuntimeHints["config_dir"] = configDir
 
 	if hasAccounts {
 		if data, err := os.ReadFile(accountsFile); err == nil {
@@ -337,7 +333,7 @@ func detectGeminiCLI(result *Result) {
 				Active string `json:"active"`
 			}
 			if json.Unmarshal(data, &accounts) == nil && accounts.Active != "" {
-				acct.ExtraData["email"] = accounts.Active
+				acct.RuntimeHints["email"] = accounts.Active
 				log.Printf("[detect] Gemini CLI active account: %s", accounts.Active)
 			}
 		}
@@ -345,38 +341,100 @@ func detectGeminiCLI(result *Result) {
 
 	if v := os.Getenv("GOOGLE_CLOUD_PROJECT"); v != "" {
 		acct.SetHint("project_id", v)
-		acct.ExtraData["project_id"] = v
+		acct.RuntimeHints["project_id"] = v
 		log.Printf("[detect] Gemini CLI project from GOOGLE_CLOUD_PROJECT: %s", v)
 	} else if v := os.Getenv("GOOGLE_CLOUD_PROJECT_ID"); v != "" {
 		acct.SetHint("project_id", v)
-		acct.ExtraData["project_id"] = v
+		acct.RuntimeHints["project_id"] = v
 		log.Printf("[detect] Gemini CLI project from GOOGLE_CLOUD_PROJECT_ID: %s", v)
 	}
 
 	addAccount(result, acct)
 }
 
-var envKeyMapping = []struct {
-	EnvVar    string
-	Provider  string
-	AccountID string
-}{
-	{"OPENAI_API_KEY", "openai", "openai"},
-	{"ANTHROPIC_API_KEY", "anthropic", "anthropic"},
-	{"OPENROUTER_API_KEY", "openrouter", "openrouter"},
-	{"GROQ_API_KEY", "groq", "groq"},
-	{"MISTRAL_API_KEY", "mistral", "mistral"},
-	{"DEEPSEEK_API_KEY", "deepseek", "deepseek"},
-	{"MOONSHOT_API_KEY", "moonshot", "moonshot-ai"},
-	{"XAI_API_KEY", "xai", "xai"},
-	{"ZAI_API_KEY", "zai", "zai"},
-	{"ZHIPUAI_API_KEY", "zai", "zhipuai-auto"},
-	{"ZEN_API_KEY", "opencode", "opencode"},
-	{"OPENCODE_API_KEY", "opencode", "opencode"},
-	{"GEMINI_API_KEY", "gemini_api", "gemini-api"},
-	{"GOOGLE_API_KEY", "gemini_api", "gemini-google"},
-	{"OLLAMA_API_KEY", "ollama", "ollama-cloud"},
-	{"ALIBABA_CLOUD_API_KEY", "alibaba_cloud", "alibaba_cloud"},
+// envKeyMappingEntry is the single source of truth for "this env var name
+// belongs to this provider/account". Every file-based detector that adopts a
+// raw API key — shell rc parsing, Aider .env/.aider.conf.yml, future Tier-1
+// detectors — funnels through this table.
+//
+// AiderShortNames lists the provider tokens Aider accepts in its list-form
+// `api-key:` config (e.g. `gemini=...`, `moonshotai=...`). Add new short
+// names alongside the env-var entry; aider.go looks them up via
+// envKeyByAiderShortName().
+type envKeyMappingEntry struct {
+	EnvVar          string
+	Provider        string
+	AccountID       string
+	AiderShortNames []string
+}
+
+var envKeyMapping = []envKeyMappingEntry{
+	{EnvVar: "OPENAI_API_KEY", Provider: "openai", AccountID: "openai", AiderShortNames: []string{"openai"}},
+	{EnvVar: "ANTHROPIC_API_KEY", Provider: "anthropic", AccountID: "anthropic", AiderShortNames: []string{"anthropic"}},
+	{EnvVar: "OPENROUTER_API_KEY", Provider: "openrouter", AccountID: "openrouter", AiderShortNames: []string{"openrouter"}},
+	{EnvVar: "GROQ_API_KEY", Provider: "groq", AccountID: "groq", AiderShortNames: []string{"groq"}},
+	{EnvVar: "MISTRAL_API_KEY", Provider: "mistral", AccountID: "mistral", AiderShortNames: []string{"mistral"}},
+	{EnvVar: "DEEPSEEK_API_KEY", Provider: "deepseek", AccountID: "deepseek", AiderShortNames: []string{"deepseek"}},
+	{EnvVar: "MOONSHOT_API_KEY", Provider: "moonshot", AccountID: "moonshot-ai", AiderShortNames: []string{"moonshot", "moonshotai"}},
+	{EnvVar: "XAI_API_KEY", Provider: "xai", AccountID: "xai", AiderShortNames: []string{"xai", "grok"}},
+	{EnvVar: "ZAI_API_KEY", Provider: "zai", AccountID: "zai", AiderShortNames: []string{"zai", "zhipuai"}},
+	{EnvVar: "ZHIPUAI_API_KEY", Provider: "zai", AccountID: "zhipuai-auto"},
+	{EnvVar: "ZEN_API_KEY", Provider: "opencode", AccountID: "opencode"},
+	{EnvVar: "OPENCODE_API_KEY", Provider: "opencode", AccountID: "opencode"},
+	{EnvVar: "GEMINI_API_KEY", Provider: "gemini_api", AccountID: "gemini-api", AiderShortNames: []string{"gemini", "google"}},
+	{EnvVar: "GOOGLE_API_KEY", Provider: "gemini_api", AccountID: "gemini-google"},
+	{EnvVar: "OLLAMA_API_KEY", Provider: "ollama", AccountID: "ollama-cloud"},
+	{EnvVar: "ALIBABA_CLOUD_API_KEY", Provider: "alibaba_cloud", AccountID: "alibaba_cloud", AiderShortNames: []string{"alibaba", "qwen"}},
+}
+
+// envKeyByVar indexes envKeyMapping by env-var name for O(1) lookup. Built
+// once at init.
+var envKeyByVar = func() map[string]envKeyMappingEntry {
+	out := make(map[string]envKeyMappingEntry, len(envKeyMapping))
+	for _, m := range envKeyMapping {
+		out[m.EnvVar] = m
+	}
+	return out
+}()
+
+// envKeyByAiderShortName indexes envKeyMapping by Aider's per-provider short
+// name (the left side of `<provider>=<key>` entries in `.aider.conf.yml`'s
+// `api-key:` list). Multiple short names can map to the same entry.
+var envKeyByAiderShortName = func() map[string]envKeyMappingEntry {
+	out := make(map[string]envKeyMappingEntry)
+	for _, m := range envKeyMapping {
+		for _, name := range m.AiderShortNames {
+			out[strings.ToLower(name)] = m
+		}
+	}
+	return out
+}()
+
+// adoptAPIKey is the shared "register an api_key account from a known env-var
+// mapping" path. Used by every file-based detector (shell rc, Aider .env /
+// YAML, future Tier-1 detectors). Honours "process env wins" by short-
+// circuiting when the env var is already set, defers to addAccount's
+// id-dedupe for cross-detector precedence, and emits a uniform masked log
+// line on success.
+func adoptAPIKey(result *Result, mapping envKeyMappingEntry, value, source string) {
+	if os.Getenv(mapping.EnvVar) != "" {
+		return
+	}
+	acct := core.AccountConfig{
+		ID:        mapping.AccountID,
+		Provider:  mapping.Provider,
+		Auth:      "api_key",
+		APIKeyEnv: mapping.EnvVar,
+		Token:     value,
+	}
+	acct.SetHint("credential_source", source)
+
+	before := len(result.Accounts)
+	addAccount(result, acct)
+	if len(result.Accounts) > before {
+		log.Printf("[detect] %s → %s/%s (%s=%s)",
+			source, mapping.Provider, mapping.AccountID, mapping.EnvVar, MaskKey(value))
+	}
 }
 
 func detectEnvKeys(result *Result) {
@@ -386,11 +444,7 @@ func detectEnvKeys(result *Result) {
 			continue
 		}
 
-		masked := val[:4] + "..." + val[len(val)-4:]
-		if len(val) < 10 {
-			masked = "****"
-		}
-		log.Printf("[detect] Found %s=%s", mapping.EnvVar, masked)
+		log.Printf("[detect] Found %s=%s", mapping.EnvVar, MaskKey(val))
 
 		addAccount(result, core.AccountConfig{
 			ID:        mapping.AccountID,
@@ -449,7 +503,9 @@ func ApplyCredentials(result *Result) {
 	}
 }
 
-// providerForStoredCredential maps a stored credential's account ID to its provider.
+// providerForStoredCredential maps a stored credential's account ID to its
+// provider. Linear scan over envKeyMapping; the table is small and this runs
+// at most once per stored credential.
 func providerForStoredCredential(accountID string) string {
 	for _, mapping := range envKeyMapping {
 		if mapping.AccountID == accountID {

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -57,9 +57,11 @@ func AutoDetect() Result {
 	detectOpenCodeAuth(&result)
 	detectAiderConfig(&result)
 
-	// Phase 4: OS keychain probes. We only annotate accounts here — the
-	// providers themselves still read the secret value at fetch time.
+	// Phase 4: credential-store probes. We only annotate accounts (or
+	// create minimal placeholders) — the providers themselves still read
+	// the secret value at fetch time.
 	detectMacOSKeychainCredentials(&result)
+	detectCredentialFiles(&result)
 
 	return result
 }
@@ -318,10 +320,10 @@ func detectGeminiCLI(result *Result) {
 	result.Tools = append(result.Tools, tool)
 
 	acct := core.AccountConfig{
-		ID:        "gemini-cli",
-		Provider:  "gemini_cli",
-		Auth:      "oauth",
-		Binary:    bin,
+		ID:           "gemini-cli",
+		Provider:     "gemini_cli",
+		Auth:         "oauth",
+		Binary:       bin,
 		RuntimeHints: make(map[string]string),
 	}
 	acct.SetHint("config_dir", configDir)

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -10,15 +10,91 @@ import (
 )
 
 func TestAutoDetect_Runs(t *testing.T) {
+	// Smoke test: AutoDetect must complete without panic regardless of what
+	// the host machine has installed. We can't assert specific accounts
+	// because the test runs against the real workstation, but we can assert
+	// the contract: every returned account has a non-empty ID and Provider.
 	result := AutoDetect()
 
-	if result.Tools == nil && result.Accounts == nil {
+	for i, acct := range result.Accounts {
+		if acct.ID == "" {
+			t.Errorf("Accounts[%d] has empty ID: %+v", i, acct)
+		}
+		if acct.Provider == "" {
+			t.Errorf("Accounts[%d] has empty Provider: %+v", i, acct)
+		}
+	}
+	for i, tool := range result.Tools {
+		if tool.Name == "" {
+			t.Errorf("Tools[%d] has empty Name: %+v", i, tool)
+		}
+	}
+}
+
+// TestAutoDetect_PrecedenceShellRCWinsWhenEnvUnset verifies the boot scenario
+// the user cares about: a key exported only in ~/.zshrc still surfaces when
+// the running process didn't inherit a set OPENAI_API_KEY (e.g. openusage
+// launched from Spotlight/Dock).
+func TestAutoDetect_PrecedenceShellRCWinsWhenEnvUnset(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".zshrc"),
+		[]byte("export OPENAI_API_KEY=sk-from-zshrc-precedence-12345\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", "")
+	for _, m := range envKeyMapping {
+		t.Setenv(m.EnvVar, "")
+	}
+
+	result := AutoDetect()
+
+	var found bool
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" && a.Token == "sk-from-zshrc-precedence-12345" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected openai account from ~/.zshrc to surface via AutoDetect, got %+v", result.Accounts)
+	}
+}
+
+// TestAutoDetect_PrecedenceEnvVarBeatsAllFiles asserts an env var set in the
+// process beats a different value in a shell rc / aider config.
+func TestAutoDetect_PrecedenceEnvVarBeatsAllFiles(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".zshrc"),
+		[]byte("export OPENAI_API_KEY=sk-from-zshrc\n"), 0o600); err != nil {
+		t.Fatalf("write zshrc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".aider.conf.yml"),
+		[]byte("openai-api-key: sk-from-aider\n"), 0o600); err != nil {
+		t.Fatalf("write aider: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", "")
+	t.Setenv("OPENAI_API_KEY", "sk-from-process-env-12345")
+
+	result := AutoDetect()
+
+	for _, a := range result.Accounts {
+		if a.Provider != "openai" {
+			continue
+		}
+		// detectEnvKeys registers the account with no Token (env var resolved
+		// at fetch time via APIKeyEnv). Token may be empty here — what
+		// matters is that the file-based shadows did NOT overwrite it.
+		if a.Token != "" && a.Token != "sk-from-process-env-12345" {
+			t.Errorf("openai Token = %q (file value leaked); env var must win", a.Token)
+		}
 	}
 }
 
 func TestDetectEnvKeys_FindsSetKey(t *testing.T) {
-	os.Setenv("OPENAI_API_KEY", "sk-test1234567890abcdef")
-	defer os.Unsetenv("OPENAI_API_KEY")
+	t.Setenv("OPENAI_API_KEY", "sk-test1234567890abcdef")
 
 	var result Result
 	detectEnvKeys(&result)
@@ -36,8 +112,7 @@ func TestDetectEnvKeys_FindsSetKey(t *testing.T) {
 }
 
 func TestDetectEnvKeys_FindsMoonshotKey(t *testing.T) {
-	os.Setenv("MOONSHOT_API_KEY", "sk-moonshot-1234567890abcdef")
-	defer os.Unsetenv("MOONSHOT_API_KEY")
+	t.Setenv("MOONSHOT_API_KEY", "sk-moonshot-1234567890abcdef")
 
 	var result Result
 	detectEnvKeys(&result)
@@ -55,8 +130,7 @@ func TestDetectEnvKeys_FindsMoonshotKey(t *testing.T) {
 }
 
 func TestDetectEnvKeys_FindsZenKeys(t *testing.T) {
-	os.Setenv("ZEN_API_KEY", "zen-test-key-123456")
-	defer os.Unsetenv("ZEN_API_KEY")
+	t.Setenv("ZEN_API_KEY", "zen-test-key-123456")
 
 	var result Result
 	detectEnvKeys(&result)
@@ -74,8 +148,7 @@ func TestDetectEnvKeys_FindsZenKeys(t *testing.T) {
 }
 
 func TestDetectEnvKeys_FindsOpenCodeKey(t *testing.T) {
-	os.Setenv("OPENCODE_API_KEY", "opencode-test-key-123456")
-	defer os.Unsetenv("OPENCODE_API_KEY")
+	t.Setenv("OPENCODE_API_KEY", "opencode-test-key-123456")
 
 	var result Result
 	detectEnvKeys(&result)
@@ -171,7 +244,7 @@ api_key: test-zai-token
 }
 
 func TestDetectEnvKeys_SkipsEmpty(t *testing.T) {
-	os.Unsetenv("OPENAI_API_KEY")
+	t.Setenv("OPENAI_API_KEY", "")
 
 	var result Result
 	detectEnvKeys(&result)

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -235,11 +235,11 @@ api_key: test-zai-token
 	if acct.Token != "test-zai-token" {
 		t.Fatalf("token = %q, want test-zai-token", acct.Token)
 	}
-	if acct.ExtraData == nil || acct.ExtraData["plan_type"] != "glm_coding_plan_china" {
-		t.Fatalf("plan_type = %q, want glm_coding_plan_china", acct.ExtraData["plan_type"])
+	if acct.RuntimeHints == nil || acct.RuntimeHints["plan_type"] != "glm_coding_plan_china" {
+		t.Fatalf("plan_type = %q, want glm_coding_plan_china", acct.RuntimeHints["plan_type"])
 	}
-	if acct.ExtraData["source"] != "chelper" {
-		t.Fatalf("source = %q, want chelper", acct.ExtraData["source"])
+	if acct.RuntimeHints["source"] != "chelper" {
+		t.Fatalf("source = %q, want chelper", acct.RuntimeHints["source"])
 	}
 }
 
@@ -354,7 +354,7 @@ func TestDetectGHCopilot_StandaloneBinaryDetected(t *testing.T) {
 	// Restrict PATH to only the temp dir. Note: findBinary also searches
 	// hardcoded system dirs (e.g. /opt/homebrew/bin), so gh may still be
 	// found on machines where it is installed. The key assertion is that the
-	// standalone copilot path ends up in ExtraData regardless.
+	// standalone copilot path ends up in RuntimeHints regardless.
 	t.Setenv("PATH", tmp)
 	t.Setenv("HOME", home)
 	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", "")
@@ -383,14 +383,14 @@ func TestDetectGHCopilot_StandaloneBinaryDetected(t *testing.T) {
 	if acct.Auth != "cli" {
 		t.Errorf("account Auth = %q, want %q", acct.Auth, "cli")
 	}
-	if acct.ExtraData == nil {
-		t.Fatal("account ExtraData is nil")
+	if acct.RuntimeHints == nil {
+		t.Fatal("account RuntimeHints is nil")
 	}
-	if acct.ExtraData["copilot_binary"] != copilotBin {
-		t.Errorf("ExtraData[copilot_binary] = %q, want %q", acct.ExtraData["copilot_binary"], copilotBin)
+	if acct.RuntimeHints["copilot_binary"] != copilotBin {
+		t.Errorf("RuntimeHints[copilot_binary] = %q, want %q", acct.RuntimeHints["copilot_binary"], copilotBin)
 	}
-	if acct.ExtraData["config_dir"] != copilotDir {
-		t.Errorf("ExtraData[config_dir] = %q, want %q", acct.ExtraData["config_dir"], copilotDir)
+	if acct.RuntimeHints["config_dir"] != copilotDir {
+		t.Errorf("RuntimeHints[config_dir] = %q, want %q", acct.RuntimeHints["config_dir"], copilotDir)
 	}
 }
 
@@ -477,9 +477,9 @@ func TestDetectGHCopilot_GHCopilotTakesPrecedence(t *testing.T) {
 	if acct.Binary != ghBin {
 		t.Errorf("account Binary = %q, want gh path %q", acct.Binary, ghBin)
 	}
-	// gh copilot path should NOT have ExtraData (legacy behavior).
-	if acct.ExtraData != nil {
-		t.Errorf("account ExtraData should be nil for gh copilot path, got %v", acct.ExtraData)
+	// gh copilot path should NOT have RuntimeHints (legacy behavior).
+	if acct.RuntimeHints != nil {
+		t.Errorf("account RuntimeHints should be nil for gh copilot path, got %v", acct.RuntimeHints)
 	}
 }
 
@@ -520,8 +520,8 @@ func TestDetectGHCopilot_StandaloneBinaryWithGH(t *testing.T) {
 	if acct.Binary != ghBin {
 		t.Errorf("account Binary = %q, want gh path %q (gh available for api calls)", acct.Binary, ghBin)
 	}
-	if acct.ExtraData["copilot_binary"] != copilotBin {
-		t.Errorf("ExtraData[copilot_binary] = %q, want %q", acct.ExtraData["copilot_binary"], copilotBin)
+	if acct.RuntimeHints["copilot_binary"] != copilotBin {
+		t.Errorf("RuntimeHints[copilot_binary] = %q, want %q", acct.RuntimeHints["copilot_binary"], copilotBin)
 	}
 }
 

--- a/internal/detect/keychain_darwin.go
+++ b/internal/detect/keychain_darwin.go
@@ -28,31 +28,56 @@ import (
 // The probe uses /usr/bin/security with a short timeout. The user gets a
 // keychain unlock prompt the first time; subsequent calls within the same
 // session are silent.
-func detectMacOSKeychainCredentials(result *Result) {
-	probes := []struct {
-		Service     string
-		AccountID   string
-		Provider    string
-		Auth        string
-		ProvenanceK string
-	}{
-		// Anthropic Claude Code CLI: stores OAuth credentials JSON.
-		// Service confirmed via anthropics/claude-code issues #9403, #37512, #44089.
-		{"Claude Code-credentials", "claude-code", "claude_code", "local",
-			"keychain:Claude Code-credentials"},
-	}
+// keychainProbe describes one well-known credential entry in the macOS
+// keychain. Adding a new AI CLI's keychain integration is a one-liner here.
+type keychainProbe struct {
+	Service          string // keychain item service name
+	AccountID        string // account ID we annotate or create
+	Provider         string // provider ID for new-account path
+	Auth             string // auth mode for new-account path
+	ProvenanceSource string // value written to the credential_source hint
+	DefaultConfigDir string // optional: relative-to-home dir set on new accounts
+}
 
-	for _, p := range probes {
+var keychainProbes = []keychainProbe{
+	// Anthropic Claude Code CLI on macOS. Service name confirmed via
+	// anthropics/claude-code issues #9403, #37512, #44089.
+	{
+		Service:          "Claude Code-credentials",
+		AccountID:        "claude-code",
+		Provider:         "claude_code",
+		Auth:             "local",
+		ProvenanceSource: "keychain:Claude Code-credentials",
+		DefaultConfigDir: ".claude",
+	},
+	// OpenAI Codex CLI when cli_auth_credentials_store=keyring (the default
+	// on macOS when keychain is reachable). The stored value is an OpenAI
+	// OAuth access token; the codex provider reads its own auth.json and
+	// can refresh as needed. We annotate so users can see where the secret
+	// is held. Service confirmed via openai/codex issue #16728.
+	{
+		Service:          "Codex Auth",
+		AccountID:        "codex-cli",
+		Provider:         "codex",
+		Auth:             "local",
+		ProvenanceSource: "keychain:Codex Auth",
+		DefaultConfigDir: ".codex",
+	},
+}
+
+func detectMacOSKeychainCredentials(result *Result) {
+	for _, p := range keychainProbes {
 		if !keychainGenericPasswordExists(p.Service) {
 			continue
 		}
 		log.Printf("[detect] macOS keychain entry present: %s", p.Service)
 
-		// Find an existing account for this provider; if found, just annotate.
+		// Annotate the existing account if file-based detection already
+		// registered it.
 		annotated := false
 		for i := range result.Accounts {
 			if result.Accounts[i].ID == p.AccountID {
-				result.Accounts[i].SetHint("credential_source", p.ProvenanceK)
+				result.Accounts[i].SetHint("credential_source", p.ProvenanceSource)
 				annotated = true
 				break
 			}
@@ -61,19 +86,17 @@ func detectMacOSKeychainCredentials(result *Result) {
 			continue
 		}
 
-		// File-based detection didn't fire for this CLI (binary not on PATH,
-		// config dir missing, etc). Register a minimal account so the provider
-		// has something to bind to.
+		// File-based detection didn't fire (binary off PATH, config dir
+		// missing, etc). Register a minimal account so the provider has
+		// something to bind to.
 		acct := core.AccountConfig{
 			ID:       p.AccountID,
 			Provider: p.Provider,
 			Auth:     p.Auth,
 		}
-		acct.SetHint("credential_source", p.ProvenanceK)
-		// Best-effort: surface the home dir so the provider's local file
-		// readers have a consistent default to fall back to.
-		if home := homeDir(); home != "" {
-			acct.SetPath("config_dir", filepath.Join(home, ".claude"))
+		acct.SetHint("credential_source", p.ProvenanceSource)
+		if home := homeDir(); home != "" && p.DefaultConfigDir != "" {
+			acct.SetPath("config_dir", filepath.Join(home, p.DefaultConfigDir))
 		}
 		addAccount(result, acct)
 	}

--- a/internal/detect/keychain_darwin.go
+++ b/internal/detect/keychain_darwin.go
@@ -1,0 +1,95 @@
+//go:build darwin
+
+package detect
+
+import (
+	"context"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// detectMacOSKeychainCredentials probes well-known macOS keychain entries
+// produced by AI CLIs and ensures we surface any account they imply.
+//
+// We do NOT extract the secret value here. Each consuming provider already
+// knows how to read its own keychain entry at fetch time (claude_code does
+// this in usage_api.go). This detector exists so:
+//
+//  1. Auto-detect picks up the account even if file-based detection missed
+//     it — for example when the CLI's binary isn't on $PATH but its
+//     keychain entry is present (SSH/devcontainer scenarios).
+//  2. The `openusage detect` debug command can show the user which keychain
+//     entries are populated and where each credential comes from.
+//
+// The probe uses /usr/bin/security with a short timeout. The user gets a
+// keychain unlock prompt the first time; subsequent calls within the same
+// session are silent.
+func detectMacOSKeychainCredentials(result *Result) {
+	probes := []struct {
+		Service     string
+		AccountID   string
+		Provider    string
+		Auth        string
+		ProvenanceK string
+	}{
+		// Anthropic Claude Code CLI: stores OAuth credentials JSON.
+		// Service confirmed via anthropics/claude-code issues #9403, #37512, #44089.
+		{"Claude Code-credentials", "claude-code", "claude_code", "local",
+			"keychain:Claude Code-credentials"},
+	}
+
+	for _, p := range probes {
+		if !keychainGenericPasswordExists(p.Service) {
+			continue
+		}
+		log.Printf("[detect] macOS keychain entry present: %s", p.Service)
+
+		// Find an existing account for this provider; if found, just annotate.
+		annotated := false
+		for i := range result.Accounts {
+			if result.Accounts[i].ID == p.AccountID {
+				result.Accounts[i].SetHint("credential_source", p.ProvenanceK)
+				annotated = true
+				break
+			}
+		}
+		if annotated {
+			continue
+		}
+
+		// File-based detection didn't fire for this CLI (binary not on PATH,
+		// config dir missing, etc). Register a minimal account so the provider
+		// has something to bind to.
+		acct := core.AccountConfig{
+			ID:       p.AccountID,
+			Provider: p.Provider,
+			Auth:     p.Auth,
+		}
+		acct.SetHint("credential_source", p.ProvenanceK)
+		// Best-effort: surface the home dir so the provider's local file
+		// readers have a consistent default to fall back to.
+		if home := homeDir(); home != "" {
+			acct.SetPath("config_dir", filepath.Join(home, ".claude"))
+		}
+		addAccount(result, acct)
+	}
+}
+
+// keychainGenericPasswordExists returns true if `security find-generic-password
+// -s <service>` succeeds (i.e. an item with that service name exists). We
+// don't request -g (the password) so this probe doesn't show the secret in
+// stdout, doesn't decrypt anything, and triggers a quieter UX.
+func keychainGenericPasswordExists(service string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/usr/bin/security", "find-generic-password", "-s", service)
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
+}

--- a/internal/detect/keychain_darwin_test.go
+++ b/internal/detect/keychain_darwin_test.go
@@ -1,0 +1,78 @@
+//go:build darwin
+
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// shimSecurityCLI replaces the system `security` binary with a stub that
+// returns the given exit code. We do this by prepending a temp dir to the
+// /usr/bin/security path... but exec.Command uses an absolute path so we
+// can't shim it that way. Instead the production code uses /usr/bin/security
+// directly. We can still test the wiring by exercising the real CLI when
+// available (skipped if not), and by directly testing the shim function
+// on a service name that should never exist.
+func TestKeychainGenericPasswordExists_MissingServiceReturnsFalse(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin only")
+	}
+	// Pick a service name that is overwhelmingly unlikely to exist.
+	ok := keychainGenericPasswordExists("openusage-fake-service-does-not-exist-9876543210")
+	if ok {
+		t.Errorf("keychainGenericPasswordExists for nonexistent service = true, want false")
+	}
+}
+
+func TestDetectMacOSKeychainCredentials_AnnotatesExistingAccount(t *testing.T) {
+	// Pre-populate a claude-code account; if the keychain entry happens to
+	// exist on this CI machine, we expect annotation. If not, the test still
+	// passes (the detector simply does nothing). The contract we verify:
+	// when keychain entry is present, the existing account gains the hint.
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin only")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	result := Result{Accounts: []core.AccountConfig{{
+		ID:       "claude-code",
+		Provider: "claude_code",
+		Auth:     "local",
+	}}}
+	before := result.Accounts[0].Hint("credential_source", "")
+
+	detectMacOSKeychainCredentials(&result)
+
+	// The detector either annotated the account (keychain entry exists) or
+	// did nothing (entry missing). Either way the account count must not grow,
+	// because we already had one.
+	if len(result.Accounts) != 1 {
+		t.Fatalf("expected exactly 1 account, got %d", len(result.Accounts))
+	}
+	after := result.Accounts[0].Hint("credential_source", "")
+	if after != before && after != "keychain:Claude Code-credentials" {
+		t.Errorf("if hint changed, it must be the documented value; got %q", after)
+	}
+}
+
+func TestDetectMacOSKeychainCredentials_AbsentKeychainIsSafe(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin only")
+	}
+	// Empty result; if keychain entry doesn't exist, detector adds nothing.
+	// If it DOES exist (developer machine running tests), detector adds a
+	// minimal claude-code account. Both are valid — the only requirement is
+	// no panic and a valid Result.
+	var result Result
+	detectMacOSKeychainCredentials(&result) // must not panic
+}

--- a/internal/detect/keychain_other.go
+++ b/internal/detect/keychain_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+
+package detect
+
+// detectMacOSKeychainCredentials is a no-op on non-darwin platforms.
+// Linux uses the Secret Service API and Windows uses Credential Manager;
+// neither is consulted by the AI CLIs we currently support, so this stub
+// simply returns. If/when we add Linux/Windows credential stores, replace
+// this with platform-specific probes behind their own build tags.
+func detectMacOSKeychainCredentials(_ *Result) {}

--- a/internal/detect/mask.go
+++ b/internal/detect/mask.go
@@ -1,0 +1,11 @@
+package detect
+
+// maskKey returns a redacted form of a secret suitable for logging:
+// "abcd...wxyz" for keys longer than 12 characters, "****" otherwise.
+// Centralised here so every detector logs credentials the same way.
+func maskKey(key string) string {
+	if len(key) <= 12 {
+		return "****"
+	}
+	return key[:4] + "..." + key[len(key)-4:]
+}

--- a/internal/detect/mask.go
+++ b/internal/detect/mask.go
@@ -1,11 +1,23 @@
 package detect
 
-// maskKey returns a redacted form of a secret suitable for logging:
-// "abcd...wxyz" for keys longer than 12 characters, "****" otherwise.
-// Centralised here so every detector logs credentials the same way.
-func maskKey(key string) string {
+import "strings"
+
+// MaskKey returns a redacted form of a secret suitable for logging:
+// "first4...last4" for keys longer than 12 characters, "****" otherwise.
+// Whitespace around the input is trimmed before measuring length so that
+// values pulled from rc files (which may have trailing newlines) mask the
+// same way as values pulled from env vars.
+//
+// This is the single source of truth for credential redaction across both
+// the internal/detect package and the cmd/openusage detect subcommand.
+func MaskKey(key string) string {
+	key = strings.TrimSpace(key)
 	if len(key) <= 12 {
 		return "****"
 	}
 	return key[:4] + "..." + key[len(key)-4:]
 }
+
+// maskKey is a package-private alias kept for terse use inside the detect
+// package's own logging. New code may use either.
+func maskKey(key string) string { return MaskKey(key) }

--- a/internal/detect/ollama.go
+++ b/internal/detect/ollama.go
@@ -36,12 +36,12 @@ func detectOllama(result *Result) {
 	}
 
 	acct := core.AccountConfig{
-		ID:        "ollama-local",
-		Provider:  "ollama",
-		Auth:      "local",
-		Binary:    bin,
-		BaseURL:   "http://127.0.0.1:11434",
-		APIKeyEnv: "OLLAMA_API_KEY",
+		ID:           "ollama-local",
+		Provider:     "ollama",
+		Auth:         "local",
+		Binary:       bin,
+		BaseURL:      "http://127.0.0.1:11434",
+		APIKeyEnv:    "OLLAMA_API_KEY",
 		RuntimeHints: make(map[string]string),
 	}
 

--- a/internal/detect/ollama.go
+++ b/internal/detect/ollama.go
@@ -42,25 +42,25 @@ func detectOllama(result *Result) {
 		Binary:    bin,
 		BaseURL:   "http://127.0.0.1:11434",
 		APIKeyEnv: "OLLAMA_API_KEY",
-		ExtraData: make(map[string]string),
+		RuntimeHints: make(map[string]string),
 	}
 
 	acct.SetHint("config_dir", configDir)
 	acct.SetHint("cloud_base_url", "https://ollama.com")
-	acct.ExtraData["config_dir"] = configDir
-	acct.ExtraData["cloud_base_url"] = "https://ollama.com"
+	acct.RuntimeHints["config_dir"] = configDir
+	acct.RuntimeHints["cloud_base_url"] = "https://ollama.com"
 
 	if fileExists(dbPath) {
 		acct.SetHint("db_path", dbPath)
-		acct.ExtraData["db_path"] = dbPath
+		acct.RuntimeHints["db_path"] = dbPath
 	}
 	if dirExists(logsDir) {
 		acct.SetHint("logs_dir", logsDir)
-		acct.ExtraData["logs_dir"] = logsDir
+		acct.RuntimeHints["logs_dir"] = logsDir
 	}
 	if fileExists(serverConfig) {
 		acct.SetHint("server_config", serverConfig)
-		acct.ExtraData["server_config"] = serverConfig
+		acct.RuntimeHints["server_config"] = serverConfig
 	}
 
 	addAccount(result, acct)

--- a/internal/detect/opencode_auth.go
+++ b/internal/detect/opencode_auth.go
@@ -129,10 +129,3 @@ func detectOpenCodeAuth(result *Result) {
 		log.Printf("[detect] OpenCode auth.json: %d api-key accounts adopted, %d oauth/other entries skipped", matched, skipped)
 	}
 }
-
-func maskKey(key string) string {
-	if len(key) <= 12 {
-		return "****"
-	}
-	return key[:4] + "..." + key[len(key)-4:]
-}

--- a/internal/detect/shellrc.go
+++ b/internal/detect/shellrc.go
@@ -1,0 +1,323 @@
+package detect
+
+import (
+	"bufio"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// detectShellRC parses common shell startup files for `export VAR=...` lines
+// matching env vars in envKeyMapping. This catches the case where a user sets
+// API keys only in their shell rc and launches openusage from a GUI launcher
+// (Spotlight/Dock/desktop launcher) which never sources those files — so
+// os.Getenv() returns empty even though the key is "set" from the user's POV.
+//
+// Precedence: detectEnvKeys runs before this. If the env var is already
+// populated in the process env, this detector skips that var entirely; the
+// addAccount de-dupe means the env-var account also wins by ID. We additionally
+// short-circuit per-var to avoid logging "found in shell rc" when the running
+// process already has the value.
+func detectShellRC(result *Result) {
+	home := homeDir()
+	if home == "" {
+		return
+	}
+
+	files := shellRCFiles(home)
+	if len(files) == 0 {
+		return
+	}
+
+	// Build a set of var names we know how to map.
+	knownVars := make(map[string]envKeyMappingEntry, len(envKeyMapping))
+	for _, m := range envKeyMapping {
+		knownVars[m.EnvVar] = envKeyMappingEntry{EnvVar: m.EnvVar, Provider: m.Provider, AccountID: m.AccountID}
+	}
+
+	for _, path := range files {
+		discoveries, err := parseShellRCFile(path, knownVars)
+		if err != nil {
+			// Read errors logged at debug-ish level; missing files were
+			// filtered out earlier so a real error here is unusual.
+			log.Printf("[detect] shell rc %s read error: %v", path, err)
+			continue
+		}
+		for _, d := range discoveries {
+			// Env var wins over file. Skip silently — same precedence rule
+			// as detectEnvKeys → file-based detectors.
+			if os.Getenv(d.EnvVar) != "" {
+				continue
+			}
+			acct := core.AccountConfig{
+				ID:        d.AccountID,
+				Provider:  d.Provider,
+				Auth:      "api_key",
+				APIKeyEnv: d.EnvVar,
+				Token:     d.Value,
+			}
+			acct.SetHint("credential_source", "shell_rc:"+path)
+			before := len(result.Accounts)
+			addAccount(result, acct)
+			if len(result.Accounts) > before {
+				log.Printf("[detect] shell rc %s → %s/%s (%s=%s)",
+					path, d.Provider, d.AccountID, d.EnvVar, maskKey(d.Value))
+			}
+		}
+	}
+}
+
+// envKeyMappingEntry mirrors the anonymous struct in envKeyMapping; we
+// re-declare it as a named type so the shellrc and aider detectors can pass
+// it around without re-declaring the same fields inline.
+type envKeyMappingEntry struct {
+	EnvVar    string
+	Provider  string
+	AccountID string
+}
+
+// shellRCDiscovery is a parsed (var, value, source-file) triple from a single
+// shell rc line.
+type shellRCDiscovery struct {
+	envKeyMappingEntry
+	Value string
+	Path  string
+}
+
+// shellRCFiles returns every shell startup file we know how to parse, in the
+// rough order shells load them. The order is informational only — addAccount
+// already de-dupes.
+func shellRCFiles(home string) []string {
+	candidates := []string{
+		filepath.Join(home, ".zshenv"),
+		filepath.Join(home, ".zprofile"),
+		filepath.Join(home, ".zshrc"),
+		filepath.Join(home, ".zlogin"),
+		filepath.Join(home, ".bash_profile"),
+		filepath.Join(home, ".bashrc"),
+		filepath.Join(home, ".profile"),
+		filepath.Join(home, ".config", "fish", "config.fish"),
+	}
+
+	// Modular configs: ~/.zshrc.d/*.zsh, ~/.bashrc.d/*.sh, ~/.config/fish/conf.d/*.fish.
+	for _, glob := range []string{
+		filepath.Join(home, ".zshrc.d", "*.zsh"),
+		filepath.Join(home, ".bashrc.d", "*.sh"),
+		filepath.Join(home, ".config", "fish", "conf.d", "*.fish"),
+	} {
+		matches, err := filepath.Glob(glob)
+		if err == nil {
+			candidates = append(candidates, matches...)
+		}
+	}
+
+	// Filter to existing regular files; strip duplicates while preserving order.
+	seen := make(map[string]struct{}, len(candidates))
+	out := make([]string, 0, len(candidates))
+	for _, p := range candidates {
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		if !fileExists(p) {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// parseShellRCFile parses a single rc file and returns all known-env-var
+// assignments it found.
+func parseShellRCFile(path string, knownVars map[string]envKeyMappingEntry) ([]shellRCDiscovery, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []shellRCDiscovery
+	scanner := bufio.NewScanner(f)
+	// Allow long lines (some users have one-line "export FOO=very_long_value").
+	const maxLine = 1 << 20 // 1 MiB
+	scanner.Buffer(make([]byte, 64*1024), maxLine)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		v, value, ok := parseExportLine(line)
+		if !ok {
+			continue
+		}
+		entry, known := knownVars[v]
+		if !known {
+			continue
+		}
+		out = append(out, shellRCDiscovery{
+			envKeyMappingEntry: entry,
+			Value:              value,
+			Path:               path,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// parseExportLine extracts (NAME, VALUE) from a shell rc line. Recognises:
+//
+//	export NAME=VALUE
+//	NAME=VALUE
+//	set -gx NAME VALUE     (fish)
+//	set -x  NAME VALUE     (fish, also acceptable)
+//
+// Returns ok=false for any line we can't safely parse without executing a
+// shell — including values that reference other variables ($VAR, ${VAR},
+// $(...), `...`) or use unquoted whitespace.
+func parseExportLine(raw string) (name, value string, ok bool) {
+	line := strings.TrimSpace(raw)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+
+	// Strip leading "export " (bash/zsh) — keep in mind "exportFOO" is not it.
+	if strings.HasPrefix(line, "export ") || strings.HasPrefix(line, "export\t") {
+		line = strings.TrimSpace(line[len("export"):])
+	}
+
+	// Fish: `set -gx NAME VALUE` or `set -x NAME VALUE`.
+	if strings.HasPrefix(line, "set ") || strings.HasPrefix(line, "set\t") {
+		fields := splitFishSet(line)
+		if len(fields) < 4 {
+			return "", "", false
+		}
+		// fields[0]=="set", fields[1] is flags like "-gx" or "-x".
+		flags := fields[1]
+		if !strings.Contains(flags, "x") {
+			return "", "", false
+		}
+		name = fields[2]
+		// Re-join the remainder so multi-word values stay intact, then the
+		// usual quote/substitution rules apply.
+		value = strings.Join(fields[3:], " ")
+	} else {
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			return "", "", false
+		}
+		name = line[:eq]
+		value = line[eq+1:]
+	}
+
+	if !isValidEnvName(name) {
+		return "", "", false
+	}
+
+	value, ok = sanitiseShellValue(value)
+	if !ok {
+		return "", "", false
+	}
+	if value == "" {
+		return "", "", false
+	}
+	return name, value, true
+}
+
+// splitFishSet tokenises a `set ...` line on whitespace, ignoring quoted
+// segments. It's a tiny shell-style splitter that keeps quoted regions
+// together; substitution rejection happens later in sanitiseShellValue.
+func splitFishSet(line string) []string {
+	var out []string
+	var cur strings.Builder
+	var inSingle, inDouble bool
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case c == '\'' && !inDouble:
+			inSingle = !inSingle
+			cur.WriteByte(c)
+		case c == '"' && !inSingle:
+			inDouble = !inDouble
+			cur.WriteByte(c)
+		case (c == ' ' || c == '\t') && !inSingle && !inDouble:
+			if cur.Len() > 0 {
+				out = append(out, cur.String())
+				cur.Reset()
+			}
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	if cur.Len() > 0 {
+		out = append(out, cur.String())
+	}
+	return out
+}
+
+// isValidEnvName rejects anything that isn't a plausible POSIX env var name.
+func isValidEnvName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		isAlpha := (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_'
+		isDigit := c >= '0' && c <= '9'
+		if i == 0 && !isAlpha {
+			return false
+		}
+		if !isAlpha && !isDigit {
+			return false
+		}
+	}
+	return true
+}
+
+// sanitiseShellValue handles quoting and rejects values we can't parse
+// without invoking a shell. Returns the literal string the shell would
+// expand to (assuming no substitutions), or ok=false if the value contains
+// substitutions, command substitutions, or unquoted whitespace.
+func sanitiseShellValue(raw string) (string, bool) {
+	v := strings.TrimSpace(raw)
+
+	// Strip a trailing inline comment when not inside quotes. We do this
+	// before quote stripping so `export FOO=bar  # note` works.
+	if !strings.HasPrefix(v, "'") && !strings.HasPrefix(v, "\"") {
+		if hash := strings.Index(v, " #"); hash >= 0 {
+			v = strings.TrimSpace(v[:hash])
+		}
+		if hash := strings.Index(v, "\t#"); hash >= 0 {
+			v = strings.TrimSpace(v[:hash])
+		}
+	}
+
+	switch {
+	case strings.HasPrefix(v, "'") && strings.HasSuffix(v, "'") && len(v) >= 2:
+		// Single quotes: literal, no expansion. Safe.
+		return v[1 : len(v)-1], true
+	case strings.HasPrefix(v, "\"") && strings.HasSuffix(v, "\"") && len(v) >= 2:
+		// Double quotes: variable expansion would happen in a real shell.
+		// Reject if any expansion characters present.
+		inner := v[1 : len(v)-1]
+		if strings.ContainsAny(inner, "$`") {
+			return "", false
+		}
+		return inner, true
+	default:
+		// Bare value. Reject anything that would be expanded or split.
+		if strings.ContainsAny(v, " \t$`\"'") {
+			return "", false
+		}
+		// Reject obvious garbage like trailing semicolons.
+		if strings.HasSuffix(v, ";") {
+			v = strings.TrimRight(v, ";")
+		}
+		if v == "" {
+			return "", false
+		}
+		return v, true
+	}
+}

--- a/internal/detect/shellrc.go
+++ b/internal/detect/shellrc.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/janekbaraniewski/openusage/internal/core"
 )
 
 // detectShellRC parses common shell startup files for `export VAR=...` lines
@@ -32,14 +30,8 @@ func detectShellRC(result *Result) {
 		return
 	}
 
-	// Build a set of var names we know how to map.
-	knownVars := make(map[string]envKeyMappingEntry, len(envKeyMapping))
-	for _, m := range envKeyMapping {
-		knownVars[m.EnvVar] = envKeyMappingEntry{EnvVar: m.EnvVar, Provider: m.Provider, AccountID: m.AccountID}
-	}
-
 	for _, path := range files {
-		discoveries, err := parseShellRCFile(path, knownVars)
+		discoveries, err := parseShellRCFile(path, envKeyByVar)
 		if err != nil {
 			// Read errors logged at debug-ish level; missing files were
 			// filtered out earlier so a real error here is unusual.
@@ -47,36 +39,9 @@ func detectShellRC(result *Result) {
 			continue
 		}
 		for _, d := range discoveries {
-			// Env var wins over file. Skip silently — same precedence rule
-			// as detectEnvKeys → file-based detectors.
-			if os.Getenv(d.EnvVar) != "" {
-				continue
-			}
-			acct := core.AccountConfig{
-				ID:        d.AccountID,
-				Provider:  d.Provider,
-				Auth:      "api_key",
-				APIKeyEnv: d.EnvVar,
-				Token:     d.Value,
-			}
-			acct.SetHint("credential_source", "shell_rc:"+path)
-			before := len(result.Accounts)
-			addAccount(result, acct)
-			if len(result.Accounts) > before {
-				log.Printf("[detect] shell rc %s → %s/%s (%s=%s)",
-					path, d.Provider, d.AccountID, d.EnvVar, maskKey(d.Value))
-			}
+			adoptAPIKey(result, d.envKeyMappingEntry, d.Value, "shell_rc:"+path)
 		}
 	}
-}
-
-// envKeyMappingEntry mirrors the anonymous struct in envKeyMapping; we
-// re-declare it as a named type so the shellrc and aider detectors can pass
-// it around without re-declaring the same fields inline.
-type envKeyMappingEntry struct {
-	EnvVar    string
-	Provider  string
-	AccountID string
 }
 
 // shellRCDiscovery is a parsed (var, value, source-file) triple from a single

--- a/internal/detect/shellrc_test.go
+++ b/internal/detect/shellrc_test.go
@@ -1,0 +1,225 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseExportLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantOK  bool
+		wantVar string
+		wantVal string
+	}{
+		{"plain export", `export OPENAI_API_KEY=sk-abc123`, true, "OPENAI_API_KEY", "sk-abc123"},
+		{"single-quoted", `export OPENAI_API_KEY='sk-abc123'`, true, "OPENAI_API_KEY", "sk-abc123"},
+		{"double-quoted", `export OPENAI_API_KEY="sk-abc123"`, true, "OPENAI_API_KEY", "sk-abc123"},
+		{"posix-form", `OPENAI_API_KEY=sk-abc123`, true, "OPENAI_API_KEY", "sk-abc123"},
+		{"with trailing comment", `export OPENAI_API_KEY=sk-abc123 # work`, true, "OPENAI_API_KEY", "sk-abc123"},
+		{"fish set -gx", `set -gx OPENAI_API_KEY sk-abc123`, true, "OPENAI_API_KEY", "sk-abc123"},
+		{"fish set -x", `set -x OPENAI_API_KEY sk-abc123`, true, "OPENAI_API_KEY", "sk-abc123"},
+		{"comment line", `# export OPENAI_API_KEY=sk`, false, "", ""},
+		{"blank", ``, false, "", ""},
+		{"command sub rejected", `export OPENAI_API_KEY=$(cat /tmp/k)`, false, "", ""},
+		{"backtick sub rejected", "export OPENAI_API_KEY=`cat /tmp/k`", false, "", ""},
+		{"var sub rejected", `export OPENAI_API_KEY=$ANOTHER`, false, "", ""},
+		{"var sub in dquote rejected", `export OPENAI_API_KEY="$ANOTHER"`, false, "", ""},
+		{"empty value rejected", `export OPENAI_API_KEY=`, false, "", ""},
+		{"unquoted whitespace rejected", `export OPENAI_API_KEY=hello world`, false, "", ""},
+		{"fish without -x flag rejected", `set -g OPENAI_API_KEY sk-abc`, false, "", ""},
+		{"odd whitespace tabs", "export\tOPENAI_API_KEY=sk-abc", true, "OPENAI_API_KEY", "sk-abc"},
+		{"single-quote preserves spaces", `export OPENAI_API_KEY='sk has space'`, true, "OPENAI_API_KEY", "sk has space"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotV, gotVal, ok := parseExportLine(tc.in)
+			if ok != tc.wantOK {
+				t.Fatalf("parseExportLine(%q) ok = %v, want %v (got name=%q value=%q)", tc.in, ok, tc.wantOK, gotV, gotVal)
+			}
+			if !ok {
+				return
+			}
+			if gotV != tc.wantVar {
+				t.Errorf("name = %q, want %q", gotV, tc.wantVar)
+			}
+			if gotVal != tc.wantVal {
+				t.Errorf("value = %q, want %q", gotVal, tc.wantVal)
+			}
+		})
+	}
+}
+
+func TestDetectShellRC_FindsKeyInZshrc(t *testing.T) {
+	home := t.TempDir()
+	zshrc := filepath.Join(home, ".zshrc")
+	body := `# my zshrc
+export PATH="/usr/local/bin:$PATH"
+export OPENAI_API_KEY=sk-from-zshrc-1234567890
+`
+	if err := os.WriteFile(zshrc, []byte(body), 0o600); err != nil {
+		t.Fatalf("write zshrc: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("OPENAI_API_KEY", "")
+
+	var result Result
+	detectShellRC(&result)
+
+	var found bool
+	for _, a := range result.Accounts {
+		if a.Provider != "openai" {
+			continue
+		}
+		found = true
+		if a.Token != "sk-from-zshrc-1234567890" {
+			t.Errorf("Token = %q, want sk-from-zshrc-1234567890", a.Token)
+		}
+		if got := a.Hint("credential_source", ""); !strings.HasPrefix(got, "shell_rc:") {
+			t.Errorf("credential_source = %q, want shell_rc: prefix", got)
+		}
+		if !strings.HasSuffix(a.Hint("credential_source", ""), ".zshrc") {
+			t.Errorf("credential_source should point at .zshrc, got %q", a.Hint("credential_source", ""))
+		}
+	}
+	if !found {
+		t.Fatalf("expected openai account from zshrc, got %+v", result.Accounts)
+	}
+}
+
+func TestDetectShellRC_FindsKeyInZshrcD(t *testing.T) {
+	home := t.TempDir()
+	dropin := filepath.Join(home, ".zshrc.d", "09-claude.zsh")
+	if err := os.MkdirAll(filepath.Dir(dropin), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(dropin, []byte(`export ANTHROPIC_API_KEY="sk-ant-from-dropin-12345"`+"\n"), 0o600); err != nil {
+		t.Fatalf("write dropin: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	var result Result
+	detectShellRC(&result)
+
+	var found bool
+	for _, a := range result.Accounts {
+		if a.Provider == "anthropic" && a.Token == "sk-ant-from-dropin-12345" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected anthropic account from .zshrc.d/, got %+v", result.Accounts)
+	}
+}
+
+func TestDetectShellRC_FindsFishKey(t *testing.T) {
+	home := t.TempDir()
+	fish := filepath.Join(home, ".config", "fish", "config.fish")
+	if err := os.MkdirAll(filepath.Dir(fish), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(fish, []byte(`set -gx GROQ_API_KEY gsk-fish-1234567890`+"\n"), 0o600); err != nil {
+		t.Fatalf("write fish: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("GROQ_API_KEY", "")
+
+	var result Result
+	detectShellRC(&result)
+
+	var found bool
+	for _, a := range result.Accounts {
+		if a.Provider == "groq" && a.Token == "gsk-fish-1234567890" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected groq account from fish config, got %+v", result.Accounts)
+	}
+}
+
+func TestDetectShellRC_EnvVarBeatsFile(t *testing.T) {
+	home := t.TempDir()
+	zshrc := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(zshrc, []byte(`export OPENAI_API_KEY=sk-from-file`+"\n"), 0o600); err != nil {
+		t.Fatalf("write zshrc: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("OPENAI_API_KEY", "sk-from-env")
+
+	var result Result
+	detectShellRC(&result)
+
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" {
+			t.Fatalf("env var was set; detectShellRC should have skipped, got %+v", a)
+		}
+	}
+}
+
+func TestDetectShellRC_IgnoresUnknownVars(t *testing.T) {
+	home := t.TempDir()
+	zshrc := filepath.Join(home, ".zshrc")
+	body := `export FOO=bar
+export NOT_AN_AI_KEY=garbage
+export OPENAI_API_KEY=sk-real-1234567890
+`
+	if err := os.WriteFile(zshrc, []byte(body), 0o600); err != nil {
+		t.Fatalf("write zshrc: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("OPENAI_API_KEY", "")
+
+	var result Result
+	detectShellRC(&result)
+
+	if len(result.Accounts) != 1 {
+		t.Fatalf("expected 1 account from %d known-var lines, got %d: %+v", 1, len(result.Accounts), result.Accounts)
+	}
+}
+
+func TestDetectShellRC_HomeUnsetIsSafe(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	var result Result
+	detectShellRC(&result) // must not panic
+	if len(result.Accounts) != 0 {
+		t.Errorf("expected 0 accounts with empty HOME, got %+v", result.Accounts)
+	}
+}
+
+func TestDetectShellRC_DoesNotDoubleCount(t *testing.T) {
+	// Same key in two files: only one account should result.
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte(`export OPENAI_API_KEY=sk-zshrc-12345`+"\n"), 0o600); err != nil {
+		t.Fatalf("write zshrc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".profile"), []byte(`export OPENAI_API_KEY=sk-profile-67890`+"\n"), 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("OPENAI_API_KEY", "")
+
+	var result Result
+	detectShellRC(&result)
+
+	count := 0
+	for _, a := range result.Accounts {
+		if a.Provider == "openai" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 openai account when key is in two files, got %d: %+v", count, result.Accounts)
+	}
+}

--- a/internal/detect/zai.go
+++ b/internal/detect/zai.go
@@ -39,13 +39,13 @@ func detectZAICodingHelper(result *Result) {
 		Provider:  "zai",
 		Auth:      "api_key",
 		APIKeyEnv: "ZAI_API_KEY",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"source":      "chelper",
 			"config_file": configFile,
 		},
 	}
 	if planType != "" {
-		acct.ExtraData["plan_type"] = planType
+		acct.RuntimeHints["plan_type"] = planType
 	}
 	if apiKey != "" {
 		acct.Token = apiKey

--- a/internal/providers/claude_code/test_helpers_test.go
+++ b/internal/providers/claude_code/test_helpers_test.go
@@ -12,7 +12,7 @@ func testClaudeAccount(id, statsPath, accountPath string) core.AccountConfig {
 
 func testClaudeAccountWithDir(id, statsPath, accountPath, claudeDir string) core.AccountConfig {
 	acct := testClaudeAccount(id, statsPath, accountPath)
-	acct.ExtraData = map[string]string{"claude_dir": claudeDir}
+	acct.RuntimeHints = map[string]string{"claude_dir": claudeDir}
 	acct.SetHint("claude_dir", claudeDir)
 	return acct
 }

--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -285,14 +285,14 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 		}
 	}
 
-	if acct.ExtraData != nil {
-		if email := acct.ExtraData["email"]; email != "" {
+	if acct.RuntimeHints != nil {
+		if email := acct.RuntimeHints["email"]; email != "" {
 			snap.Raw["account_email"] = email
 		}
-		if planType := acct.ExtraData["plan_type"]; planType != "" {
+		if planType := acct.RuntimeHints["plan_type"]; planType != "" {
 			snap.Raw["plan_type"] = planType
 		}
-		if accountID := acct.ExtraData["account_id"]; accountID != "" {
+		if accountID := acct.RuntimeHints["account_id"]; accountID != "" {
 			snap.Raw["account_id"] = accountID
 		}
 	}

--- a/internal/providers/codex/codex_test.go
+++ b/internal/providers/codex/codex_test.go
@@ -83,7 +83,7 @@ func TestFetchWithSessionData(t *testing.T) {
 		ID:       "codex-test",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir":   tmpDir,
 			"sessions_dir": filepath.Join(tmpDir, "sessions"),
 			"email":        "test@example.com",
@@ -215,7 +215,7 @@ func TestFetchNearLimit(t *testing.T) {
 		ID:       "test",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir":   tmpDir,
 			"sessions_dir": filepath.Join(tmpDir, "sessions"),
 		},
@@ -241,7 +241,7 @@ func TestFetchLimited(t *testing.T) {
 		ID:       "test",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir":   tmpDir,
 			"sessions_dir": filepath.Join(tmpDir, "sessions"),
 		},
@@ -260,7 +260,7 @@ func TestFetchNoSessions(t *testing.T) {
 		ID:       "test",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir": tmpDir,
 		},
 	})
@@ -379,7 +379,7 @@ func TestFetchUsesLiveUsageEndpoint(t *testing.T) {
 		ID:       "codex-live",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir":       tmpDir,
 			"sessions_dir":     filepath.Join(tmpDir, "sessions"),
 			"auth_file":        authPath,
@@ -479,7 +479,7 @@ func TestFetchParsesNestedLiveRateLimitStatus(t *testing.T) {
 		ID:       "codex-live",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir":       tmpDir,
 			"sessions_dir":     filepath.Join(tmpDir, "sessions"),
 			"auth_file":        authPath,
@@ -552,7 +552,7 @@ func TestFetchClearsSessionRateLimitsWhenLiveHasNoWindows(t *testing.T) {
 		ID:       "codex-live",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir":       tmpDir,
 			"sessions_dir":     filepath.Join(tmpDir, "sessions"),
 			"auth_file":        authPath,
@@ -615,7 +615,7 @@ func TestFetchFallsBackToSessionWhenLiveUsageFails(t *testing.T) {
 		ID:       "codex-fallback",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir":       tmpDir,
 			"sessions_dir":     filepath.Join(tmpDir, "sessions"),
 			"auth_file":        authPath,
@@ -672,7 +672,7 @@ func TestFetchBuildsModelAndClientUsageSplits(t *testing.T) {
 		ID:       "codex-split",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir":   tmpDir,
 			"sessions_dir": sessionsRoot,
 		},
@@ -769,7 +769,7 @@ func TestFetchExtractsToolLanguageAndCodeStats(t *testing.T) {
 		ID:       "codex-rich",
 		Provider: "codex",
 		Auth:     "local",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"config_dir":   tmpDir,
 			"sessions_dir": sessionsRoot,
 		},

--- a/internal/providers/copilot/telemetry.go
+++ b/internal/providers/copilot/telemetry.go
@@ -88,7 +88,7 @@ func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOpti
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("read copilot session directory: %w", err)
+		return nil, fmt.Errorf("copilot: read session directory: %w", err)
 	}
 
 	var out []shared.TelemetryEvent
@@ -104,7 +104,7 @@ func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOpti
 		eventsPath := filepath.Join(sessionDir, entry.Name(), "events.jsonl")
 		events, err := parseCopilotTelemetrySessionFile(eventsPath, entry.Name())
 		if err != nil {
-			return nil, fmt.Errorf("parse copilot session telemetry %s: %w", eventsPath, err)
+			return nil, fmt.Errorf("copilot: parse session telemetry %s: %w", eventsPath, err)
 		}
 		out = append(out, events...)
 	}
@@ -113,7 +113,7 @@ func (p *Provider) Collect(ctx context.Context, opts shared.TelemetryCollectOpti
 	// events.jsonl state (Copilot rotates session-state aggressively).
 	storeEvents, err := parseCopilotTelemetrySessionStore(ctx, storeDB, seenSessions)
 	if err != nil {
-		return nil, fmt.Errorf("parse copilot session store telemetry: %w", err)
+		return nil, fmt.Errorf("copilot: parse session store telemetry: %w", err)
 	}
 	out = append(out, storeEvents...)
 

--- a/internal/providers/copilot/telemetry_session_store.go
+++ b/internal/providers/copilot/telemetry_session_store.go
@@ -22,7 +22,7 @@ func parseCopilotTelemetrySessionStore(ctx context.Context, dbPath string, skipS
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("stat session store db: %w", err)
+		return nil, fmt.Errorf("copilot: stat session store db: %w", err)
 	}
 
 	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro", dbPath))
@@ -72,7 +72,7 @@ func appendSessionStoreTurnEvents(ctx context.Context, db *sql.DB, dbPath string
 		var sessionID, cwd, repo, userMsg, reply, tsRaw string
 		var turnIndex int
 		if err := rows.Scan(&sessionID, &cwd, &repo, &turnIndex, &userMsg, &reply, &tsRaw); err != nil {
-			return out, fmt.Errorf("scan session store turn row: %w", err)
+			return out, fmt.Errorf("copilot: scan session store turn row: %w", err)
 		}
 		sessionID = strings.TrimSpace(sessionID)
 		if sessionID == "" || skipSessions[sessionID] {
@@ -81,7 +81,7 @@ func appendSessionStoreTurnEvents(ctx context.Context, db *sql.DB, dbPath string
 		out = append(out, buildSessionStoreTurnEvent(dbPath, sessionID, cwd, repo, userMsg, reply, tsRaw, turnIndex))
 	}
 	if err := rows.Err(); err != nil {
-		return out, fmt.Errorf("iterate session store turn rows: %w", err)
+		return out, fmt.Errorf("copilot: iterate session store turn rows: %w", err)
 	}
 	return out, nil
 }
@@ -144,7 +144,7 @@ func appendSessionStoreFileEvents(ctx context.Context, db *sql.DB, dbPath string
 		ORDER BY sf.session_id ASC, sf.turn_index ASC, sf.id ASC
 	`)
 	if err != nil {
-		return out, fmt.Errorf("query session store file rows: %w", err)
+		return out, fmt.Errorf("copilot: query session store file rows: %w", err)
 	}
 	defer rows.Close()
 
@@ -155,7 +155,7 @@ func appendSessionStoreFileEvents(ctx context.Context, db *sql.DB, dbPath string
 		var sessionID, filePath, toolRaw, tsRaw, cwd, repo string
 		var turnIndex int
 		if err := rows.Scan(&sessionID, &filePath, &toolRaw, &turnIndex, &tsRaw, &cwd, &repo); err != nil {
-			return out, fmt.Errorf("scan session store file row: %w", err)
+			return out, fmt.Errorf("copilot: scan session store file row: %w", err)
 		}
 		sessionID = strings.TrimSpace(sessionID)
 		filePath = strings.TrimSpace(filePath)
@@ -165,7 +165,7 @@ func appendSessionStoreFileEvents(ctx context.Context, db *sql.DB, dbPath string
 		out = append(out, buildSessionStoreFileEvent(dbPath, sessionID, filePath, toolRaw, tsRaw, cwd, repo, turnIndex))
 	}
 	if err := rows.Err(); err != nil {
-		return out, fmt.Errorf("iterate session store file rows: %w", err)
+		return out, fmt.Errorf("copilot: iterate session store file rows: %w", err)
 	}
 	return out, nil
 }

--- a/internal/providers/copilot/test_helpers_test.go
+++ b/internal/providers/copilot/test_helpers_test.go
@@ -12,13 +12,13 @@ func testCopilotAccount(binary, configDir, copilotBinary string) core.AccountCon
 	if configDir == "" && copilotBinary == "" {
 		return acct
 	}
-	acct.ExtraData = map[string]string{}
+	acct.RuntimeHints = map[string]string{}
 	if configDir != "" {
-		acct.ExtraData["config_dir"] = configDir
+		acct.RuntimeHints["config_dir"] = configDir
 		acct.SetHint("config_dir", configDir)
 	}
 	if copilotBinary != "" {
-		acct.ExtraData["copilot_binary"] = copilotBinary
+		acct.RuntimeHints["copilot_binary"] = copilotBinary
 		acct.SetHint("copilot_binary", copilotBinary)
 	}
 	return acct

--- a/internal/providers/cursor/api.go
+++ b/internal/providers/cursor/api.go
@@ -31,7 +31,7 @@ func (p *Provider) callDashboardAPIWithBody(ctx context.Context, token, method s
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("cursor: HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	return json.NewDecoder(resp.Body).Decode(result)
@@ -54,7 +54,7 @@ func (p *Provider) callRESTAPI(ctx context.Context, token, path string, result i
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("cursor: HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
 	return json.NewDecoder(resp.Body).Decode(result)
@@ -76,7 +76,7 @@ func (p *Provider) doPost(ctx context.Context, token, url string, result interfa
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("cursor: HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	return json.NewDecoder(resp.Body).Decode(result)

--- a/internal/providers/cursor/api_projection.go
+++ b/internal/providers/cursor/api_projection.go
@@ -286,7 +286,7 @@ func (p *Provider) fetchFromAPI(ctx context.Context, token string, snap *core.Us
 	_, hasSpendLimit := snap.Metrics["spend_limit"]
 	_, hasBillingTotal := snap.Metrics["billing_total_cost"]
 	if !hasPlanSpend && !hasSpendLimit && !hasBillingTotal && !hasPeriodUsage && !aggApplied {
-		return fmt.Errorf("all billing API endpoints failed")
+		return fmt.Errorf("cursor: all billing API endpoints failed")
 	}
 
 	return nil

--- a/internal/providers/cursor/cursor.go
+++ b/internal/providers/cursor/cursor.go
@@ -29,6 +29,15 @@ type scoredCommitsAggregate struct {
 	TotalCommits  int
 }
 
+// cursorAPIBase is Cursor's billing/usage API host.
+//
+// Kept as a var (not const) only because the existing tests mutate it via
+// `prev := cursorAPIBase; cursorAPIBase = ts.URL; defer func(){cursorAPIBase = prev}()`
+// to point at a fake httptest server. Production code never mutates it; the
+// path forward when these tests get rewritten is to thread the URL through
+// AccountConfig.BaseURL like other providers and make this a const.
+//
+//nolint:gochecknoglobals // see comment above
 var cursorAPIBase = "https://api2.cursor.sh"
 
 type Provider struct {

--- a/internal/providers/cursor/cursor_local_test.go
+++ b/internal/providers/cursor/cursor_local_test.go
@@ -38,7 +38,7 @@ func TestProvider_Fetch_ReadsComposerSessionsFromStateDB(t *testing.T) {
 	snap, err := p.Fetch(context.Background(), core.AccountConfig{
 		ID:       "cursor-composer-test",
 		Provider: "cursor",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"state_db": stateDBPath,
 		},
 	})
@@ -102,7 +102,7 @@ func TestProvider_Fetch_ReadsScoredCommitsFromTrackingDB(t *testing.T) {
 	snap, err := p.Fetch(context.Background(), core.AccountConfig{
 		ID:       "cursor-commits-test",
 		Provider: "cursor",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"tracking_db": dbPath,
 		},
 	})
@@ -345,7 +345,7 @@ func TestProvider_Fetch_CachedBillingMetricsRestoreOnAPIFailure(t *testing.T) {
 		ID:       "cursor-cache-billing",
 		Provider: "cursor",
 		Token:    "test-token",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"state_db": stateDBPath,
 		},
 	}
@@ -593,7 +593,7 @@ func TestProvider_Fetch_LocalOnlyComposerCostCreatesCreditsTag(t *testing.T) {
 	// Fetch with no token — API is completely unavailable.
 	snap, err := p.Fetch(context.Background(), core.AccountConfig{
 		ID: "test-local-only",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"state_db": stateDBPath,
 		},
 	})
@@ -667,7 +667,7 @@ func TestProvider_Fetch_LocalOnlyCachedLimitCreatesPlanSpendGauge(t *testing.T) 
 	// Fetch with no token.
 	snap, err := p.Fetch(context.Background(), core.AccountConfig{
 		ID: "test-cached",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"state_db": stateDBPath,
 		},
 	})

--- a/internal/providers/cursor/cursor_test.go
+++ b/internal/providers/cursor/cursor_test.go
@@ -503,7 +503,7 @@ func TestProvider_Fetch_MergesAPIWithLocalTrackingBreakdowns(t *testing.T) {
 		ID:       "cursor-api-local-merge",
 		Provider: "cursor",
 		Token:    "test-token",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"tracking_db": trackingDBPath,
 		},
 	})
@@ -616,7 +616,7 @@ func TestProvider_Fetch_PreservesLocalMetricsWhenOptionalAPICallsTimeout(t *test
 		ID:       "cursor-optional-timeout",
 		Provider: "cursor",
 		Token:    "test-token",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"tracking_db": trackingDBPath,
 		},
 	})

--- a/internal/providers/cursor/fetch.go
+++ b/internal/providers/cursor/fetch.go
@@ -24,11 +24,11 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 		Raw:         make(map[string]string),
 		DailySeries: make(map[string][]core.TimePoint),
 	}
-	if acct.ExtraData != nil {
-		if email := strings.TrimSpace(acct.ExtraData["email"]); email != "" {
+	if acct.RuntimeHints != nil {
+		if email := strings.TrimSpace(acct.RuntimeHints["email"]); email != "" {
 			snap.Raw["account_email"] = email
 		}
-		if membership := strings.TrimSpace(acct.ExtraData["membership"]); membership != "" {
+		if membership := strings.TrimSpace(acct.RuntimeHints["membership"]); membership != "" {
 			snap.Raw["membership_type"] = membership
 		}
 	}
@@ -65,15 +65,15 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 		apiCh <- apiResult{err: fmt.Errorf("no token")}
 	}
 
-	if acct.ExtraData == nil {
-		acct.ExtraData = make(map[string]string)
+	if acct.RuntimeHints == nil {
+		acct.RuntimeHints = make(map[string]string)
 	}
-	if acct.ExtraData["tracking_db"] == "" && trackingDBPath != "" {
-		acct.ExtraData["tracking_db"] = trackingDBPath
+	if acct.RuntimeHints["tracking_db"] == "" && trackingDBPath != "" {
+		acct.RuntimeHints["tracking_db"] = trackingDBPath
 		acct.SetHint("tracking_db", trackingDBPath)
 	}
-	if acct.ExtraData["state_db"] == "" && stateDBPath != "" {
-		acct.ExtraData["state_db"] = stateDBPath
+	if acct.RuntimeHints["state_db"] == "" && stateDBPath != "" {
+		acct.RuntimeHints["state_db"] = stateDBPath
 		acct.SetHint("state_db", stateDBPath)
 	}
 

--- a/internal/providers/cursor/fetch.go
+++ b/internal/providers/cursor/fetch.go
@@ -62,7 +62,7 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 			apiCh <- apiResult{snap: &apiSnap, err: err}
 		}()
 	} else {
-		apiCh <- apiResult{err: fmt.Errorf("no token")}
+		apiCh <- apiResult{err: fmt.Errorf("cursor: no token")}
 	}
 
 	if acct.RuntimeHints == nil {

--- a/internal/providers/cursor/incremental_test.go
+++ b/internal/providers/cursor/incremental_test.go
@@ -529,7 +529,7 @@ func TestFetchProducesIdenticalOutput_CachedVsFresh(t *testing.T) {
 	acct := core.AccountConfig{
 		ID:       "test-identical",
 		Provider: "cursor",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"tracking_db": trackingDBPath,
 			"state_db":    stateDBPath,
 		},

--- a/internal/providers/cursor/test_helpers_test.go
+++ b/internal/providers/cursor/test_helpers_test.go
@@ -11,7 +11,7 @@ func testCursorAccount(id, token string, extra map[string]string) core.AccountCo
 	if len(extra) == 0 {
 		return acct
 	}
-	acct.ExtraData = extra
+	acct.RuntimeHints = extra
 	for _, key := range []string{"tracking_db", "state_db"} {
 		if value := extra[key]; value != "" {
 			acct.SetHint(key, value)

--- a/internal/providers/gemini_api/gemini_api.go
+++ b/internal/providers/gemini_api/gemini_api.go
@@ -84,14 +84,19 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 
 	snap.Raw = parsers.RedactHeaders(resp.Header)
 
-	switch resp.StatusCode {
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusBadRequest:
+	// 401/403/429 mapping comes from shared. Gemini also returns 400 on
+	// invalid API keys (other providers return 401), so we check for that
+	// specifically before delegating to the shared switch.
+	if resp.StatusCode == http.StatusBadRequest {
 		snap.Status = core.StatusAuth
-		snap.Message = fmt.Sprintf("HTTP %d – check API key", resp.StatusCode)
+		snap.Message = "HTTP 400 – check API key"
 		return snap, nil
-	case http.StatusTooManyRequests:
-		snap.Status = core.StatusLimited
-		snap.Message = "rate limited (HTTP 429)"
+	}
+	shared.ApplyStatusFromResponse(resp, &snap)
+	switch snap.Status {
+	case core.StatusAuth:
+		return snap, nil
+	case core.StatusLimited:
 		p.parseRetryInfo(resp.Body, &snap)
 		return snap, nil
 	}

--- a/internal/providers/gemini_cli/gemini_cli.go
+++ b/internal/providers/gemini_cli/gemini_cli.go
@@ -17,6 +17,15 @@ import (
 )
 
 const (
+	// oauthClientID and oauthClientSecret are the well-known public client
+	// credentials shipped with Google's open-source Gemini CLI (the same
+	// values the upstream binary embeds). They identify the *application*,
+	// not any user, and they're not secret in any meaningful sense — the
+	// CLI distributes them in the public binary. We mirror them here so
+	// our refresh-token exchange against `tokenEndpoint` accepts the
+	// access tokens minted by the user's own `gemini auth login`.
+	// Override at build time only if you've registered a private OAuth
+	// client and want refreshes to flow through your client_id quota.
 	oauthClientID     = "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com"
 	oauthClientSecret = "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"
 	tokenEndpoint     = "https://oauth2.googleapis.com/token"

--- a/internal/providers/gemini_cli/gemini_cli.go
+++ b/internal/providers/gemini_cli/gemini_cli.go
@@ -394,8 +394,8 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 		}
 	}
 
-	if acct.ExtraData != nil {
-		if email := acct.ExtraData["email"]; email != "" && snap.Raw["account_email"] == "" {
+	if acct.RuntimeHints != nil {
+		if email := acct.RuntimeHints["email"]; email != "" && snap.Raw["account_email"] == "" {
 			snap.Raw["account_email"] = email
 		}
 	}

--- a/internal/providers/gemini_cli/test_helpers_test.go
+++ b/internal/providers/gemini_cli/test_helpers_test.go
@@ -6,7 +6,7 @@ func testGeminiCLIAccount(id, configDir string) core.AccountConfig {
 	acct := core.AccountConfig{
 		ID:        id,
 		Provider:  "gemini_cli",
-		ExtraData: map[string]string{"config_dir": configDir},
+		RuntimeHints: map[string]string{"config_dir": configDir},
 	}
 	acct.SetHint("config_dir", configDir)
 	return acct

--- a/internal/providers/gemini_cli/test_helpers_test.go
+++ b/internal/providers/gemini_cli/test_helpers_test.go
@@ -4,8 +4,8 @@ import "github.com/janekbaraniewski/openusage/internal/core"
 
 func testGeminiCLIAccount(id, configDir string) core.AccountConfig {
 	acct := core.AccountConfig{
-		ID:        id,
-		Provider:  "gemini_cli",
+		ID:           id,
+		Provider:     "gemini_cli",
 		RuntimeHints: map[string]string{"config_dir": configDir},
 	}
 	acct.SetHint("config_dir", configDir)

--- a/internal/providers/mistral/mistral.go
+++ b/internal/providers/mistral/mistral.go
@@ -168,13 +168,13 @@ func (p *Provider) fetchRateLimits(ctx context.Context, baseURL, apiKey string, 
 	url := baseURL + "/models"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
+		return fmt.Errorf("mistral: creating request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
 	resp, err := p.Client().Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return fmt.Errorf("mistral: request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -182,16 +182,17 @@ func (p *Provider) fetchRateLimits(ctx context.Context, baseURL, apiKey string, 
 		snap.Raw[k] = v
 	}
 
-	switch resp.StatusCode {
-	case http.StatusUnauthorized, http.StatusForbidden:
-		snap.Status = core.StatusAuth
-		snap.Message = fmt.Sprintf("HTTP %d – check API key", resp.StatusCode)
+	// Centralised 401/403/429 mapping. Mistral has no provider-specific
+	// status codes to override, so the shared switch is sufficient.
+	shared.ApplyStatusFromResponse(resp, snap)
+	if snap.Status == core.StatusAuth {
 		return nil
-	case http.StatusTooManyRequests:
-		snap.Status = core.StatusLimited
-		snap.Message = "rate limited (HTTP 429)"
 	}
 
+	// Mistral exposes three rate-limit header groups: unprefixed
+	// `ratelimit-*` (canonical RPM), per-request `x-ratelimit-*-requests`,
+	// and per-token `x-ratelimit-*-tokens`. The shared ApplyStandardRateLimits
+	// only knows the second-and-third pattern, so we apply each explicitly.
 	parsers.ApplyRateLimitGroup(resp.Header, snap, "rpm", "requests", "1m",
 		"ratelimit-limit", "ratelimit-remaining", "ratelimit-reset")
 	parsers.ApplyRateLimitGroup(resp.Header, snap, "rpm_alt", "requests", "1m",

--- a/internal/providers/moonshot/moonshot.go
+++ b/internal/providers/moonshot/moonshot.go
@@ -19,7 +19,6 @@ package moonshot
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/janekbaraniewski/openusage/internal/core"
@@ -143,14 +142,8 @@ func (p *Provider) fetchUserInfo(ctx context.Context, url, apiKey string, snap *
 	var info userInfoResponse
 	statusCode, _, err := shared.FetchJSON(ctx, url, apiKey, &info, p.Client())
 	if err != nil {
-		switch statusCode {
-		case http.StatusUnauthorized, http.StatusForbidden:
-			snap.Status = core.StatusAuth
-			snap.Message = fmt.Sprintf("HTTP %d – check MOONSHOT_API_KEY", statusCode)
-			return nil
-		case http.StatusTooManyRequests:
-			snap.Status = core.StatusLimited
-			snap.Message = "rate limited (HTTP 429)"
+		shared.ApplyStatusFromCode(statusCode, snap, "MOONSHOT_API_KEY")
+		if snap.Status != "" {
 			return nil
 		}
 		return fmt.Errorf("user info: %w", err)
@@ -200,18 +193,11 @@ func (p *Provider) fetchBalance(ctx context.Context, url, apiKey string, snap *c
 	var bal balanceResponse
 	statusCode, _, err := shared.FetchJSON(ctx, url, apiKey, &bal, p.Client())
 	if err != nil {
-		switch statusCode {
-		case http.StatusUnauthorized, http.StatusForbidden:
-			if snap.Status == "" {
-				snap.Status = core.StatusAuth
-				snap.Message = fmt.Sprintf("HTTP %d – check MOONSHOT_API_KEY", statusCode)
-			}
-			return nil
-		case http.StatusTooManyRequests:
-			if snap.Status == "" {
-				snap.Status = core.StatusLimited
-				snap.Message = "rate limited (HTTP 429)"
-			}
+		// Don't clobber a status set by a previous fetch in the same poll.
+		if snap.Status == "" {
+			shared.ApplyStatusFromCode(statusCode, snap, "MOONSHOT_API_KEY")
+		}
+		if snap.Status == core.StatusAuth || snap.Status == core.StatusLimited {
 			return nil
 		}
 		return fmt.Errorf("balance: %w", err)

--- a/internal/providers/moonshot/widget.go
+++ b/internal/providers/moonshot/widget.go
@@ -1,10 +1,15 @@
 package moonshot
 
-import "github.com/janekbaraniewski/openusage/internal/core"
+import (
+	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/janekbaraniewski/openusage/internal/providers/providerbase"
+)
 
 func dashboardWidget() core.DashboardWidget {
-	cfg := core.DefaultDashboardWidget()
-	cfg.ColorRole = core.DashboardColorRoleMauve
+	// Routed through providerbase.DefaultDashboard so future option
+	// additions in providerbase apply to moonshot uniformly with other
+	// providers.
+	cfg := providerbase.DefaultDashboard(providerbase.WithColorRole(core.DashboardColorRoleMauve))
 
 	// One gauge — total spent vs cumulative deposit (high-water-mark of the
 	// observed available balance). Cash/voucher breakdown lives in compact

--- a/internal/providers/ollama/ollama_details_test.go
+++ b/internal/providers/ollama/ollama_details_test.go
@@ -176,7 +176,7 @@ func TestThinkingMetricsFromDB(t *testing.T) {
 		Provider: "ollama",
 		Auth:     "local",
 		BaseURL:  localServer.URL,
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"db_path": dbPath,
 		},
 	}
@@ -254,7 +254,7 @@ func TestExpandedSettings(t *testing.T) {
 		Provider: "ollama",
 		Auth:     "local",
 		BaseURL:  localServer.URL,
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"db_path": dbPath,
 		},
 	}

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -117,7 +117,7 @@ func TestFetch_Success(t *testing.T) {
 		Auth:      "local",
 		APIKeyEnv: "TEST_OLLAMA_KEY",
 		BaseURL:   localServer.URL,
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"db_path":        dbPath,
 			"logs_dir":       logDir,
 			"server_config":  serverConfigPath,
@@ -282,7 +282,7 @@ func TestFetch_AuthRequired_CloudOnlyWithoutKey(t *testing.T) {
 		Provider:  "ollama",
 		Auth:      "api_key",
 		APIKeyEnv: "TEST_OLLAMA_MISSING",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"cloud_base_url": "https://ollama.com",
 		},
 	}
@@ -312,7 +312,7 @@ func TestFetch_RateLimited_CloudOnly(t *testing.T) {
 		Provider:  "ollama",
 		Auth:      "api_key",
 		APIKeyEnv: "TEST_OLLAMA_KEY",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"cloud_base_url": cloudServer.URL,
 		},
 	}
@@ -398,7 +398,7 @@ func TestFetch_NoSyntheticUsageWithoutCloudWindows(t *testing.T) {
 		Auth:      "local",
 		APIKeyEnv: "TEST_OLLAMA_KEY",
 		BaseURL:   localServer.URL,
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"db_path":        dbPath,
 			"logs_dir":       logDir,
 			"server_config":  serverConfigPath,
@@ -469,7 +469,7 @@ func TestFetch_CloudSettingsFallbackUsage(t *testing.T) {
 		Provider:  "ollama",
 		Auth:      "api_key",
 		APIKeyEnv: "TEST_OLLAMA_KEY",
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"cloud_base_url": cloudServer.URL + "/api/v1",
 		},
 	}
@@ -541,7 +541,7 @@ func TestFetchServerLogs_CountsAnthropicMessagesPath(t *testing.T) {
 		Provider: "ollama",
 		Auth:     "local",
 		BaseURL:  localServer.URL,
-		ExtraData: map[string]string{
+		RuntimeHints: map[string]string{
 			"logs_dir":      logDir,
 			"server_config": serverConfigPath,
 			// No DB path on purpose; this test should be log-driven.

--- a/internal/providers/openrouter/account_api.go
+++ b/internal/providers/openrouter/account_api.go
@@ -16,13 +16,13 @@ func (p *Provider) fetchAuthKey(ctx context.Context, baseURL, apiKey string, sna
 	for _, endpoint := range []string{"/key", "/auth/key"} {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+endpoint, nil)
 		if err != nil {
-			return fmt.Errorf("creating request: %w", err)
+			return fmt.Errorf("openrouter: creating request: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 
 		resp, err := p.Client().Do(req)
 		if err != nil {
-			return fmt.Errorf("request failed: %w", err)
+			return fmt.Errorf("openrouter: request failed: %w", err)
 		}
 
 		snap.Raw = parsers.RedactHeaders(resp.Header)
@@ -34,7 +34,7 @@ func (p *Provider) fetchAuthKey(ctx context.Context, baseURL, apiKey string, sna
 		body, readErr := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if readErr != nil {
-			return fmt.Errorf("reading body: %w", readErr)
+			return fmt.Errorf("openrouter: reading body: %w", readErr)
 		}
 
 		switch resp.StatusCode {
@@ -62,7 +62,7 @@ func (p *Provider) fetchAuthKey(ctx context.Context, baseURL, apiKey string, sna
 		return nil
 	}
 
-	return fmt.Errorf("key endpoint not available (HTTP 404)")
+	return fmt.Errorf("openrouter: key endpoint not available (HTTP 404)")
 }
 
 func applyKeyData(data *keyData, snap *core.UsageSnapshot) {
@@ -259,7 +259,7 @@ func (p *Provider) fetchKeysMeta(ctx context.Context, baseURL, apiKey string, sn
 
 		var pageResp keysResponse
 		if err := json.Unmarshal(body, &pageResp); err != nil {
-			return fmt.Errorf("parsing keys list: %w", err)
+			return fmt.Errorf("openrouter: parsing keys list: %w", err)
 		}
 		if len(pageResp.Data) == 0 {
 			break

--- a/internal/providers/perplexity/widget.go
+++ b/internal/providers/perplexity/widget.go
@@ -1,10 +1,15 @@
 package perplexity
 
-import "github.com/janekbaraniewski/openusage/internal/core"
+import (
+	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/janekbaraniewski/openusage/internal/providers/providerbase"
+)
 
 func dashboardWidget() core.DashboardWidget {
-	cfg := core.DefaultDashboardWidget()
-	cfg.ColorRole = core.DashboardColorRoleSky
+	// Routed through providerbase.DefaultDashboard so future option
+	// additions in providerbase apply to perplexity uniformly with other
+	// providers.
+	cfg := providerbase.DefaultDashboard(providerbase.WithColorRole(core.DashboardColorRoleSky))
 	// Single primary gauge — balance (USD remaining). Tier is shown as a
 	// raw line below since tier 0/5 doesn't make sense as a percent.
 	cfg.GaugePriority = []string{"available_balance"}

--- a/internal/providers/shared/helpers.go
+++ b/internal/providers/shared/helpers.go
@@ -30,24 +30,40 @@ func CreateStandardRequest(ctx context.Context, baseURL, endpoint, apiKey string
 func ProcessStandardResponse(resp *http.Response, acct core.AccountConfig, providerID string) (core.UsageSnapshot, error) {
 	snap := core.NewUsageSnapshot(providerID, acct.ID)
 	snap.Raw = parsers.RedactHeaders(resp.Header)
-	applyStatusFromResponse(resp, &snap)
+	ApplyStatusFromResponse(resp, &snap)
 	return snap, nil
 }
 
-// applyStatusFromResponse sets snap.Status and snap.Message based on the HTTP
-// status code. It centralises the 401/403 → StatusAuth, 429 → StatusLimited
-// mapping used by both ProcessStandardResponse and ProbeRateLimits.
-func applyStatusFromResponse(resp *http.Response, snap *core.UsageSnapshot) {
-	switch resp.StatusCode {
-	case http.StatusUnauthorized, http.StatusForbidden:
-		snap.Status = core.StatusAuth
-		snap.Message = fmt.Sprintf("HTTP %d – check API key", resp.StatusCode)
-	case http.StatusTooManyRequests:
-		snap.Status = core.StatusLimited
-		snap.Message = "rate limited (HTTP 429)"
+// ApplyStatusFromResponse sets snap.Status and snap.Message based on the HTTP
+// status code. Centralises the 401/403 → StatusAuth, 429 → StatusLimited
+// mapping that providers with custom response handling (mistral, gemini_api,
+// alibaba_cloud, moonshot, zai) used to hand-roll. Call this first, then add
+// provider-specific cases on top if needed. Reads Retry-After when present.
+func ApplyStatusFromResponse(resp *http.Response, snap *core.UsageSnapshot) {
+	ApplyStatusFromCode(resp.StatusCode, snap, "")
+	if snap.Status == core.StatusLimited {
 		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
 			snap.Raw["retry_after"] = retryAfter
 		}
+	}
+}
+
+// ApplyStatusFromCode is the response-less variant for callers that only have
+// the status code (e.g. shared.FetchJSON returns an error + status code).
+// The keyHint is included in the auth-failure message — pass the env-var name
+// the user should check (e.g. "MOONSHOT_API_KEY"). Empty means "API key".
+func ApplyStatusFromCode(statusCode int, snap *core.UsageSnapshot, keyHint string) {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		hint := "API key"
+		if keyHint != "" {
+			hint = keyHint
+		}
+		snap.Status = core.StatusAuth
+		snap.Message = fmt.Sprintf("HTTP %d – check %s", statusCode, hint)
+	case http.StatusTooManyRequests:
+		snap.Status = core.StatusLimited
+		snap.Message = "rate limited (HTTP 429)"
 	}
 }
 
@@ -145,7 +161,7 @@ func ProbeRateLimits(ctx context.Context, url, apiKey string, snap *core.UsageSn
 		snap.Raw[k] = v
 	}
 
-	applyStatusFromResponse(resp, snap)
+	ApplyStatusFromResponse(resp, snap)
 	if snap.Status == core.StatusAuth {
 		return nil
 	}

--- a/internal/providers/zai/monitor_helpers.go
+++ b/internal/providers/zai/monitor_helpers.go
@@ -15,8 +15,8 @@ import (
 
 func resolveAPIBases(acct core.AccountConfig) (codingBase, monitorBase, region string) {
 	planType := ""
-	if acct.ExtraData != nil {
-		planType = strings.TrimSpace(acct.ExtraData["plan_type"])
+	if acct.RuntimeHints != nil {
+		planType = strings.TrimSpace(acct.RuntimeHints["plan_type"])
 	}
 
 	isChina := strings.Contains(strings.ToLower(planType), "china")

--- a/internal/providers/zai/zai.go
+++ b/internal/providers/zai/zai.go
@@ -136,12 +136,12 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 	snap.Raw["provider_region"] = region
 	snap.SetAttribute("provider_region", region)
 
-	if acct.ExtraData != nil {
-		if planType := strings.TrimSpace(acct.ExtraData["plan_type"]); planType != "" {
+	if acct.RuntimeHints != nil {
+		if planType := strings.TrimSpace(acct.RuntimeHints["plan_type"]); planType != "" {
 			snap.Raw["plan_type"] = planType
 			snap.SetAttribute("plan_type", planType)
 		}
-		if source := strings.TrimSpace(acct.ExtraData["source"]); source != "" {
+		if source := strings.TrimSpace(acct.RuntimeHints["source"]); source != "" {
 			snap.Raw["auth_type"] = source
 			snap.SetAttribute("auth_type", source)
 		}

--- a/internal/providers/zai/zai_test.go
+++ b/internal/providers/zai/zai_test.go
@@ -632,7 +632,7 @@ func TestResolveAPIBases(t *testing.T) {
 		{
 			name: "plan china",
 			acct: core.AccountConfig{
-				ExtraData: map[string]string{"plan_type": "glm_coding_plan_china"},
+				RuntimeHints: map[string]string{"plan_type": "glm_coding_plan_china"},
 			},
 			wantCoding:  defaultChinaCodingBaseURL,
 			wantMonitor: defaultChinaMonitorBaseURL,


### PR DESCRIPTION
## Summary

This PR started as "improve credential auto-detection" and expanded into a broader cleanup pass driven by a full codebase review. Three logical groups:

**1. Credential auto-detection (the original scope)**
- New file-based detectors: shell rc files (`.zshrc`/`.bashrc`/fish/modular dirs), Aider `.aider.conf.yml`+`.env`, Codex `auth.json` top-level `OPENAI_API_KEY`, Claude Code Linux/Windows `.credentials.json`, gh CLI `hosts.yml`, gcloud ADC, Codex macOS keychain entry. Each annotates a `credential_source` runtime hint that surfaces in `openusage detect`.
- macOS keychain probe extended to `Codex Auth` alongside `Claude Code-credentials`.
- New `openusage detect` cobra subcommand: prints tools, accounts (masked tokens + source provenance), and a coverage list of providers with no detected credential. `--all` shows the full registry.
- Privacy gate: Aider config detection only runs when the `aider` binary is actually installed (was scanning every cwd's `.env` unconditionally — fixed before merge).
- Aider precedence fixed: cwd/.env now correctly beats home/.aider.conf.yml (was processing all YAML before any .env, inverting Aider's documented order).

**2. Detection-layer DRY**
- `core.AccountConfig.ExtraData` removed; `RuntimeHints` is the single runtime-only metadata map. 100+ references migrated.
- `envKeyMappingEntry` lifted to `detect.go` with new `AiderShortNames []string` field; package-level `envKeyByVar` and `envKeyByAiderShortName` indexes replace linear scans and ad-hoc map-builds.
- New shared `adoptAPIKey` helper centralises "register an api_key account from a known mapping with credential_source provenance" — used by every file-based detector.
- `MaskKey` exported from `internal/detect`; three duplicate implementations consolidated (cmd-level `maskToken`, package-private `maskKey`, and a buggy inline mask in `detect.go`).

**3. Codebase cleanup driven by full review**
- **Daemon correctness:**
  - `config.Save`/`SaveTo` now take `saveMu` (was bypassing while `modifyConfig` held it — race fix).
  - `ResolveAccounts` no longer rewrites `settings.json` on every poll cycle; only when content changed.
  - `runWatchLoop` debounce timer captures `event.Name`/`Op` by value (was by reference — printed wrong event under load).
  - Read-model HTTP handler re-arms `dataIngested` after compute failure so periodic refresh recovers instead of sticking on stale empty templates.
  - `pollProviders` per-account goroutines check `ctx.Done()` at entry — no more N×8s leak on shutdown.
- **Provider hygiene:**
  - Provider-prefix error wrapping (CLAUDE.md mandate) added to cursor, openrouter, copilot/telemetry. Errors now identify their source.
  - `gemini_api`, `moonshot`, `mistral` converted to use `shared.ApplyStatusFromResponse` / `shared.ApplyStatusFromCode` instead of duplicate 401/403/429 switches. New `ApplyStatusFromCode` helper for callers that only have a status code (e.g. via `shared.FetchJSON`'s error path).
  - `moonshot`/`perplexity` widget construction routed through `providerbase.DefaultDashboard` for uniformity.
  - `gemini_cli` hardcoded GOCSPX OAuth client secret documented as the public application credential shipped by Google.
  - `cursorAPIBase` documented (still a var because tests mutate it; comment points forward to BaseURL-threading rewrite).

**Out of scope (deferred to follow-up PRs):**
- `zai`'s 5 near-identical fetch endpoints (~250 LOC reducible) — substantial structural refactor.
- TUI cleanup (View() impurity, oversized Update switch, widgetSection duplication, lipgloss style caching).
- `openrouter.fetchAnalytics` 383-line function decomposition.
- Continue.dev / Cline / Roo Code / Codeium-Windsurf credential sources (out of original scope).

## Verified facts

- **Aider** `.aider.conf.yml` and `.env` search order — `$HOME` -> git root -> cwd, last-loaded wins. YAML keys: `openai-api-key`, `anthropic-api-key`, list-form `api-key:` ([docs](https://aider.chat/docs/config/api-keys.html), [docs](https://aider.chat/docs/config/aider_conf.html), [docs](https://aider.chat/docs/config/dotenv.html)).
- **Claude Code CLI** macOS keychain service `Claude Code-credentials` (anthropics/claude-code issues #9403, #37512, #44089).
- **Codex** auth.json top-level `OPENAI_API_KEY` field via `AuthDotJson` struct (openai/codex #5212, #20899). macOS keychain `Codex Auth` (openai/codex #16728).
- **gh CLI** `~/.config/gh/hosts.yml` plaintext fallback when no system keychain (cli/cli #7757).
- **Google Cloud ADC** `~/.config/gcloud/application_default_credentials.json` documented Google Cloud auth path.

## Test plan

- [x] `go test ./... -race -count=1` clean (34 packages)
- [x] `go vet ./...` clean
- [x] `make build` clean
- [x] `DOCS_PREVIEW=1 npm run build` in `docs/site` finishes with `[SUCCESS]`
- [x] Manual smoke: `./bin/openusage detect` on dev machine surfaces:
  - `keychain:Claude Code-credentials` source on claude-code account
  - `file:~/.config/gh/hosts.yml` source on copilot account (new — gh hosts.yml detector)
  - `opencode_auth_json` source on openrouter/zai accounts (existing)
  - All tokens masked
- [x] `OPENAI_API_KEY=sk-test... ./bin/openusage detect` correctly shows env source
- [x] grep for clear-text tokens: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)