### PR TITLE
ci: fix release-please changelog scope + clean Dependabot commit format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,8 +30,7 @@ updates:
       - dependencies
       - ci
     commit-message:
-      prefix: "ci"
-      include: scope
+      prefix: "ci(actions)"
     groups:
       actions-minor-and-patch:
         update-types:
@@ -50,7 +49,6 @@ updates:
       - website
     commit-message:
       prefix: "deps(website)"
-      include: scope
     groups:
       website-minor-and-patch:
         update-types:
@@ -72,7 +70,6 @@ updates:
       - docs
     commit-message:
       prefix: "deps(docs)"
-      include: scope
     groups:
       docusaurus:
         patterns:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,25 +1,28 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "go",
   "packages": {
     ".": {
+      "release-type": "go",
       "package-name": "openusage",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance"},
+        {"type": "deps", "section": "Dependencies"},
+        {"type": "refactor", "section": "Refactoring"},
+        {"type": "docs", "section": "Documentation", "hidden": true},
+        {"type": "chore", "section": "Miscellaneous", "hidden": true},
+        {"type": "ci", "section": "CI/CD", "hidden": true},
+        {"type": "test", "section": "Tests", "hidden": true},
+        {"type": "style", "section": "Style", "hidden": true},
+        {"type": "build", "section": "Build", "hidden": true},
+        {"type": "revert", "section": "Reverts"}
+      ]
     }
-  },
-  "changelog-sections": [
-    {"type": "feat", "section": "Features"},
-    {"type": "fix", "section": "Bug Fixes"},
-    {"type": "perf", "section": "Performance"},
-    {"type": "deps", "section": "Dependencies"},
-    {"type": "refactor", "section": "Refactoring"},
-    {"type": "docs", "section": "Documentation", "hidden": true},
-    {"type": "chore", "section": "Miscellaneous", "hidden": true},
-    {"type": "ci", "section": "CI/CD", "hidden": true},
-    {"type": "test", "section": "Tests", "hidden": true}
-  ]
+  }
 }


### PR DESCRIPTION
## Summary

Two real bugs that caused release-please PR #110 to show only \`feat\` and \`fix\` entries even though main has had many merged commits since v0.10.3.

### Bug 1 — \`changelog-sections\` at wrong nesting level

\`release-please-config.json\` had \`changelog-sections\` at the top level. Per the [schema](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json), it must be inside each per-package config (\`packages.".".changelog-sections\`). release-please was silently falling back to the \`go\` release-type's defaults — which only include \`feat\` and \`fix\`. That's why \`deps\`, \`refactor\`, \`ci\`, etc. never appeared in the generated changelog even though the config "looked" right.

Fix: move \`changelog-sections\` inside the package config. Also added \`revert\`, \`style\`, \`build\` for completeness.

### Bug 2 — Dependabot npm/github-actions producing malformed scopes

For \`website\` and \`docs/site\` npm ecosystems we had:

\`\`\`yaml
commit-message:
  prefix: "deps(website)"
  include: scope
\`\`\`

That produced commit messages like \`deps(website)(deps): bump react...\` — **two scopes**. Conventional Commits permits exactly one. release-please can't parse the type, so the commit gets dropped from the changelog entirely.

Fix: drop \`include: scope\` for npm ecosystems so messages become \`deps(website): bump react...\` (single scope, parses as type \`deps\`).

Same fix for \`github-actions\`: changed \`prefix: "ci"\` + \`include: scope\` to \`prefix: "ci(actions)"\` (single scope).

\`gomod\` left unchanged — \`prefix: "deps"\` + \`include: scope\` produces \`deps(<dep-type>): ...\` which is valid CC.

## Test plan

- [x] JSON + YAML lint clean
- [ ] After merge: release-please workflow runs on push to main, PR #110 is rewritten with the full changelog (Dependencies, Refactoring sections appear)
- [ ] Future Dependabot npm bumps emit single-scope conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)