### PR TITLE
ci: make bot PR refresh deterministic

### DIFF
--- a/.github/workflows/dependabot-rebase-on-main.yaml
+++ b/.github/workflows/dependabot-rebase-on-main.yaml
@@ -16,7 +16,7 @@ jobs:
     with:
       author-login: dependabot[bot]
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
 
   dispatch-required-checks:

--- a/.github/workflows/dispatch-required-pr-checks.yaml
+++ b/.github/workflows/dispatch-required-pr-checks.yaml
@@ -28,21 +28,33 @@ jobs:
           - codeql.yaml
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          REFS_JSON: ${{ inputs.refs-json }}
-          WORKFLOW_FILE: ${{ matrix.workflow }}
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404
           script: |
             const refs = JSON.parse(process.env.REFS_JSON);
             const workflow_id = process.env.WORKFLOW_FILE;
             const { owner, repo } = context.repo;
 
+            const failures = [];
             for (const ref of refs) {
               core.info(`Dispatching ${workflow_id} on ${ref}`);
-              await github.rest.actions.createWorkflowDispatch({
-                owner,
-                repo,
-                workflow_id,
-                ref,
-              });
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id,
+                  ref,
+                });
+              } catch (error) {
+                failures.push(`${ref}: ${error.message}`);
+                core.warning(`Could not dispatch ${workflow_id} on ${ref}: ${error.message}`);
+              }
             }
+
+            if (failures.length > 0) {
+              core.setFailed(`Failed to dispatch ${workflow_id}: ${failures.join('; ')}`);
+            }
+        env:
+          REFS_JSON: ${{ inputs.refs-json }}
+          WORKFLOW_FILE: ${{ matrix.workflow }}

--- a/.github/workflows/refresh-pr-branches.yaml
+++ b/.github/workflows/refresh-pr-branches.yaml
@@ -19,7 +19,7 @@ on:
         value: ${{ jobs.refresh.outputs.refs-json }}
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -44,6 +44,9 @@ jobs:
             const isAlreadyCurrent = (error) =>
               error.status === 422 &&
               /no new commits|not behind|up to date/i.test(error.message);
+
+            const isCurrent = (pull) =>
+              !['behind', 'dirty', 'unknown'].includes(pull.mergeable_state);
 
             async function listPulls() {
               if (!labels) {
@@ -74,21 +77,29 @@ jobs:
               return pulls;
             }
 
-            async function waitForBranchUpdate(pr, previousSha) {
+            async function getPull(pullNumber) {
+              const response = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullNumber,
+              });
+              return response.data;
+            }
+
+            async function waitForCurrentBranch(pr, previousSha) {
               let current = pr;
+              if ((!previousSha || current.head.sha !== previousSha) && isCurrent(current)) {
+                return current;
+              }
+
               for (const delay of [2000, 3000, 5000, 10000, 15000, 25000]) {
                 await sleep(delay);
-                const response = await github.rest.pulls.get({
-                  owner,
-                  repo,
-                  pull_number: pr.number,
-                });
-                current = response.data;
-                if (current.head.sha !== previousSha) {
+                current = await getPull(pr.number);
+                if ((!previousSha || current.head.sha !== previousSha) && isCurrent(current)) {
                   return current;
                 }
               }
-              core.warning(`PR #${pr.number} branch update did not finish before dispatch; dispatching current ref.`);
+              core.warning(`PR #${pr.number} branch update did not finish; skipping required-check dispatch for now.`);
               return current;
             }
 
@@ -96,27 +107,45 @@ jobs:
               authorLogin ? pull.user?.login === authorLogin : true
             );
             const refs = [];
