### PR TITLE
ci: sign macOS releases + auto-merge every Dependabot PR

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -10,39 +10,25 @@ permissions:
 
 jobs:
   automerge:
-    name: Auto-merge safe Dependabot PRs
+    name: Approve and enable auto-merge
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Fetch Dependabot metadata
+      - name: Fetch Dependabot metadata (for the log)
         id: metadata
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Decide auto-merge eligibility
-        id: decide
+      - name: Log update info
         env:
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
           DEP_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
         run: |
-          set -euo pipefail
-          eligible=false
-          if [ "$UPDATE_TYPE" = "version-update:semver-patch" ]; then
-            eligible=true
-          fi
-          if [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
-            case "$DEP_TYPE" in
-              direct:development|indirect)
-                eligible=true
-                ;;
-            esac
-          fi
-          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
-          echo "::notice::update_type=$UPDATE_TYPE dep_type=$DEP_TYPE eligible=$eligible"
+          echo "::notice::ecosystem=$ECOSYSTEM update_type=$UPDATE_TYPE dep_type=$DEP_TYPE"
 
       - name: Approve the PR
-        if: steps.decide.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -50,18 +36,8 @@ jobs:
           gh pr review --approve "$PR_URL" --body "Auto-approved by policy."
 
       - name: Enable auto-merge (squash)
-        if: steps.decide.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
-
-      - name: Comment on PRs left for review
-        if: steps.decide.outputs.eligible != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
-          DEP_TYPE: ${{ steps.metadata.outputs.dependency-type }}
         run: |
-          gh pr comment "$PR_URL" --body "This update is **$UPDATE_TYPE** on a **$DEP_TYPE** dependency, so it's left for human review per the auto-merge policy. See \`docs/CI_AUTOMATION_BOTS.md\`."
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,6 +84,9 @@ jobs:
             -X 'github.com/janekbaraniewski/openusage/internal/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)'" \
             -o dist/openusage_darwin_arm64 ./cmd/openusage
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
       - name: Create macOS archives
         run: |
           VERSION=${{ steps.version.outputs.version }}
@@ -103,6 +106,18 @@ jobs:
           [ -f ../README* ] && cp ../README* openusage_${VERSION}_darwin_arm64/ || true
           tar czf openusage_${VERSION}_darwin_arm64.tar.gz openusage_${VERSION}_darwin_arm64
 
+      - name: Sign macOS archives with cosign (keyless)
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          cd dist
+          for arch in amd64 arm64; do
+            archive="openusage_${VERSION}_darwin_${arch}.tar.gz"
+            cosign sign-blob --yes \
+              --output-signature   "${archive}.sig" \
+              --output-certificate "${archive}.pem" \
+              "${archive}"
+          done
+
       - name: Upload macOS binaries to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +126,11 @@ jobs:
           chmod +x scripts/install.sh
           gh release upload "${GITHUB_REF_NAME}" \
             dist/openusage_${VERSION}_darwin_amd64.tar.gz \
+            dist/openusage_${VERSION}_darwin_amd64.tar.gz.sig \
+            dist/openusage_${VERSION}_darwin_amd64.tar.gz.pem \
             dist/openusage_${VERSION}_darwin_arm64.tar.gz \
+            dist/openusage_${VERSION}_darwin_arm64.tar.gz.sig \
+            dist/openusage_${VERSION}_darwin_arm64.tar.gz.pem \
             scripts/install.sh \
             --clobber
 

--- a/docs/CI_AUTOMATION_BOTS.md
+++ b/docs/CI_AUTOMATION_BOTS.md
@@ -47,14 +47,18 @@ We also add **grouping** so that `@docusaurus/*` patch+minor bumps come as a sin
 
 ### 2. Dependabot auto-merge workflow
 
-Approach: a small workflow listens for Dependabot PRs, reads metadata via `dependabot/fetch-metadata@v2`, and:
+Approach: every Dependabot PR is auto-approved and gets squash auto-merge enabled. Branch protection on `main` enforces that every required check must pass before the squash actually fires. If CI fails, the PR sits open for human attention — no force-merging.
 
-- For **patch updates** of any ecosystem: enable squash auto-merge
-- For **minor updates** of dev/build dependencies: enable squash auto-merge
-- For **minor updates** of runtime dependencies: leave for human review
-- For **major updates**: leave for human review
+CI is the safety net. We trust that:
 
-The actual merge fires only after every required CI check passes. If a check fails, the PR sits open for human attention — no force-merging.
+- `go test -race`, `golangci-lint`, and `vet` catch behavioral regressions
+- `govulncheck` catches reachable CVEs introduced by the bump
+- The Dependency Review action blocks PRs that introduce vulnerable transitive deps
+- The Docusaurus build catches anything that breaks docs tooling
+
+If those gates pass, the bump is safe to ship. The cost of human review on every patch update is higher than the residual risk this leaves.
+
+**This requires branch protection on `main` with required status checks.** Without it, `gh pr merge --auto` merges as soon as nothing is blocking — which is "immediately" if nothing's required.
 
 We use the **native GitHub auto-merge** (via `gh pr merge --auto`) instead of a third-party action. Cleaner, no extra permissions to grant.
 


### PR DESCRIPTION
## Summary

Two follow-ups to PR #94's CI automation work.

### 1. macOS release archives get cosign signatures

v0.10.3 showed a gap: 4 of 6 artifacts signed (linux + windows + checksums.txt), darwin missing. The `release-macos` job builds with raw `go build` (CGO cross-compile to darwin from linux is awkward) and never invoked cosign.

Fix:
- Install `sigstore/cosign-installer` in `release-macos`
- Sign `darwin_amd64.tar.gz` and `darwin_arm64.tar.gz` with `cosign sign-blob --yes`
- Upload `.sig` and `.pem` siblings in the existing `gh release upload`

Next release will have 6 of 6 artifacts signed.

### 2. Auto-merge every Dependabot PR

Stripped the eligibility tree. Every Dependabot PR is auto-approved and has squash auto-merge enabled.

CI is the gate. The merge only fires after every required status check on `main` passes:

- `go test -race`, `golangci-lint`, `vet`
- `govulncheck`
- Dependency Review (blocks vulnerable transitive deps)
- Docusaurus build (`Build & Preview` / `Lychee`)

A behavior-breaking bump fails tests and the auto-merge waits indefinitely.

**Prerequisite:** branch protection on `main` with required status checks. Without it, `gh pr merge --auto` merges as soon as nothing blocks — which is "immediately" if nothing's required. Set this in repo Settings → Branches.

### About the existing 11 Dependabot PRs

After #107 merges, the next push to each Dependabot branch (or a `@dependabot rebase` comment) re-fires the workflow and they all queue for auto-merge. Or I can manually approve+enable on each in one batch right now. Tell me which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)