### PR TITLE
ci: avoid reserved reusable workflow secret name

### DIFF
--- a/.github/workflows/refresh-pr-branches.yaml
+++ b/.github/workflows/refresh-pr-branches.yaml
@@ -14,7 +14,7 @@ on:
         type: string
         default: ""
     secrets:
-      github_token:
+      branch_refresh_token:
         description: Token used for branch updates.
         required: false
     outputs:
@@ -36,7 +36,7 @@ jobs:
       - id: refresh
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.github_token || github.token }}
+          github-token: ${{ secrets.branch_refresh_token || github.token }}
           script: |
             const { owner, repo } = context.repo;
             const authorLogin = process.env.AUTHOR_LOGIN.trim();

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -28,7 +28,7 @@ jobs:
     with:
       labels: "autorelease: pending"
     secrets:
-      github_token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.AUTOMATION_TOKEN }}
+      branch_refresh_token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.AUTOMATION_TOKEN }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- rename the reusable workflow secret from reserved github_token to branch_refresh_token
- fix the main workflow validation failure in release-please and refresh-pr-branches

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/refresh-pr-branches.yaml .github/workflows/release-please.yaml .github/workflows/dependabot-rebase-on-main.yaml .github/workflows/refresh-dependabot-prs.yaml
- ruby YAML parse for changed workflow files
- git diff --check
- rg confirms github_token is gone