### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -3,6 +3,7 @@ name: release-please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Lets us regenerate the release PR on demand without pushing an unrelated commit. Useful for situations like the current one where release-please's 'PR remained the same' optimization keeps an open release PR stale after a config change.