### PR TITLE
ci: use automation token for bot PR refreshes

### DIFF
--- a/.github/workflows/dependabot-rebase-on-main.yaml
+++ b/.github/workflows/dependabot-rebase-on-main.yaml
@@ -10,10 +10,9 @@ permissions:
   pull-requests: read
 
 jobs:
-  request-dependabot-rebases:
-    name: Request open Dependabot PR rebases
-    uses: ./.github/workflows/request-dependabot-rebases.yaml
+  refresh-dependabot-prs:
+    name: Refresh open Dependabot PRs
+    uses: ./.github/workflows/refresh-dependabot-prs.yaml
+    secrets: inherit
     permissions:
       contents: read
-      issues: write
-      pull-requests: read

--- a/.github/workflows/dependabot-rebase-on-main.yaml
+++ b/.github/workflows/dependabot-rebase-on-main.yaml
@@ -5,26 +5,15 @@ on:
     branches: [main]
 
 permissions:
-  actions: write
-  contents: write
-  pull-requests: write
+  contents: read
+  issues: write
+  pull-requests: read
 
 jobs:
-  refresh-dependabot-prs:
-    name: Update open Dependabot PR branches
-    uses: ./.github/workflows/refresh-pr-branches.yaml
-    with:
-      author-login: dependabot[bot]
+  request-dependabot-rebases:
+    name: Request open Dependabot PR rebases
+    uses: ./.github/workflows/request-dependabot-rebases.yaml
     permissions:
-      contents: write
-      pull-requests: write
-
-  dispatch-required-checks:
-    needs: refresh-dependabot-prs
-    if: needs.refresh-dependabot-prs.outputs.refs-json != '[]'
-    uses: ./.github/workflows/dispatch-required-pr-checks.yaml
-    with:
-      refs-json: ${{ needs.refresh-dependabot-prs.outputs.refs-json }}
-    permissions:
-      actions: write
       contents: read
+      issues: write
+      pull-requests: read

--- a/.github/workflows/refresh-dependabot-prs.yaml
+++ b/.github/workflows/refresh-dependabot-prs.yaml
@@ -1,24 +1,36 @@
-name: Request Dependabot rebases
+name: Refresh Dependabot PRs
 
 on:
   workflow_call:
+    secrets:
+      AUTOMATION_TOKEN:
+        description: User PAT or equivalent token with repo/write and workflow permission.
+        required: true
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
 
 jobs:
