### PR TITLE
ci(release-please): use a PAT so its pushes trigger downstream CI

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,5 +15,13 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
+          # Use a PAT (or GitHub App token) so commits release-please pushes
+          # to its branch trigger downstream workflows (CI, Lychee, govulncheck,
+          # CodeQL). Falls back to GITHUB_TOKEN when no PAT is configured —
+          # in that mode the release PR will sit blocked on missing required
+          # checks and need an admin-merge.
+          #
+          # See docs/CI_AUTOMATION_BOTS.md for PAT scope + secret-name details.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/docs/CI_AUTOMATION_BOTS.md
+++ b/docs/CI_AUTOMATION_BOTS.md
@@ -151,6 +151,20 @@ For auto-merge to work, the repo needs:
 For `release-please`:
 
 - The workflow needs `contents: write` and `pull-requests: write` on the GITHUB_TOKEN — already granted for the existing release workflow.
+- **`RELEASE_PLEASE_TOKEN` secret** — a fine-grained PAT (or GitHub App token) that lets release-please push commits in a way that *does* trigger downstream workflows (CI, Lychee, govulncheck, CodeQL). Without it, release-please uses `GITHUB_TOKEN` and its pushes are bot-attributed; GitHub Actions explicitly will not chain workflow runs from bot pushes, so the release PR sits with required checks never reporting and stays unmergeable except via admin-merge.
+
+  To create the PAT:
+
+  1. Go to <https://github.com/settings/personal-access-tokens/new> (fine-grained PAT).
+  2. **Resource owner**: yourself. **Repository access**: only `janekbaraniewski/openusage`.
+  3. **Repository permissions**:
+     - **Contents** → Read and write
+     - **Pull requests** → Read and write
+     - **Workflows** → Read and write
+  4. Set an expiry (90d is fine; longer if you trust your machine).
+  5. Save the token. Add as secret `RELEASE_PLEASE_TOKEN` in repo Settings → Secrets and variables → Actions.
+
+  The workflow falls back to `GITHUB_TOKEN` when the PAT secret isn't set — so the project keeps working before the secret is configured, just with the admin-merge step.
 
 For Scorecard:
 


### PR DESCRIPTION
## Summary

Closes the loop on why release-please PRs can't be merged via the normal flow: the action's pushes are authored by \`GITHUB_TOKEN\`, and GitHub Actions explicitly does not chain workflow runs from bot-authored pushes. So our required CI / Lychee / govulncheck / CodeQL checks never run on the release PR, branch protection blocks merge forever, and the only escape is admin-merge.

This PR wires \`secrets.RELEASE_PLEASE_TOKEN\` into the workflow's \`token:\` input, with fallback to \`GITHUB_TOKEN\`. After you add the secret, release-please pushes get attributed to your identity, downstream workflows run, and release PRs become regular CI-gated auto-mergeable PRs.

## What you need to do

Create a fine-grained PAT and add it as a secret. **<https://github.com/settings/personal-access-tokens/new>**

- **Resource owner:** yourself
- **Repository access:** only \`janekbaraniewski/openusage\`
- **Repository permissions:**
  - Contents → Read and write
  - Pull requests → Read and write
  - Workflows → Read and write
- Set an expiry (90d works; longer if convenient)
- Save it as \`RELEASE_PLEASE_TOKEN\` in **Settings → Secrets and variables → Actions**

After that, the next release-please PR will:
1. Get pushed by \`RELEASE_PLEASE_TOKEN\` identity
2. Trigger CI, Lychee, govulncheck, CodeQL on the release PR's branch
3. All required checks report
4. Branch protection unblocks
5. Mergeable via UI / CLI without admin override

If the secret isn't set, fallback path keeps the workflow alive — release PR still gets created, just stays admin-merge-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)