+            const skipped = [];
 
             for (const pull of pulls) {
               core.startGroup(`PR #${pull.number}`);
-              refs.push(pull.head.ref);
               try {
                 await github.rest.pulls.updateBranch({
                   owner,
                   repo,
                   pull_number: pull.number,
+                  expected_head_sha: pull.head.sha,
                 });
-                const updated = await waitForBranchUpdate(pull, pull.head.sha);
-                core.info(`Updated ${pull.head.ref}: ${pull.head.sha} -> ${updated.head.sha}`);
+                const updated = await waitForCurrentBranch(pull, pull.head.sha);
+                if (isCurrent(updated)) {
+                  refs.push(updated.head.ref);
+                  core.info(`Updated ${pull.head.ref}: ${pull.head.sha} -> ${updated.head.sha}`);
+                } else {
+                  skipped.push({ number: pull.number, ref: pull.head.ref, state: updated.mergeable_state });
+                }
               } catch (error) {
                 if (isAlreadyCurrent(error)) {
-                  core.info(`${pull.head.ref} is already current with main.`);
+                  const current = await waitForCurrentBranch(pull, '');
+                  if (isCurrent(current)) {
+                    refs.push(current.head.ref);
+                    core.info(`${current.head.ref} is already current with main.`);
+                  } else {
+                    skipped.push({ number: pull.number, ref: pull.head.ref, state: current.mergeable_state });
+                    core.warning(`PR #${pull.number} is ${current.mergeable_state}; skipping required-check dispatch.`);
+                  }
                 } else {
                   core.warning(`Could not update PR #${pull.number}: ${error.message}`);
+                  skipped.push({ number: pull.number, ref: pull.head.ref, state: pull.mergeable_state });
                 }
               } finally {
                 core.endGroup();
               }
+            }
+
+            if (skipped.length > 0) {
+              core.notice(`Skipped ${skipped.length} PR branch(es) that were not safe to dispatch: ${JSON.stringify(skipped)}`);
             }
 
             return refs;

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -28,7 +28,7 @@ jobs:
     with:
       labels: "autorelease: pending"
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
 
   dispatch-required-checks:

--- a/docs/CI_AUTOMATION_BOTS.md
+++ b/docs/CI_AUTOMATION_BOTS.md
@@ -121,7 +121,7 @@ Benefit: the v0.10.1 / v0.10.2 cuts we just did become a single click on a PR.
 
 A separate workflow at `.github/workflows/dependabot-rebase-on-main.yaml` runs on every push to `main` and updates open Dependabot PRs via GitHub's `update-branch` API.
 
-Important detail: the update commit is authored by `github-actions[bot]`. GitHub will not automatically chain `pull_request` workflows from that bot-authored head update, so strict required checks would otherwise stall forever on the new SHA. To keep the PR mergeable, the rebase workflow calls the reusable `refresh-pr-branches` workflow, waits for the branch update to land, then calls `dispatch-required-pr-checks` to run `CI`, `Dependency Review`, `govulncheck`, `Lychee`, and `CodeQL` against the refreshed branch.
+Dependabot does automatically rebase PRs, but it is not an immediate per-push guarantee and strict branch protection requires PR branches to be current before auto-merge can complete. The workflow is the deterministic backstop: it calls the reusable `refresh-pr-branches` workflow with `contents: write`, waits until each branch is current with `main`, and only then calls `dispatch-required-pr-checks` to run `CI`, `Dependency Review`, `govulncheck`, `Lychee`, and `CodeQL` against the refreshed branch. Branches that cannot be made current are skipped instead of dispatching stale refs.
 
 ### 8. Stale issue/PR bot
 
@@ -154,7 +154,7 @@ For `release-please`:
 
 - The workflow needs `contents: write`, `pull-requests: write`, and `actions: write` on the `GITHUB_TOKEN`.
 - Release PR commits are authored by `github-actions[bot]`, so the same "no chained workflow runs from bot-authored commits" rule applies there too.
-- Instead of relying on a separate PAT, the workflow now keeps any open release PR branch current with `main` through `refresh-pr-branches` and then calls the same reusable required-check dispatcher.
+- Instead of relying on a separate PAT, the workflow now keeps any open release PR branch current with `main` through `refresh-pr-branches` and then calls the same reusable required-check dispatcher. This is required because `release-please` PR updates made with `GITHUB_TOKEN` do not automatically trigger downstream `pull_request` workflows.
 
 For manually dispatched required-check workflows:
 


### PR DESCRIPTION
## Summary
- grant the reusable PR refresh workflow the write permission needed by GitHub update-branch
- only dispatch required checks for PR refs confirmed current with main
- retry workflow dispatch through actions/github-script instead of custom shell loops
- document why Dependabot native rebases are not enough for strict required checks and why release-please still needs explicit dispatch

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/refresh-pr-branches.yaml .github/workflows/dispatch-required-pr-checks.yaml .github/workflows/dependabot-rebase-on-main.yaml .github/workflows/release-please.yaml
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/refresh-pr-branches.yaml .github/workflows/dispatch-required-pr-checks.yaml .github/workflows/dependabot-rebase-on-main.yaml .github/workflows/release-please.yaml\n- git diff --check\n- go test ./...\n