-  request:
-    name: Request native Dependabot updates
+  refresh:
+    name: Refresh open Dependabot PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          github-token: ${{ secrets.AUTOMATION_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const duplicateWindowMs = 30 * 60 * 1000;
             const duplicateCutoff = Date.now() - duplicateWindowMs;
+
+            if (!process.env.GH_TOKEN) {
+              core.setFailed('AUTOMATION_TOKEN is required. Use a PAT with repo and workflow scope, or an equivalent GitHub App token.');
+              return;
+            }
+
+            const isAlreadyCurrent = (error) =>
+              error.status === 422 &&
+              /no new commits|not behind|up to date/i.test(error.message);
 
             async function compareWithBase(pull) {
               const response = await github.rest.repos.compareCommitsWithBasehead({
@@ -52,7 +64,8 @@ jobs:
               return commits.some((commit) => commit.author?.login !== 'dependabot[bot]');
             }
 
-            async function requestDependabot(pull, command) {
+            async function requestRecreate(pull) {
+              const command = '@dependabot recreate';
               if (await hasRecentCommand(pull.number, command)) {
                 core.info(`PR #${pull.number}: ${command} was already requested recently.`);
                 return;
@@ -85,19 +98,32 @@ jobs:
                 const pull = response.data;
 
                 if (pull.mergeable_state === 'dirty' || await hasNonDependabotCommits(pull.number)) {
-                  await requestDependabot(pull, '@dependabot recreate');
+                  await requestRecreate(pull);
                   continue;
                 }
 
                 const comparison = await compareWithBase(pull);
-                if (comparison.behind_by > 0 || pull.mergeable_state === 'behind') {
-                  await requestDependabot(pull, '@dependabot rebase');
-                } else {
+                if (comparison.behind_by === 0 && pull.mergeable_state !== 'behind') {
                   core.info(`PR #${pull.number} is not behind main.`);
+                  continue;
                 }
+
+                await github.rest.pulls.updateBranch({
+                  owner,
+                  repo,
+                  pull_number: pull.number,
+                  expected_head_sha: pull.head.sha,
+                });
+                core.notice(`Requested branch update for PR #${pull.number}.`);
               } catch (error) {
-                core.warning(`Could not request Dependabot update for PR #${pullSummary.number}: ${error.message}`);
+                if (isAlreadyCurrent(error)) {
+                  core.info(`PR #${pullSummary.number} is already current with main.`);
+                } else {
+                  core.warning(`Could not refresh PR #${pullSummary.number}: ${error.message}`);
+                }
               } finally {
                 core.endGroup();
               }
             }
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}

--- a/.github/workflows/refresh-pr-branches.yaml
+++ b/.github/workflows/refresh-pr-branches.yaml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      github_token:
+        description: Token used for branch updates.
+        required: false
     outputs:
       refs-json:
         description: JSON array of refreshed branch refs.
@@ -31,10 +35,8 @@ jobs:
     steps:
       - id: refresh
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          AUTHOR_LOGIN: ${{ inputs.author-login }}
-          LABELS: ${{ inputs.labels }}
         with:
+          github-token: ${{ secrets.github_token || github.token }}
           script: |
             const { owner, repo } = context.repo;
             const authorLogin = process.env.AUTHOR_LOGIN.trim();
@@ -149,3 +151,6 @@ jobs:
             }
 
             return refs;
+        env:
+          AUTHOR_LOGIN: ${{ inputs.author-login }}
+          LABELS: ${{ inputs.labels }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,7 +17,7 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,7 +17,7 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -27,6 +27,8 @@ jobs:
     uses: ./.github/workflows/refresh-pr-branches.yaml
     with:
       labels: "autorelease: pending"
+    secrets:
+      github_token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.AUTOMATION_TOKEN }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/request-dependabot-rebases.yaml
+++ b/.github/workflows/request-dependabot-rebases.yaml
@@ -1,0 +1,103 @@
+name: Request Dependabot rebases
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  request:
+    name: Request native Dependabot updates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const duplicateWindowMs = 30 * 60 * 1000;
+            const duplicateCutoff = Date.now() - duplicateWindowMs;
+
+            async function compareWithBase(pull) {
+              const response = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${pull.base.sha}...${pull.head.sha}`,
+              });
+              return response.data;
+            }
+
+            async function hasRecentCommand(pullNumber, command) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pullNumber,
+                per_page: 100,
+              });
+              return comments.some((comment) =>
+                comment.body?.trim() === command &&
+                Date.parse(comment.created_at) >= duplicateCutoff
+              );
+            }
+
+            async function hasNonDependabotCommits(pullNumber) {
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner,
+                repo,
+                pull_number: pullNumber,
+                per_page: 100,
+              });
+              return commits.some((commit) => commit.author?.login !== 'dependabot[bot]');
+            }
+
+            async function requestDependabot(pull, command) {
+              if (await hasRecentCommand(pull.number, command)) {
+                core.info(`PR #${pull.number}: ${command} was already requested recently.`);
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull.number,
+                body: command,
+              });
+              core.notice(`Requested ${command} on PR #${pull.number}.`);
+            }
+
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            for (const pullSummary of pulls.filter((pull) => pull.user?.login === 'dependabot[bot]')) {
+              core.startGroup(`PR #${pullSummary.number}`);
+              try {
+                const response = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: pullSummary.number,
+                });
+                const pull = response.data;
+
+                if (pull.mergeable_state === 'dirty' || await hasNonDependabotCommits(pull.number)) {
+                  await requestDependabot(pull, '@dependabot recreate');
+                  continue;
+                }
+
+                const comparison = await compareWithBase(pull);
+                if (comparison.behind_by > 0 || pull.mergeable_state === 'behind') {
+                  await requestDependabot(pull, '@dependabot rebase');
+                } else {
+                  core.info(`PR #${pull.number} is not behind main.`);
+                }
+              } catch (error) {
+                core.warning(`Could not request Dependabot update for PR #${pullSummary.number}: ${error.message}`);
+              } finally {
+                core.endGroup();
+              }
+            }

