### PR TITLE
fix(telemetry): cache canonical usage view, lift refresh clamp, fix daemon run flags

### DIFF
--- a/cmd/openusage/telemetry.go
+++ b/cmd/openusage/telemetry.go
@@ -234,19 +234,35 @@ func newTelemetryDaemonCommand() *cobra.Command {
 	defaultSpoolDir, _ := telemetry.DefaultSpoolDir()
 
 	cmd.PersistentFlags().StringVar(&socketPath, "socket-path", defaultSocketPath, "path to telemetry daemon unix socket")
-	cmd.Flags().StringVar(&dbPath, "db-path", defaultDBPath, "path to telemetry sqlite database")
-	cmd.Flags().StringVar(&spoolDir, "spool-dir", defaultSpoolDir, "path to telemetry spool directory")
-	cmd.Flags().DurationVar(&interval, "interval", 0, "default collector/poller interval (0 uses config or 30s)")
-	cmd.Flags().DurationVar(&collectInterval, "collect-interval", 0, "collector interval override (0 uses --interval)")
-	cmd.Flags().DurationVar(&pollInterval, "poll-interval", 0, "provider poll interval override (0 uses --interval)")
-	cmd.Flags().BoolVar(&verbose, "verbose", false, "enable daemon logs")
+	addDaemonRunFlags(cmd, &dbPath, &spoolDir, &interval, &collectInterval, &pollInterval, &verbose, defaultDBPath, defaultSpoolDir)
 
-	cmd.AddCommand(newDaemonRunCommand(runDaemon))
+	runCmd := newDaemonRunCommand(runDaemon)
+	addDaemonRunFlags(runCmd, &dbPath, &spoolDir, &interval, &collectInterval, &pollInterval, &verbose, defaultDBPath, defaultSpoolDir)
+	cmd.AddCommand(runCmd)
 	cmd.AddCommand(newDaemonInstallCommand())
 	cmd.AddCommand(newDaemonUninstallCommand())
 	cmd.AddCommand(newDaemonStatusCommand())
 
 	return cmd
+}
+
+func addDaemonRunFlags(
+	cmd *cobra.Command,
+	dbPath *string,
+	spoolDir *string,
+	interval *time.Duration,
+	collectInterval *time.Duration,
+	pollInterval *time.Duration,
+	verbose *bool,
+	defaultDBPath string,
+	defaultSpoolDir string,
+) {
+	cmd.Flags().StringVar(dbPath, "db-path", defaultDBPath, "path to telemetry sqlite database")
+	cmd.Flags().StringVar(spoolDir, "spool-dir", defaultSpoolDir, "path to telemetry spool directory")
+	cmd.Flags().DurationVar(interval, "interval", 0, "default collector/poller interval (0 uses config or 30s)")
+	cmd.Flags().DurationVar(collectInterval, "collect-interval", 0, "collector interval override (0 uses --interval)")
+	cmd.Flags().DurationVar(pollInterval, "poll-interval", 0, "provider poll interval override (0 uses --interval)")
+	cmd.Flags().BoolVar(verbose, "verbose", false, "enable daemon logs")
 }
 
 func newDaemonRunCommand(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {

--- a/cmd/openusage/telemetry_test.go
+++ b/cmd/openusage/telemetry_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestTelemetryDaemonRunCommandExposesRunFlags(t *testing.T) {
+	cmd := newTelemetryDaemonCommand()
+	runCmd, _, err := cmd.Find([]string{"run"})
+	if err != nil {
+		t.Fatalf("find run command: %v", err)
+	}
+	if runCmd == nil || runCmd.Use != "run" {
+		t.Fatalf("expected run command, got %#v", runCmd)
+	}
+
+	for _, name := range []string{
+		"db-path",
+		"spool-dir",
+		"interval",
+		"collect-interval",
+		"poll-interval",
+		"verbose",
+	} {
+		if runCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("run command missing %q flag", name)
+		}
+	}
+}

--- a/internal/daemon/server_read_model.go
+++ b/internal/daemon/server_read_model.go
@@ -68,8 +68,7 @@ func (s *Service) runReadModelCacheLoop(ctx context.Context) {
 		return
 	}
 
-	interval := s.cfg.PollInterval / 2
-	interval = max(5*time.Second, min(30*time.Second, interval))
+	interval := readModelCacheInterval(s.cfg.PollInterval)
 
 	s.infof("read_model_cache_loop_start", "interval=%s", interval)
 	s.dataIngested.Store(true) // ensure first boot always computes
@@ -104,4 +103,14 @@ func (s *Service) refreshReadModelCacheFromConfig(ctx context.Context) {
 	}
 	cacheKey := ReadModelRequestKey(req)
 	s.refreshReadModelCacheAsync(ctx, cacheKey, req, 60*time.Second)
+}
+
+func readModelCacheInterval(pollInterval time.Duration) time.Duration {
+	if pollInterval <= 0 {
+		pollInterval = 30 * time.Second
+	}
+	if pollInterval < 5*time.Second {
+		return 5 * time.Second
+	}
+	return pollInterval
 }

