### PR TITLE
ci: tag auto-approved Dependabot PRs with 'auto-approved' label

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -35,6 +35,13 @@ jobs:
         run: |
           gh pr review --approve "$PR_URL" --body "Auto-approved by policy."
 
+      - name: Add auto-approved label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$PR_URL" --add-label auto-approved
+
       - name: Enable auto-merge (squash)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a step to the dependabot-automerge workflow that applies an 'auto-approved' label to every Dependabot PR after it gets auto-approved. Easy visual signal in the PR list that a PR was approved by policy rather than by a human.

The label was created via 'gh label create auto-approved --description "Auto-approved by the dependabot-automerge workflow." --color 0e8a16'.