--- a/docs/CI_AUTOMATION_BOTS.md
+++ b/docs/CI_AUTOMATION_BOTS.md
@@ -119,9 +119,9 @@ Benefit: the v0.10.1 / v0.10.2 cuts we just did become a single click on a PR.
 
 ### 7. Dependabot rebase-on-main-update workflow
 
-A separate workflow at `.github/workflows/dependabot-rebase-on-main.yaml` runs on every push to `main` and updates open Dependabot PRs via GitHub's `update-branch` API.
+A separate workflow at `.github/workflows/dependabot-rebase-on-main.yaml` runs on every push to `main` and asks Dependabot to update open Dependabot PRs with its native comment commands.
 
-Dependabot does automatically rebase PRs, but it is not an immediate per-push guarantee and strict branch protection requires PR branches to be current before auto-merge can complete. The workflow is the deterministic backstop: it calls the reusable `refresh-pr-branches` workflow with `contents: write`, waits until each branch is current with `main`, and only then calls `dispatch-required-pr-checks` to run `CI`, `Dependency Review`, `govulncheck`, `Lychee`, and `CodeQL` against the refreshed branch. Branches that cannot be made current are skipped instead of dispatching stale refs.
+Dependabot does automatically rebase PRs, but it is not an immediate per-push guarantee and strict branch protection requires PR branches to be current before auto-merge can complete. The workflow is the deterministic backstop: it posts `@dependabot rebase` for behind PRs and `@dependabot recreate` for conflicted PRs. This avoids GitHub Actions `updateBranch` limitations on PRs that modify `.github/workflows/**`, and it lets Dependabot's native branch update trigger normal PR checks instead of detached workflow-dispatch runs.
 
 ### 8. Stale issue/PR bot
 
@@ -153,8 +153,9 @@ For auto-merge to work, the repo needs:
 For `release-please`:
 
 - The workflow needs `contents: write`, `pull-requests: write`, and `actions: write` on the `GITHUB_TOKEN`.
+- Configure a `RELEASE_PLEASE_TOKEN` repository secret with `contents`, `pull_requests`, and `workflow` write access for native release PR updates that trigger downstream PR checks. The workflow falls back to `GITHUB_TOKEN`, but that fallback still needs the explicit refresh/dispatch backstop below because events created by `GITHUB_TOKEN` do not chain into normal `pull_request` runs.
 - Release PR commits are authored by `github-actions[bot]`, so the same "no chained workflow runs from bot-authored commits" rule applies there too.
-- Instead of relying on a separate PAT, the workflow now keeps any open release PR branch current with `main` through `refresh-pr-branches` and then calls the same reusable required-check dispatcher. This is required because `release-please` PR updates made with `GITHUB_TOKEN` do not automatically trigger downstream `pull_request` workflows.
+- When the fallback `GITHUB_TOKEN` path is used, the workflow keeps any open release PR branch current with `main` through `refresh-pr-branches` and then calls the same reusable required-check dispatcher. This is required because `release-please` PR updates made with `GITHUB_TOKEN` do not automatically trigger downstream `pull_request` workflows.
 
 For manually dispatched required-check workflows:
 

--- a/docs/CI_AUTOMATION_BOTS.md
+++ b/docs/CI_AUTOMATION_BOTS.md
@@ -119,9 +119,11 @@ Benefit: the v0.10.1 / v0.10.2 cuts we just did become a single click on a PR.
 
 ### 7. Dependabot rebase-on-main-update workflow
 
