### PR TITLE
ci: auto-rebase open Dependabot PRs on every push to main

### DIFF
--- a/.github/workflows/dependabot-rebase-on-main.yaml
+++ b/.github/workflows/dependabot-rebase-on-main.yaml
@@ -1,0 +1,45 @@
+name: Dependabot rebase open PRs on main update
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  rebase:
+    name: Comment '@dependabot rebase' on open Dependabot PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find open Dependabot PRs and ask for rebase
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Skip when this push is itself a Dependabot merge — only the
+          # NEXT push (typically a non-Dependabot one) should kick a fresh
+          # rebase, otherwise we churn on every dependabot merge.
+          # Actually we DO want to rebase after every main update because
+          # that's exactly when the other PRs go stale. Keep firing.
+
+          prs=$(gh pr list \
+            --state open \
+            --author "app/dependabot" \
+            --json number,headRefName \
+            --jq '.[].number')
+
+          if [ -z "$prs" ]; then
+            echo "No open Dependabot PRs."
+            exit 0
+          fi
+
+          for pr in $prs; do
+            echo "::group::PR #$pr"
+            # Ask Dependabot to rebase. It will only do so if the branch
+            # is actually behind; otherwise it's a no-op.
+            gh pr comment "$pr" --body "@dependabot rebase"
+            echo "::endgroup::"
+          done

--- a/docs/CI_AUTOMATION_BOTS.md
+++ b/docs/CI_AUTOMATION_BOTS.md
@@ -105,7 +105,11 @@ Replaces the manual tag-and-release flow. How it works:
 
 Benefit: the v0.10.1 / v0.10.2 cuts we just did become a single click on a PR.
 
-### 7. Stale issue/PR bot
+### 7. Dependabot rebase-on-main-update workflow
+
+A separate workflow at `.github/workflows/dependabot-rebase-on-main.yaml` runs on every push to `main` and comments `@dependabot rebase` on every open Dependabot PR. Without this, after one Dependabot PR auto-merges, the others stay `BEHIND` indefinitely (GitHub doesn't auto-rebase even when auto-merge is enabled, and the `strict: true` branch-protection setting blocks merging behind branches). Standard pattern; fixes the cascade.
+
+### 8. Stale issue/PR bot
 
 `actions/stale` with conservative defaults:
 


### PR DESCRIPTION
## Summary

Closes a gap in the auto-merge setup: after one Dependabot PR auto-merges, the remaining ones stay \`BEHIND\` main forever. GitHub doesn't auto-rebase even when auto-merge is enabled, and \`strict: true\` branch protection blocks merging behind branches. Manual \`@dependabot rebase\` was needed to keep the queue moving.

This adds a workflow on \`push: branches: [main]\` that lists every open Dependabot PR and comments \`@dependabot rebase\` on each. Dependabot does the actual rebase (or a no-op if the PR is already current). The auto-merge workflow re-fires on the rebase push, required checks re-run, and the PR merges as soon as everything's green. Repeat until the queue is drained.

Standard, well-known pattern for projects running fully-automated Dependabot.

## Test plan

- [x] YAML lint clean
- [ ] After merge: confirm a fresh push to main triggers the workflow and existing open Dependabot PRs get rebased (and then merged via the existing auto-merge)