### PR TITLE
ci: use live base refs for Dependabot refreshes

### DIFF
--- a/.github/workflows/dependabot-rebase-on-main.yaml
+++ b/.github/workflows/dependabot-rebase-on-main.yaml
@@ -3,6 +3,7 @@ name: Dependabot rebase open PRs on main update
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/refresh-dependabot-prs.yaml
+++ b/.github/workflows/refresh-dependabot-prs.yaml
@@ -32,11 +32,26 @@ jobs:
               error.status === 422 &&
               /no new commits|not behind|up to date/i.test(error.message);
 
+            const baseShaByRef = new Map();
+
+            async function latestBaseSha(pull) {
+              if (!baseShaByRef.has(pull.base.ref)) {
+                const response = await github.rest.repos.getBranch({
+                  owner,
+                  repo,
+                  branch: pull.base.ref,
+                });
+                baseShaByRef.set(pull.base.ref, response.data.commit.sha);
+              }
+              return baseShaByRef.get(pull.base.ref);
+            }
+
             async function compareWithBase(pull) {
+              const baseSha = await latestBaseSha(pull);
               const response = await github.rest.repos.compareCommitsWithBasehead({
                 owner,
                 repo,
-                basehead: `${pull.base.sha}...${pull.head.sha}`,
+                basehead: `${baseSha}...${pull.head.sha}`,
               });
               return response.data;
             }


### PR DESCRIPTION
## Summary
- compare Dependabot PR heads against the current base branch tip instead of the PR object's cached base SHA
- add workflow_dispatch to the Dependabot refresh wrapper for operator re-runs when GitHub state lags

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dependabot-rebase-on-main.yaml .github/workflows/refresh-dependabot-prs.yaml
- ruby YAML parse for changed workflow files
- git diff --check