-A separate workflow at `.github/workflows/dependabot-rebase-on-main.yaml` runs on every push to `main` and asks Dependabot to update open Dependabot PRs with its native comment commands.
+A separate workflow at `.github/workflows/dependabot-rebase-on-main.yaml` runs on every push to `main` and updates open Dependabot PR branches with an automation token.
 
-Dependabot does automatically rebase PRs, but it is not an immediate per-push guarantee and strict branch protection requires PR branches to be current before auto-merge can complete. The workflow is the deterministic backstop: it posts `@dependabot rebase` for behind PRs and `@dependabot recreate` for conflicted PRs. This avoids GitHub Actions `updateBranch` limitations on PRs that modify `.github/workflows/**`, and it lets Dependabot's native branch update trigger normal PR checks instead of detached workflow-dispatch runs.
+Dependabot does automatically rebase PRs, but it is not an immediate per-push guarantee and strict branch protection requires PR branches to be current before auto-merge can complete. The workflow is the deterministic backstop: it calls GitHub's `updateBranch` API with `AUTOMATION_TOKEN`, which must be a PAT with `repo` + `workflow` scope or an equivalent GitHub App token. Using `GITHUB_TOKEN` here is not sufficient: GitHub suppresses follow-up workflow runs for most events created by `GITHUB_TOKEN`, and it also cannot update PRs that touch `.github/workflows/**` without workflow-level permission.
+
+Conflicted or polluted Dependabot PRs are handled separately. If a PR is `dirty` or already has non-Dependabot commits, the workflow requests `@dependabot recreate` using `AUTOMATION_TOKEN`; this must be a real write-access user token because Dependabot ignores/denies commands from `github-actions[bot]`.
 
 ### 8. Stale issue/PR bot
 
@@ -153,7 +155,7 @@ For auto-merge to work, the repo needs:
 For `release-please`:
 
 - The workflow needs `contents: write`, `pull-requests: write`, and `actions: write` on the `GITHUB_TOKEN`.
-- Configure a `RELEASE_PLEASE_TOKEN` repository secret with `contents`, `pull_requests`, and `workflow` write access for native release PR updates that trigger downstream PR checks. The workflow falls back to `GITHUB_TOKEN`, but that fallback still needs the explicit refresh/dispatch backstop below because events created by `GITHUB_TOKEN` do not chain into normal `pull_request` runs.
+- Configure a `RELEASE_PLEASE_TOKEN` repository secret with `contents`, `pull_requests`, and `workflow` write access for native release PR updates that trigger downstream PR checks. If that secret is absent, the workflow uses `AUTOMATION_TOKEN`. It falls back to `GITHUB_TOKEN` only as a last resort, and that fallback still needs the explicit refresh/dispatch backstop below because events created by `GITHUB_TOKEN` do not chain into normal `pull_request` runs.
 - Release PR commits are authored by `github-actions[bot]`, so the same "no chained workflow runs from bot-authored commits" rule applies there too.
 - When the fallback `GITHUB_TOKEN` path is used, the workflow keeps any open release PR branch current with `main` through `refresh-pr-branches` and then calls the same reusable required-check dispatcher. This is required because `release-please` PR updates made with `GITHUB_TOKEN` do not automatically trigger downstream `pull_request` workflows.
 


### PR DESCRIPTION
## Summary
- replace bot-authored Dependabot rebase comments with token-authenticated branch refreshes
- require AUTOMATION_TOKEN for Dependabot PR refreshes so updates trigger normal PR checks
- let release-please use RELEASE_PLEASE_TOKEN/AUTOMATION_TOKEN before falling back to GITHUB_TOKEN
- document why GITHUB_TOKEN and github-actions[bot] comments do not unblock these PRs

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- go test ./...
- git diff --check origin/main...HEAD

## Repo setup
- AUTOMATION_TOKEN repository secret is configured and updated on 2026-05-10.