### PR TITLE
ci(release): fix cosign signing for cosign v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,8 +113,7 @@ jobs:
           for arch in amd64 arm64; do
             archive="openusage_${VERSION}_darwin_${arch}.tar.gz"
             cosign sign-blob --yes \
-              --output-signature   "${archive}.sig" \
-              --output-certificate "${archive}.pem" \
+              --bundle "${archive}.sigstore.json" \
               "${archive}"
           done
 
@@ -126,11 +125,9 @@ jobs:
           chmod +x scripts/install.sh
           gh release upload "${GITHUB_REF_NAME}" \
             dist/openusage_${VERSION}_darwin_amd64.tar.gz \
-            dist/openusage_${VERSION}_darwin_amd64.tar.gz.sig \
-            dist/openusage_${VERSION}_darwin_amd64.tar.gz.pem \
+            dist/openusage_${VERSION}_darwin_amd64.tar.gz.sigstore.json \
             dist/openusage_${VERSION}_darwin_arm64.tar.gz \
-            dist/openusage_${VERSION}_darwin_arm64.tar.gz.sig \
-            dist/openusage_${VERSION}_darwin_arm64.tar.gz.pem \
+            dist/openusage_${VERSION}_darwin_arm64.tar.gz.sigstore.json \
             scripts/install.sh \
             --clobber
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -83,28 +83,29 @@ checksum:
 
 # Sigstore cosign keyless signing.
 #
-# Each release archive plus the checksums file gets a `.sig` and `.pem`
-# attached to the release. Verification is done with the GitHub Actions
-# OIDC identity that ran the workflow — no key management required.
-# Verify a downloaded artifact:
+# Each release archive plus the checksums file gets a `.sigstore.json`
+# bundle attached to the release. Verification is done with the GitHub
+# Actions OIDC identity that ran the workflow, so no key management is
+# required. Verify a downloaded artifact:
 #
 #   cosign verify-blob \
-#     --certificate openusage_X.Y.Z_linux_amd64.tar.gz.pem \
-#     --signature   openusage_X.Y.Z_linux_amd64.tar.gz.sig \
+#     --bundle openusage_X.Y.Z_linux_amd64.tar.gz.sigstore.json \
 #     --certificate-identity-regexp 'https://github\.com/janekbaraniewski/openusage/\.github/workflows/' \
 #     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
 #     openusage_X.Y.Z_linux_amd64.tar.gz
+#
+# Note: cosign v3 (shipped by sigstore/cosign-installer v4) removed the
+# deprecated --output-signature / --output-certificate flags. A single
+# --bundle file now carries both the signature and the certificate.
 signs:
   - id: cosign-keyless
     cmd: cosign
     artifacts: all
-    signature: "${artifact}.sig"
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
       - "--yes"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
+      - "--bundle=${signature}"
       - "${artifact}"
     output: true
 


### PR DESCRIPTION
## Summary
- The Release workflow has been failing since v0.10.6 with `Error: signing dist/openusage_0.10.6_linux_arm64.tar.gz: create bundle file: open : no such file or directory` (run [26002748224](https://github.com/janekbaraniewski/openusage/actions/runs/26002748224)). Root cause: PR #135 bumped `sigstore/cosign-installer` from 3.10.1 to 4.1.2, which defaults to cosign v3.0.6. cosign v3 removed the deprecated `--output-signature` / `--output-certificate` flags; with `--new-bundle-format` on by default it silently ignores them and tries to open the empty `--bundle ""` path.
- Migrate `signs:` in `.goreleaser.yaml` and the macOS sign step in `.github/workflows/release.yaml` to the cosign v3 API: drop the certificate output, switch to `--bundle=${signature}`, and rename the signed asset suffix from `.sig` / `.pem` to a single `.sigstore.json` bundle.
- Refresh the verify-blob example in the goreleaser comment so users learn the new `--bundle` verification flow.

## Test plan
- [x] `goreleaser check` passes against the new config
- [x] `cosign sign-blob --help` on v3.0.6 (the version cosign-installer v4.1.2 installs) confirms `--bundle` exists and the old flags are gone
- [ ] After merge, re-tag `v0.10.6` on the new main tip and confirm the Release workflow completes signing, attaches `*.tar.gz` + `*.sigstore.json` to the release, and `release-macos` + `update-homebrew` succeed end-to-end

## Verification post-release
Once the next release runs, anyone can verify an asset with:

    cosign verify-blob \
      --bundle openusage_X.Y.Z_linux_amd64.tar.gz.sigstore.json \
      --certificate-identity-regexp 'https://github\.com/janekbaraniewski/openusage/\.github/workflows/' \
      --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
      openusage_X.Y.Z_linux_amd64.tar.gz

## Docs sweep
CI-only change. No user-facing docs reference the `.sig` / `.pem` filenames (verified with `grep -rn "\.sig\|\.pem" docs/site/docs`). SECURITY.md only mentions "Sigstore cosign keyless signing" generically, which is still accurate.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>