--- a/internal/daemon/server_read_model_test.go
+++ b/internal/daemon/server_read_model_test.go
@@ -1,0 +1,26 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReadModelCacheIntervalRespectsPollInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{name: "default", in: 0, want: 30 * time.Second},
+		{name: "minimum", in: time.Second, want: 5 * time.Second},
+		{name: "normal", in: 30 * time.Second, want: 30 * time.Second},
+		{name: "long", in: time.Hour, want: time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := readModelCacheInterval(tt.in); got != tt.want {
+				t.Fatalf("readModelCacheInterval(%s) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/telemetry/helpers_test.go
+++ b/internal/telemetry/helpers_test.go
@@ -27,7 +27,7 @@ func applyCanonicalUsageViewForTest(ctx context.Context, dbPath string, snaps ma
 	if err := configureSQLiteConnection(db); err != nil {
 		return snaps, fmt.Errorf("configure canonical usage db: %w", err)
 	}
-	return applyCanonicalUsageViewWithDB(ctx, db, snaps, nil, time.Time{}, time.Time{}, "")
+	return applyCanonicalUsageViewWithDB(ctx, db, usageViewCacheNamespace(dbPath), snaps, nil, time.Time{}, time.Time{}, "")
 }
 
 func applyCanonicalTelemetryViewForTest(ctx context.Context, dbPath string, snaps map[string]core.UsageSnapshot) (map[string]core.UsageSnapshot, error) {

--- a/internal/telemetry/read_model.go
+++ b/internal/telemetry/read_model.go
@@ -105,7 +105,7 @@ func ApplyCanonicalTelemetryViewWithOptions(
 	done()
 
 	done = trace("applyCanonicalUsageViewWithDB")
-	result, err := applyCanonicalUsageViewWithDB(ctx, db, merged, links, options.Since, options.TodaySince, options.TimeWindow)
+	result, err := applyCanonicalUsageViewWithDB(ctx, db, usageViewCacheNamespace(dbPath), merged, links, options.Since, options.TodaySince, options.TimeWindow)
 	done()
 	return result, err
 }

--- a/internal/telemetry/usage_view.go
+++ b/internal/telemetry/usage_view.go
@@ -148,6 +148,7 @@ type usageFilter struct {
 func applyCanonicalUsageViewWithDB(
 	ctx context.Context,
 	db *sql.DB,
+	cacheNamespace usageViewCacheNamespace,
 	snaps map[string]core.UsageSnapshot,
 	providerLinks map[string]string,
 	since time.Time, todaySince time.Time, timeWindow core.TimeWindow,
@@ -186,7 +187,7 @@ func applyCanonicalUsageViewWithDB(
 		cacheKey := strings.Join(sourceProviders, ",") + "|" + accountScope
 		agg, ok := cache[cacheKey]
 		if !ok {
-			loaded, loadErr := loadUsageViewForProviderWithSources(ctx, db, sourceProviders, accountScope, since, todaySince)
+			loaded, loadErr := loadUsageViewForProviderWithSources(ctx, db, cacheNamespace, sourceProviders, accountScope, since, todaySince)
 			if loadErr != nil {
 				return snaps, loadErr
 			}
@@ -263,7 +264,7 @@ func queryTelemetryActiveProviders(ctx context.Context, db *sql.DB) (map[string]
 	return out, nil
 }
 
-func loadUsageViewForProviderWithSources(ctx context.Context, db *sql.DB, providerIDs []string, accountID string, since time.Time, todaySince time.Time) (*telemetryUsageAgg, error) {
+func loadUsageViewForProviderWithSources(ctx context.Context, db *sql.DB, cacheNamespace usageViewCacheNamespace, providerIDs []string, accountID string, since time.Time, todaySince time.Time) (*telemetryUsageAgg, error) {
 	providerIDs = normalizeProviderIDs(providerIDs)
 	if len(providerIDs) == 0 {
 		return &telemetryUsageAgg{}, nil
@@ -271,7 +272,7 @@ func loadUsageViewForProviderWithSources(ctx context.Context, db *sql.DB, provid
 	accountID = strings.TrimSpace(accountID)
 
 	if accountID != "" {
-		scoped, err := loadUsageViewForFilter(ctx, db, usageFilter{
+		scoped, err := loadUsageViewForFilter(ctx, db, cacheNamespace, usageFilter{
 			ProviderIDs: providerIDs,
 			AccountID:   accountID,
 			Since:       since,
@@ -292,7 +293,7 @@ func loadUsageViewForProviderWithSources(ctx context.Context, db *sql.DB, provid
 		// Fall through to provider-scoped query if no account-scoped events found.
 	}
 
-	fallback, err := loadUsageViewForFilter(ctx, db, usageFilter{
+	fallback, err := loadUsageViewForFilter(ctx, db, cacheNamespace, usageFilter{
 		ProviderIDs: providerIDs,
 		Since:       since,
 		TodaySince:  todaySince,
@@ -307,8 +308,18 @@ func loadUsageViewForProviderWithSources(ctx context.Context, db *sql.DB, provid
 	return fallback, nil
 }
 
-func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter) (*telemetryUsageAgg, error) {
+func loadUsageViewForFilter(ctx context.Context, db *sql.DB, cacheNamespace usageViewCacheNamespace, filter usageFilter) (*telemetryUsageAgg, error) {
 	filterStart := time.Now()
+
+	cached, maxRowID, count, hit, cacheErr := loadUsageViewCached(ctx, db, cacheNamespace, filter)
+	if cacheErr != nil {
+		return nil, cacheErr
+	}
+	if hit {
+		core.Tracef("[usage_view_perf] loadUsageViewForFilter CACHE HIT: %dms (providers=%v)", time.Since(filterStart).Milliseconds(), filter.ProviderIDs)
+		return cached, nil
+	}
+
 	agg := newTelemetryUsageAgg()
 
 	matFilter, cleanup, err := materializeUsageFilter(ctx, db, filter)
@@ -333,11 +344,13 @@ func loadUsageViewForFilter(ctx context.Context, db *sql.DB, filter usageFilter)
 	core.Tracef("[usage_view_perf] countQuery: %dms (events=%d, providers=%v, since=%s)",
 		time.Since(countStart).Milliseconds(), agg.EventCount, filter.ProviderIDs, filter.Since.Format(time.RFC3339))
 	if agg.EventCount == 0 {
+		storeUsageViewCache(cacheNamespace, filter, agg, maxRowID, count)
 		return agg, nil
 	}
 	if err := loadMaterializedUsageAgg(ctx, db, matFilter, agg); err != nil {
 		return nil, err
 	}
+	storeUsageViewCache(cacheNamespace, filter, agg, maxRowID, count)
 	core.Tracef("[usage_view_perf] loadUsageViewForFilter TOTAL: %dms (providers=%v)", time.Since(filterStart).Milliseconds(), filter.ProviderIDs)
 	return agg, nil
 }

--- a/internal/telemetry/usage_view_cache.go
+++ b/internal/telemetry/usage_view_cache.go
@@ -1,0 +1,184 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// usageViewCache caches the fully aggregated telemetryUsageAgg for a given
+// filter, keyed by (dbPath, providerIDs, accountID, since, todaySince).
+//
+// Each entry stores a content fingerprint (MAX(rowid), COUNT(*)) captured at
+// the time the aggregate was built. On lookup a cheap probe query runs the
+// same MAX/COUNT against the underlying usage_events table; if the fingerprint
+// matches we skip the expensive materialize + 14 aggregate queries.
+//
+// Retention pruning lowers COUNT(*) so prunes invalidate cleanly. Inserts
+// raise MAX(rowid) so new events invalidate cleanly.
+//
+// The cache is process-global. It is bounded by a fixed maximum number of
+// entries; on overflow the oldest entry by insertion order is dropped. The
+// expected cardinality is small (one entry per provider × account × window
+// class, typically <50), so a simple cap is sufficient.
+const usageViewCacheMaxEntries = 64
+
+type usageViewCacheEntry struct {
+	agg        *telemetryUsageAgg
+	maxRowID   int64
+	count      int64
+	insertedAt time.Time
+}
+
+type usageViewCacheStore struct {
+	mu      sync.Mutex
+	entries map[string]*usageViewCacheEntry
+	// order tracks insertion order for FIFO eviction; we keep it cheap and
+	// simple rather than building a full LRU.
+	order []string
+}
+
+var globalUsageViewCache = &usageViewCacheStore{
+	entries: make(map[string]*usageViewCacheEntry),
+}
+
+// usageViewCacheNamespace identifies the database backing a cache entry. It
+// flows from ApplyCanonicalTelemetryViewWithOptions down into the loader so
+// the cache survives the per-call sql.Open/Close lifecycle.
+type usageViewCacheNamespace string
+
+func usageViewCacheKey(namespace usageViewCacheNamespace, filter usageFilter) string {
+	providers := strings.Join(normalizeProviderIDs(filter.ProviderIDs), ",")
+	since := int64(0)
+	if !filter.Since.IsZero() {
+		since = filter.Since.UTC().UnixNano()
+	}
+	today := int64(0)
+	if !filter.TodaySince.IsZero() {
+		today = filter.TodaySince.UTC().UnixNano()
+	}
+	return fmt.Sprintf("%s|%s|%s|%d|%d", namespace, providers, strings.TrimSpace(filter.AccountID), since, today)
+}
+
+func (s *usageViewCacheStore) lookup(key string) (*usageViewCacheEntry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.entries[key]
+	return entry, ok
+}
+
+func (s *usageViewCacheStore) store(key string, entry *usageViewCacheEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.entries[key]; !exists {
+		s.order = append(s.order, key)
+		for len(s.order) > usageViewCacheMaxEntries {
+			drop := s.order[0]
+			s.order = s.order[1:]
+			delete(s.entries, drop)
+		}
+	}
+	s.entries[key] = entry
+}
+
+// reset is exposed for tests so they can run against a clean cache.
+func (s *usageViewCacheStore) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = make(map[string]*usageViewCacheEntry)
+	s.order = nil
+}
+
+// probeUsageEventsFingerprint runs a cheap MAX(rowid) + COUNT(*) query against
+// usage_events using the same provider/account filter as the materialization
+// step. It deliberately ignores the Since cutoff so the probe stays index-
+// driven: the cache key already includes Since, so an entry only matches when
+// Since is identical between builder and reader.
+func probeUsageEventsFingerprint(ctx context.Context, db *sql.DB, filter usageFilter) (int64, int64, error) {
+	providers := normalizeProviderIDs(filter.ProviderIDs)
+	if len(providers) == 0 {
+		return 0, 0, nil
+	}
+
+	args := make([]any, 0, len(providers)+1)
+	var b strings.Builder
+	b.WriteString(`SELECT COALESCE(MAX(rowid), 0), COUNT(*)
+		FROM usage_events
+		WHERE event_type IN ('message_usage', 'tool_usage')
+		  AND provider_id IN (`)
+	for i, p := range providers {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString("?")
+		args = append(args, p)
+	}
+	b.WriteString(")")
+
+	accountID := strings.TrimSpace(filter.AccountID)
+	if accountID != "" {
+		b.WriteString(" AND account_id = ?")
+		args = append(args, accountID)
+	}
+
+	var maxRowID, count int64
+	if err := db.QueryRowContext(ctx, b.String(), args...).Scan(&maxRowID, &count); err != nil {
+		return 0, 0, fmt.Errorf("probe usage_events fingerprint: %w", err)
+	}
+	return maxRowID, count, nil
+}
+
+// loadUsageViewCached returns a cached aggregate if the fingerprint is
+// unchanged. The hit bool is true on cache hit; on miss the caller must
+// fall back to a full materialize+aggregate pass and then call
+// storeUsageViewCache to populate the cache.
+func loadUsageViewCached(
+	ctx context.Context,
+	db *sql.DB,
+	namespace usageViewCacheNamespace,
+	filter usageFilter,
+) (*telemetryUsageAgg, int64, int64, bool, error) {
+	if namespace == "" {
+		return nil, 0, 0, false, nil
+	}
+	key := usageViewCacheKey(namespace, filter)
+	entry, hit := globalUsageViewCache.lookup(key)
+	maxRowID, count, err := probeUsageEventsFingerprint(ctx, db, filter)
+	if err != nil {
+		return nil, 0, 0, false, err
+	}
+	if !hit || entry == nil {
+		return nil, maxRowID, count, false, nil
+	}
+	if entry.maxRowID != maxRowID || entry.count != count {
+		core.Tracef("[usage_view_cache] miss (fingerprint changed) providers=%v account=%s maxRowID=%d→%d count=%d→%d",
+			filter.ProviderIDs, filter.AccountID, entry.maxRowID, maxRowID, entry.count, count)
+		return nil, maxRowID, count, false, nil
+	}
+	core.Tracef("[usage_view_cache] hit providers=%v account=%s maxRowID=%d count=%d age=%s",
+		filter.ProviderIDs, filter.AccountID, entry.maxRowID, entry.count, time.Since(entry.insertedAt))
+	return entry.agg, maxRowID, count, true, nil
+}
+
+func storeUsageViewCache(
+	namespace usageViewCacheNamespace,
+	filter usageFilter,
+	agg *telemetryUsageAgg,
+	maxRowID, count int64,
+) {
+	if namespace == "" || agg == nil {
+		return
+	}
+	key := usageViewCacheKey(namespace, filter)
+	globalUsageViewCache.store(key, &usageViewCacheEntry{
+		agg:        agg,
+		maxRowID:   maxRowID,
+		count:      count,
+		insertedAt: time.Now(),
+	})
+}

--- a/internal/telemetry/usage_view_cache_test.go
+++ b/internal/telemetry/usage_view_cache_test.go
@@ -1,0 +1,233 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// TestLoadUsageViewCached_ColdStart verifies that a cold cache reports a
+// miss but still returns the current fingerprint so the caller can populate
+// the cache after building the aggregate.
+func TestLoadUsageViewCached_ColdStart(t *testing.T) {
+	globalUsageViewCache.reset()
+	_, db, store := openUsageViewRawTestStore(t)
+	mustIngestUsageEvent(t, store, IngestRequest{
+		SourceSystem:  SourceSystem("opencode"),
+		SourceChannel: SourceChannelHook,
+		OccurredAt:    time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC),
+		ProviderID:    "openrouter",
+		AccountID:     "openrouter",
+		AgentName:     "opencode",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-cold",
+		MessageID:     "msg-cold",
+		ModelRaw:      "qwen/qwen3-coder-flash",
+		TokenUsage: core.TokenUsage{
+			InputTokens:  int64Ptr(10),
+			OutputTokens: int64Ptr(5),
+			TotalTokens:  int64Ptr(15),
+			Requests:     int64Ptr(1),
+		},
+	}, "ingest cold event")
+
+	filter := usageFilter{ProviderIDs: []string{"openrouter"}}
+	agg, maxRowID, count, hit, err := loadUsageViewCached(context.Background(), db, "test-ns", filter)
+	if err != nil {
+		t.Fatalf("cache lookup: %v", err)
+	}
+	if hit {
+		t.Fatal("expected cache miss on cold start")
+	}
+	if agg != nil {
+		t.Fatal("expected nil agg on miss")
+	}
+	if count == 0 || maxRowID == 0 {
+		t.Fatalf("expected non-zero fingerprint on cold start, got maxRowID=%d count=%d", maxRowID, count)
+	}
+}
+
+// TestLoadUsageViewCached_HitWhenFingerprintMatches stores an agg then verifies
+// a subsequent lookup with unchanged data returns a cache hit.
+func TestLoadUsageViewCached_HitWhenFingerprintMatches(t *testing.T) {
+	globalUsageViewCache.reset()
+	_, db, store := openUsageViewRawTestStore(t)
+	mustIngestUsageEvent(t, store, IngestRequest{
+		SourceSystem:  SourceSystem("opencode"),
+		SourceChannel: SourceChannelHook,
+		OccurredAt:    time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC),
+		ProviderID:    "openrouter",
+		AccountID:     "openrouter",
+		AgentName:     "opencode",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-hit",
+		MessageID:     "msg-hit",
+		ModelRaw:      "qwen/qwen3-coder-flash",
+		TokenUsage: core.TokenUsage{
+			InputTokens:  int64Ptr(10),
+			OutputTokens: int64Ptr(5),
+			TotalTokens:  int64Ptr(15),
+			Requests:     int64Ptr(1),
+		},
+	}, "ingest hit event")
+
+	filter := usageFilter{ProviderIDs: []string{"openrouter"}}
+	_, maxRowID, count, _, err := loadUsageViewCached(context.Background(), db, "test-ns", filter)
+	if err != nil {
+		t.Fatalf("cache lookup (probe): %v", err)
+	}
+	expectedAgg := &telemetryUsageAgg{EventCount: 1, LastOccurred: "2026-05-17T12:00:00Z"}
+	storeUsageViewCache("test-ns", filter, expectedAgg, maxRowID, count)
+
+	agg, _, _, hit, err := loadUsageViewCached(context.Background(), db, "test-ns", filter)
+	if err != nil {
+		t.Fatalf("cache lookup (hit): %v", err)
+	}
+	if !hit {
+		t.Fatal("expected cache hit when fingerprint unchanged")
+	}
+	if agg == nil || agg.EventCount != 1 {
+		t.Fatalf("expected stored agg to be returned, got %+v", agg)
+	}
+}
+
+// TestLoadUsageViewCached_InvalidatedOnNewEvent verifies that ingesting a new
+// event after caching reports a miss because MAX(rowid) shifts.
+func TestLoadUsageViewCached_InvalidatedOnNewEvent(t *testing.T) {
+	globalUsageViewCache.reset()
+	_, db, store := openUsageViewRawTestStore(t)
+	mustIngestUsageEvent(t, store, IngestRequest{
+		SourceSystem:  SourceSystem("opencode"),
+		SourceChannel: SourceChannelHook,
+		OccurredAt:    time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC),
+		ProviderID:    "openrouter",
+		AccountID:     "openrouter",
+		AgentName:     "opencode",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-inv-1",
+		MessageID:     "msg-inv-1",
+		ModelRaw:      "qwen/qwen3-coder-flash",
+		TokenUsage: core.TokenUsage{
+			InputTokens: int64Ptr(10),
+			TotalTokens: int64Ptr(10),
+			Requests:    int64Ptr(1),
+		},
+	}, "ingest first event")
+
+	filter := usageFilter{ProviderIDs: []string{"openrouter"}}
+	_, maxRowID, count, _, err := loadUsageViewCached(context.Background(), db, "test-ns", filter)
+	if err != nil {
+		t.Fatalf("cache lookup (probe): %v", err)
+	}
+	storeUsageViewCache("test-ns", filter, &telemetryUsageAgg{EventCount: 1}, maxRowID, count)
+
+	// Ingest a second event — fingerprint changes.
+	mustIngestUsageEvent(t, store, IngestRequest{
+		SourceSystem:  SourceSystem("opencode"),
+		SourceChannel: SourceChannelHook,
+		OccurredAt:    time.Date(2026, 5, 17, 12, 1, 0, 0, time.UTC),
+		ProviderID:    "openrouter",
+		AccountID:     "openrouter",
+		AgentName:     "opencode",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-inv-2",
+		MessageID:     "msg-inv-2",
+		ModelRaw:      "qwen/qwen3-coder-flash",
+		TokenUsage: core.TokenUsage{
+			InputTokens: int64Ptr(20),
+			TotalTokens: int64Ptr(20),
+			Requests:    int64Ptr(1),
+		},
+	}, "ingest second event")
+
+	_, _, _, hit, err := loadUsageViewCached(context.Background(), db, "test-ns", filter)
+	if err != nil {
+		t.Fatalf("cache lookup after ingest: %v", err)
+	}
+	if hit {
+		t.Fatal("expected cache miss after new event ingest (fingerprint changed)")
+	}
+}
+
+// TestLoadUsageViewCached_InvalidatedOnPrune verifies that deleting rows (as
+// retention pruning does) drops COUNT(*) and invalidates the cached entry.
+func TestLoadUsageViewCached_InvalidatedOnPrune(t *testing.T) {
+	globalUsageViewCache.reset()
+	_, db, store := openUsageViewRawTestStore(t)
+	mustIngestUsageEvent(t, store, IngestRequest{
+		SourceSystem:  SourceSystem("opencode"),
+		SourceChannel: SourceChannelHook,
+		OccurredAt:    time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC),
+		ProviderID:    "openrouter",
+		AccountID:     "openrouter",
+		AgentName:     "opencode",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-prune",
+		MessageID:     "msg-prune",
+		ModelRaw:      "qwen/qwen3-coder-flash",
+		TokenUsage: core.TokenUsage{
+			InputTokens: int64Ptr(10),
+			TotalTokens: int64Ptr(10),
+			Requests:    int64Ptr(1),
+		},
+	}, "ingest prune event")
+
+	filter := usageFilter{ProviderIDs: []string{"openrouter"}}
+	_, maxRowID, count, _, err := loadUsageViewCached(context.Background(), db, "test-ns", filter)
+	if err != nil {
+		t.Fatalf("cache lookup (probe): %v", err)
+	}
+	storeUsageViewCache("test-ns", filter, &telemetryUsageAgg{EventCount: 1}, maxRowID, count)
+
+	// Simulate prune: delete the row.
+	if _, err := db.Exec("DELETE FROM usage_events WHERE provider_id = 'openrouter'"); err != nil {
+		t.Fatalf("prune events: %v", err)
+	}
+
+	_, _, _, hit, err := loadUsageViewCached(context.Background(), db, "test-ns", filter)
+	if err != nil {
+		t.Fatalf("cache lookup after prune: %v", err)
+	}
+	if hit {
+		t.Fatal("expected cache miss after prune (count changed)")
+	}
+}
+
+// TestLoadUsageViewCached_EmptyNamespaceDisablesCache verifies that callers
+// that pass an empty namespace (e.g. tests) bypass the cache entirely.
+func TestLoadUsageViewCached_EmptyNamespaceDisablesCache(t *testing.T) {
+	globalUsageViewCache.reset()
+	_, db, store := openUsageViewRawTestStore(t)
+	mustIngestUsageEvent(t, store, IngestRequest{
+		SourceSystem:  SourceSystem("opencode"),
+		SourceChannel: SourceChannelHook,
+		OccurredAt:    time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC),
+		ProviderID:    "openrouter",
+		AccountID:     "openrouter",
+		AgentName:     "opencode",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-bypass",
+		MessageID:     "msg-bypass",
+		ModelRaw:      "qwen/qwen3-coder-flash",
+		TokenUsage: core.TokenUsage{
+			InputTokens: int64Ptr(10),
+			TotalTokens: int64Ptr(10),
+			Requests:    int64Ptr(1),
+		},
+	}, "ingest bypass event")
+
+	filter := usageFilter{ProviderIDs: []string{"openrouter"}}
+	storeUsageViewCache("", filter, &telemetryUsageAgg{EventCount: 999}, 1, 1)
+	agg, _, _, hit, err := loadUsageViewCached(context.Background(), db, "", filter)
+	if err != nil {
+		t.Fatalf("cache lookup with empty namespace: %v", err)
+	}
+	if hit {
+		t.Fatal("empty namespace should always miss")
+	}
+	if agg != nil {
+		t.Fatalf("empty namespace should return nil agg, got %+v", agg)
+	}
+}

--- a/internal/telemetry/usage_view_queries.go
+++ b/internal/telemetry/usage_view_queries.go
@@ -23,7 +23,29 @@ func dedupedUsageCTE(filter usageFilter) (string, []any) {
 	cte := fmt.Sprintf(`
 		WITH scoped_usage AS (
 			SELECT
-				e.*,
+				e.event_id,
+				e.occurred_at,
+				e.provider_id,
+				e.account_id,
+				e.workspace_id,
+				e.session_id,
+				e.turn_id,
+				e.message_id,
+				e.tool_call_id,
+				e.event_type,
+				e.model_raw,
+				e.model_canonical,
+				e.input_tokens,
+				e.output_tokens,
+				e.reasoning_tokens,
+				e.cache_read_tokens,
+				e.cache_write_tokens,
+				e.total_tokens,
+				e.cost_usd,
+				e.requests,
+				e.tool_name,
+				e.status,
+				e.dedup_key,
 				COALESCE(r.source_system, '') AS source_system,
 				COALESCE(r.source_channel, '') AS source_channel,
 				COALESCE(r.source_payload, '{}') AS source_payload
@@ -67,7 +89,33 @@ func dedupedUsageCTE(filter usageFilter) (string, []any) {
 			FROM scoped_usage
 		),
 		deduped_usage AS (
-			SELECT *
+			SELECT
+				event_id,
+				occurred_at,
+				provider_id,
+				account_id,
+				workspace_id,
+				session_id,
+				turn_id,
+				message_id,
+				tool_call_id,
+				event_type,
+				model_raw,
+				model_canonical,
+				input_tokens,
+				output_tokens,
+				reasoning_tokens,
+				cache_read_tokens,
+				cache_write_tokens,
+				total_tokens,
+				cost_usd,
+				requests,
+				tool_name,
+				status,
+				dedup_key,
+				source_system,
+				source_channel,
+				source_payload
 			FROM (
 				SELECT
 					ranked_usage.*,

--- a/internal/telemetry/usage_view_test.go
+++ b/internal/telemetry/usage_view_test.go
@@ -80,6 +80,69 @@ func TestMaterializedTableNameConstant(t *testing.T) {
 	}
 }
 
+func TestMaterializeUsageFilterUsesSlimProjection(t *testing.T) {
+	_, db, store := openUsageViewRawTestStore(t)
+	occurredAt := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	mustIngestUsageEvent(t, store, IngestRequest{
+		SourceSystem:  SourceSystem("claude_code"),
+		SourceChannel: SourceChannelJSONL,
+		OccurredAt:    occurredAt,
+		ProviderID:    "claude_code",
+		AccountID:     "claude_code",
+		AgentName:     "claude",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-1",
+		MessageID:     "msg-1",
+		ModelRaw:      "claude-sonnet",
+		TokenUsage: core.TokenUsage{
+			InputTokens:  int64Ptr(100),
+			OutputTokens: int64Ptr(20),
+			Requests:     int64Ptr(1),
+		},
+	}, "ingest message event")
+
+	filter, cleanup, err := materializeUsageFilter(context.Background(), db, usageFilter{
+		ProviderIDs: []string{"claude_code"},
+	})
+	if err != nil {
+		t.Fatalf("materialize usage filter: %v", err)
+	}
+	defer cleanup()
+
+	rows, err := db.QueryContext(context.Background(), "PRAGMA table_info("+filter.materializedTbl+")")
+	if err != nil {
+		t.Fatalf("pragma table_info: %v", err)
+	}
+	defer rows.Close()
+
+	columns := make(map[string]bool)
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			t.Fatalf("scan table info: %v", err)
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate table info: %v", err)
+	}
+
+	for _, required := range []string{"event_id", "occurred_at", "provider_id", "source_payload", "status"} {
+		if !columns[required] {
+			t.Fatalf("materialized table missing required column %q; columns=%v", required, columns)
+		}
+	}
+	for _, omitted := range []string{"agent_name", "model_lineage_id", "raw_event_id", "normalization_version"} {
+		if columns[omitted] {
+			t.Fatalf("materialized table kept unused column %q; columns=%v", omitted, columns)
+		}
+	}
+}
+
 func TestApplyCanonicalUsageView_MergesTelemetryWithoutReplacingRootMetrics(t *testing.T) {
 	dbPath, store := openUsageViewTestStore(t)
 


### PR DESCRIPTION
Closes #144 by addressing the remaining root causes after event retention landed on main in a separate change.

After about 24 hours of heavy Claude Code use the telemetry daemon could reach 2+ GB RSS and spike to 200 to 340% CPU on every read-model refresh, while the SQLite store grew unbounded. With retention now in place, the dominant remaining cost was the full canonical-view rebuild on every TUI tick. This PR caches that aggregate and tidies up two related smaller issues from the same bug report.

## Cached canonical usage view

The previous code ran `DROP TABLE IF EXISTS` followed by `CREATE TEMP TABLE AS SELECT * FROM deduped_usage` on every refresh. With 175k+ rows that's the dominant CPU and IO cost on each rebuild.

The cache is keyed by `(dbPath, providers, account, since, todaySince)` and validated by a cheap `MAX(rowid), COUNT(*)` probe against `idx_usage_events_provider_window`. New inserts shift the max rowid; retention prunes drop the count; both invalidate the cached aggregate. FIFO eviction at 64 entries.

`dedupedUsageCTE` was also tightened to materialise only the columns the aggregate queries consume, rather than `SELECT e.*`. Smaller temp tables, less RSS.

## Refresh-interval clamp lifted

The hard `max(5s, min(30s, interval))` clamp meant `--poll-interval` values larger than 30s were silently ignored. Replaced with a 5s floor only, so a user polling every 2 minutes now gets a refresh every 60s rather than every 15s.

## Flag registration on `daemon run`

`--poll-interval`, `--socket-path` and other flags were registered on the parent `daemon` command but not on the `run` subcommand. The launchd plist generated by `daemon install` invokes `daemon run` directly, so any flag added to the plist failed with `unknown flag`. Both commands now share the same flag set via a small `addDaemonRunFlags` helper.

## Tests

- `usage_view_cache_test.go`: cold-start, hit, new-event invalidation, prune invalidation, empty-namespace bypass
- `server_read_model_test.go`: `TestReadModelCacheIntervalRespectsPollInterval` covers default, minimum, normal, and long intervals
- `telemetry_test.go`: flag registration on the `run` subcommand
- `usage_view_test.go`: `TestMaterializeUsageFilterUsesSlimProjection` covers the slim projection
- Existing test suite passes with `-race`

## What still needs verification

Real-world memory bound is best confirmed on a long-running daemon against a heavy `claude_code` workload. Cache correctness is unit-tested, but the user-visible payoff (flat steady-state CPU on TUI refresh) is easiest to feel on a real machine.

## Docs

No user-facing config or env-var keys are introduced by this PR; `data.retention_days` is already documented from the retention change. No doc updates needed.