### PR TITLE
feat(tui): cost visibility (hide_costs) and burn-rate projection on usage gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ openusage integrations uninstall <id>     # Remove
 | `/` | Filter providers |
 | `t` | Cycle theme |
 | `w` | Cycle time window |
+| `c` | Cycle cost visibility for focused tile (auto → hide → show → auto, persists per-account) |
 | `,` | Open settings |
 | `Shift+J` / `Shift+K` | Reorder providers |
 | `?` | Help |

--- a/configs/example_settings.json
+++ b/configs/example_settings.json
@@ -25,6 +25,7 @@
     ]
   },
   "dashboard": {
+    "hide_costs": null,
     "providers": [
       {
         "account_id": "openai-personal",
@@ -32,7 +33,8 @@
       },
       {
         "account_id": "anthropic-work",
-        "enabled": true
+        "enabled": true,
+        "hide_costs": true
       },
       {
         "account_id": "openrouter",

--- a/docs/site/docs/customization/keybindings.md
+++ b/docs/site/docs/customization/keybindings.md
@@ -41,6 +41,7 @@ OpenUsage's keymap is grouped by **context** — global keys are always live, wh
 | <kbd>t</kbd> | Cycle theme |
 | <kbd>w</kbd> | Cycle time window (`1d`, `3d`, `7d`, `30d`, `all`) |
 | <kbd>Ctrl+O</kbd> | Expand model breakdown |
+| <kbd>c</kbd> | Cycle cost visibility for the focused account (auto → hide → show → auto); persists to config |
 
 ## Detail pane highlights
 

--- a/docs/site/docs/getting-started/first-run.md
+++ b/docs/site/docs/getting-started/first-run.md
@@ -41,7 +41,7 @@ A tile shows the most useful number per provider, plus a status. Examples of wha
 
 | Provider | Primary metric | What's interesting |
 |---|---|---|
-| Claude Code | Cost (estimated) | Per-model token mix, current 5h billing block, burn rate |
+| Claude Code | Cost (API key) / 5h block (Pro / Max) | Per-model token mix, current 5h billing block, burn rate. Cost is hidden by default on Pro / Max subscriptions — see [`dashboard.hide_costs`](../reference/configuration.md#dashboardhide_costs). |
 | Cursor | Plan spend | Used vs included, plus AI code score |
 | Copilot | Quota remaining | Chat / completions / premium interactions |
 | OpenRouter | Credits | Daily/weekly/monthly usage, model mix |

--- a/docs/site/docs/getting-started/quickstart.md
+++ b/docs/site/docs/getting-started/quickstart.md
@@ -52,6 +52,7 @@ The defaults you'll use most often:
 | <kbd>/</kbd> | Filter providers |
 | <kbd>v</kbd> | Cycle dashboard view (Grid → Stacked → Tabs → Split → Compare) |
 | <kbd>w</kbd> | Cycle time window (today / 3d / 7d / 30d / all) |
+| <kbd>c</kbd> | Cycle cost visibility for focused tile (auto → hide → show → auto, persists per-account) |
 | <kbd>t</kbd> | Cycle theme |
 | <kbd>,</kbd> | Open settings |
 | <kbd>?</kbd> | Help overlay |

--- a/docs/site/docs/guides/cost-attribution.md
+++ b/docs/site/docs/guides/cost-attribution.md
@@ -113,5 +113,6 @@ Set it before the data ages out. Then use `w` to cycle to `30d` (or `all`) and t
 
 - [Telemetry pipeline](../concepts/telemetry.md) — how events get deduped.
 - [Time windows](../concepts/time-windows.md) — the semantics of `1d` vs `7d`.
+- [Usage gauge projections](usage-projections.md) — the `projected 100% in …` annotation under windowed gauges.
 - [Multi-account](multi-account.md)
 - [Daemon overview](/daemon) — install hooks and integrations.

--- a/docs/site/docs/guides/usage-projections.md
+++ b/docs/site/docs/guides/usage-projections.md
@@ -1,0 +1,119 @@
+---
+title: Usage gauge projections
+description: How OpenUsage computes the "resets in X · projected 100% in Y" annotation on windowed usage gauges, and when to trust it.
+---
+
+Usage gauges for windowed metrics (Claude Code 5h blocks, daily / weekly / monthly plan caps, etc.) carry a small dim annotation under the bar. It estimates when you will hit the cap at your current pace, alongside the time remaining in the window. This page documents the math, the eligibility rules, and the limits of the heuristic.
+
+## What the annotation looks like
+
+The detail panel is verbose; the dashboard tile is compressed. The projection half has two wordings depending on whether the pace would actually reach 100% before the window resets:
+
+| Surface | Pace fits in window | Pace overshoots window |
+|---|---|---|
+| Detail view | `resets in 1h 23m · projected 100% in 42m` | `resets in 3h 42m · projected ~85% by reset` |
+| Tile view | `resets 1h 23m · 100% in 42m` | `resets 3h 42m · ~85% by reset` |
+
+Either half can render independently:
+
+- Only `resets in 1h 23m` when the window has a known reset timestamp but no usable pace yet (zero usage so far, or the window just opened).
+- Only `projected 100% in 42m` (or `projected ~85% by reset`) when pace is known but the metric has no `Resets[]` entry (rare; you only get this for tools that report a reset clock).
+
+The annotation always renders in the dim style; it never blocks the headline percentage.
+
+## How the projection is computed
+
+The pace is a flat linear extrapolation of the current window:
+
+```
+elapsed         = window_duration − time_until_reset
+pace            = (used% / 100) / elapsed_minutes    # fraction of window per minute
+remaining%      = 100 − used%
+minutes_to_100  = remaining% / (pace × 100)
+```
+
+OpenUsage then picks one of two wordings:
+
+**Branch A — pace fits in the window** (`minutes_to_100 ≤ time_until_reset`).
+The annotation reads `projected 100% in <duration>` because the window will actually reset *after* the linear projection hits the cap. This is the case the original heuristic always assumed.
+
+**Branch B — pace overshoots the window** (`minutes_to_100 > time_until_reset`).
+A naive "100% in 4h 35m" claim when the window resets in 3h 42m is misleading: you will never see those last 53 minutes — the window will roll over and `used%` will drop back to 0. Instead, OpenUsage shows the linear projection's value *at reset*:
+
+```
+projected_pct_at_reset = used% + pace × 100 × minutes_until_reset
+N = round(projected_pct_at_reset)            # clamped to [0, 99]
+```
+
+The cap is `99`, not `100`. If the linear extrapolation rounds up to `100`, the wording would contradict the branch (we picked this wording precisely because we expect *not* to hit 100); printing `~99% by reset` is honest about that.
+
+**Worked example.** A 5-hour window starts at 16:00 and resets at 21:00. At 17:18 (1h 18m elapsed, 3h 42m to reset) you have used 22%.
+
+- `pace = 0.22 / 78 ≈ 0.00282` per minute.
+- `minutes_to_100 = 78 / 0.282 ≈ 277` minutes ≈ 4h 37m.
+- `time_until_reset = 222` minutes (3h 42m). The pace overshoots → Branch B.
+- `projected_pct_at_reset = 22 + 0.282 × 222 ≈ 85`.
+- Annotation prints `resets 3h 42m · ~85% by reset`.
+
+The reset half is just `resetAt − now`, formatted compactly (`1h 23m`, `42m`, `45s`).
+
+The same formula drives both the detail-view and the tile-view annotation; the wording differs but the numbers do not.
+
+## Which metrics get a projection
+
+Projection requires three things:
+
+1. **A recognized window string** on the metric. Currently: `5h`, `1d`, `24h`, `today`, `7d`, `30d`. Other windows (e.g. `1m`, `1h`, `all-time`) render the gauge with no annotation.
+2. **A reset timestamp** in `snap.Resets[key]`. Without it, OpenUsage cannot compute elapsed time and skips the annotation entirely.
+3. **A gauge-eligible metric** — one with a meaningful `used%` (i.e. it already renders as a usage bar).
+
+In practice, the annotation shows up on:
+
+- Claude Code 5-hour billing blocks.
+- Z.AI coding-plan 5h and 24h usage gauges.
+- Cursor monthly / 14-day plan caps.
+- Ollama request quotas where the upstream reports a `5h` window.
+- OpenRouter and Perplexity windowed plan caps where reset times are exposed.
+- Alibaba Cloud daily and monthly quotas.
+
+If a provider doesn't supply a reset timestamp or uses an unrecognized window, the gauge still works — you just won't see the projection.
+
+## When the projection is suppressed
+
+The pace half is omitted (only `resets in …` renders, or nothing at all) when:
+
+| Condition | Reason |
+|---|---|
+| `used% == 0` | No data to extrapolate from. |
+| `used% >= 100` | Already at the cap — a forecast is meaningless. |
+| `elapsed <= 0` | Window has not started yet, or the reset clock is in the future by more than the window. |
+| `pace` is NaN, ±Inf, or `<= 0` | Numerically degenerate; refuse rather than print a misleading number. |
+| Computed `minutes_to_100 <= 0` | Same — degenerate. Render the reset half alone. |
+
+These rules apply to both the tile and the detail annotation.
+
+## Limitations: it is a heuristic, not a forecast
+
+The pace is the **average** rate over the whole elapsed window. It assumes you will keep spending at exactly that rate until reset. In practice:
+
+- A burst of activity in the first 10 minutes of a 5-hour block makes the projection look catastrophic. Wait a few minutes of idle time and the prediction relaxes.
+- A long idle stretch followed by a spike makes the projection look reassuring right up until you hit the wall.
+- Approaching the end of a window, even a fraction of a percent per minute can dominate the projection because `remaining%` is small.
+- Branch B (`~N% by reset`) is just as linear as Branch A. It assumes the next `time_until_reset` minutes look exactly like the elapsed slice. A quiet stretch ahead of you will land below `N`; a burst will overshoot it. The number is a sanity check, not a guarantee.
+
+Treat the annotation as a *"if today keeps looking like today"* signal — useful for catching pace problems early, not a substitute for hard rate-limit math. If you need a non-linear forecast (recent-weighted, EWMA, etc.) the analytics screen is the place to build that yourself; the gauge will not do it for you.
+
+## Interaction with `hide_costs`
+
+The projection is a **usage** annotation, not a cost annotation. It is computed from percentages and never references dollars. That means:
+
+- `hide_costs = true` (per-account or global) hides cost columns and the dollar projections in the cost section, but it **does not** hide gauge projections.
+- The `c` keystroke that cycles cost visibility (auto → hide → show → auto) has no effect on this annotation.
+
+If you want the gauge projection without the dollar noise on a subscription plan, that's already how the default plan-aware `hide_costs` policy behaves: costs hidden, usage projection visible. See [`dashboard.hide_costs`](../reference/configuration.md#dashboardhide_costs) for the precedence rules.
+
+## Related
+
+- [Claude Code provider](../providers/claude-code.md) — 5-hour billing blocks, the highest-traffic user of this annotation.
+- [Time windows](../concepts/time-windows.md) — separate concept; `w` changes the **aggregation** window for totals, not the **gauge** window which is fixed per-metric by the provider.
+- [Cost attribution](cost-attribution.md) — for the dollar side of "where is the burn coming from?"

--- a/docs/site/docs/guides/usage-projections.md
+++ b/docs/site/docs/guides/usage-projections.md
@@ -70,6 +70,7 @@ Projection requires three things:
 In practice, the annotation shows up on:
 
 - Claude Code 5-hour billing blocks.
+- Codex CLI primary and secondary rate-limit windows. The live usage endpoint reports `window_minutes` and a `resets_at` timestamp; primary windows are `300m → 5h` (recognized) and secondary windows are `10080m → 7d` (recognized). Both render with a projection. Other plans may emit non-standard `window_minutes` values (e.g. `60`, `1440`); those format as `1h` or `1d`, of which only `1d` is recognized — see the window-string allowlist above.
 - Z.AI coding-plan 5h and 24h usage gauges.
 - Cursor monthly / 14-day plan caps.
 - Ollama request quotas where the upstream reports a `5h` window.

--- a/docs/site/docs/providers/claude-code.md
+++ b/docs/site/docs/providers/claude-code.md
@@ -200,3 +200,4 @@ A block starts at `floor(timestamp_of_first_message, 1h)` and ends 5 hours later
 
 - [Codex CLI](./codex.md) — sibling local-file provider for OpenAI's Codex
 - [Anthropic](./anthropic.md) — direct API rate limits for the same backend models
+- [Usage gauge projections](../guides/usage-projections.md) — how the `resets in … · projected 100% in …` annotation under the 5h gauge is computed

--- a/docs/site/docs/providers/claude-code.md
+++ b/docs/site/docs/providers/claude-code.md
@@ -192,6 +192,12 @@ Costs are API-equivalent estimates derived from token counts and public pricing 
 
 The Cost tile is an **API-equivalent estimate**: the provider takes input/output/cache token counts from your local conversation logs and multiplies by Anthropic's published per-million rates. That's what the same usage would cost on the API. A Pro / Max subscription bills flat-rate, so the local estimate often exceeds your actual subscription charge — that's a feature, not a bug; it's the leverage you get from the subscription.
 
+:::note Cost values hidden by default on Pro / Max
+Because the dollar number is API-equivalent and unrelated to what you are actually charged, OpenUsage hides cost values by default when `~/.claude.json` shows an active Pro or Max subscription. The plan-aware default leaves token totals, the 5h block, and the usage projection visible — only dollar columns are suppressed.
+
+Override the default by setting [`dashboard.hide_costs`](../reference/configuration.md#dashboardhide_costs) (top-level or per-account) or by pressing <kbd>c</kbd> on the focused tile to cycle auto → hide → show → auto. The [usage-projection annotation](../guides/usage-projections.md) is unaffected — it is a usage signal, not a cost signal.
+:::
+
 ### Why does the 5-hour block reset at a weird time?
 
 A block starts at `floor(timestamp_of_first_message, 1h)` and ends 5 hours later. The window is local to your machine and rolls forward only when a turn lands after the prior block's end. Quiet periods don't slide it; a single late-night turn opens a new block aligned to that hour.

--- a/docs/site/docs/providers/codex.md
+++ b/docs/site/docs/providers/codex.md
@@ -100,6 +100,10 @@ The base URL for the live endpoint is, in order: `acct.BaseURL` → `extra.chatg
 - **Per-token spend in dollars from local sessions.** Codex sessions don't carry pricing — only token counts. The credit balance is the only $ figure, and it comes from the live endpoint.
 - **Hook-driven real-time events without the integration.** Install the `codex` integration (see [Daemon integrations](../daemon/integrations.md)) for per-turn events.
 
+:::note Cost values hidden by default on Plus / Pro / Team / Enterprise
+On a ChatGPT subscription plan (Plus, Pro, Team, Enterprise) the dollar number is misleading — usage is governed by rate-limit windows, not by per-call pricing. OpenUsage hides cost columns by default whenever the live `plan_type` reports a subscription tier; rate-limit windows, sessions, and tokens stay visible. Override with [`dashboard.hide_costs`](../reference/configuration.md#dashboardhide_costs) or the <kbd>c</kbd> keystroke.
+:::
+
 ### How fresh is the data?
 
 - Polling: every 30 s by default. JSONL files are re-parsed when their mtime/size changes; otherwise served from cache.

--- a/docs/site/docs/providers/copilot.md
+++ b/docs/site/docs/providers/copilot.md
@@ -101,6 +101,10 @@ No direct HTTPS calls are made — everything goes through `gh`, which uses the 
 - **$ spend per turn.** Copilot is per-seat, so the dashboard exposes seat counts and quota usage rather than dollars per call.
 - **Org metrics for non-admin accounts.** GitHub does not return them.
 
+:::note Cost values hidden by default on Individual / Business / Enterprise
+Copilot bills per seat on every plan, so per-turn dollar figures are not meaningful. OpenUsage hides cost columns by default on all Copilot plans (Individual, Business, Enterprise) and surfaces quotas, seats, and rate limits instead. Override with [`dashboard.hide_costs`](../reference/configuration.md#dashboardhide_costs) or the <kbd>c</kbd> keystroke.
+:::
+
 ### How fresh is the data?
 
 - Polled every 30 s by default. `gh` calls are throttled by GitHub's own rate limit; the values OpenUsage reads include `remaining` and `reset` so you can see headroom.

--- a/docs/site/docs/providers/zai.md
+++ b/docs/site/docs/providers/zai.md
@@ -89,6 +89,10 @@ Each poll (default every 30 seconds in daemon mode) hits up to five endpoints. A
 - Source: a flag in the `quota/limit` response.
 - Transform: stored as `Attributes["subscription_status"]`. When no coding package is active, the value is `inactive_or_free` and the tile flags it.
 
+:::note Cost values hidden by default on `glm_coding_plan*`
+Z.AI's coding packages (anything whose subscription status starts with `glm_coding_plan`) bill a flat package fee — the per-call dollar figures on `model-usage` are reference numbers, not what your card is charged. OpenUsage hides cost columns by default for those subscriptions; the 5h window, monthly usage, and credit grants stay visible. Free / `inactive_or_free` accounts pay per-call and keep costs visible. Override with [`dashboard.hide_costs`](../reference/configuration.md#dashboardhide_costs) or the <kbd>c</kbd> keystroke.
+:::
+
 ### Per-model rows
 
 - Source: rows under `data` of `model-usage`. Each row carries a model name, request count, input/output/reasoning/cached tokens, cost in USD, and tool calls.

--- a/docs/site/docs/reference/configuration.md
+++ b/docs/site/docs/reference/configuration.md
@@ -355,9 +355,10 @@ Read-only mirror of accounts the detector found at startup. Format is identical 
   },
   "dashboard": {
     "view": "grid",
+    "hide_costs": null,
     "providers": [
       { "account_id": "openai-personal", "enabled": true },
-      { "account_id": "anthropic-work",  "enabled": true },
+      { "account_id": "anthropic-work",  "enabled": true,  "hide_costs": true },
       { "account_id": "openrouter",      "enabled": false }
     ],
     "widget_sections": [

--- a/docs/site/docs/reference/configuration.md
+++ b/docs/site/docs/reference/configuration.md
@@ -143,6 +143,23 @@ Ordered list of accounts to render in the dashboard. Order in the array is the d
 |---|---|---|
 | `account_id` | string | Must match an `id` from `accounts` or `auto_detected_accounts`. |
 | `enabled` | bool | Show the tile or hide it. |
+| `hide_costs` | nullable bool | Per-account override for monetary visibility. See [`dashboard.hide_costs`](#dashboardhide_costs). Omitted / `null` falls through to the top-level setting; `true` force-hides costs for this account; `false` force-shows them. |
+
+### `dashboard.hide_costs`
+
+| Type | Default | Purpose |
+|---|---|---|
+| nullable bool | omitted | Global default for whether monetary metrics (cost, spend, dollars) render in tiles and detail. Omitted / `null` means "automatic, plan-aware"; `true` force-hides everywhere; `false` force-shows everywhere. |
+
+Resolution order, highest precedence first:
+
+1. `dashboard.providers[].hide_costs` (per-account override)
+2. `dashboard.hide_costs` (top-level override)
+3. Automatic, plan-aware policy
+
+The automatic policy hides costs on fixed-rate subscription plans (Claude Code with an active subscription, Codex on Plus / Team / Enterprise, GitHub Copilot on any plan, Z.AI on `glm_coding_plan*`) where dollar figures would be misleading, and shows costs everywhere else.
+
+You can also toggle the per-account override live from the dashboard with <kbd>c</kbd> — it cycles auto → hide → show → auto for the focused tile and persists the choice here.
 
 ### `dashboard.hide_sections_with_no_data`
 

--- a/docs/site/docs/reference/keybindings.md
+++ b/docs/site/docs/reference/keybindings.md
@@ -45,6 +45,7 @@ Active in any list-like view.
 | <kbd>V</kbd> | Previous dashboard view |
 | <kbd>r</kbd> | Refresh now |
 | <kbd>t</kbd> | Cycle theme forward |
+| <kbd>c</kbd> | Toggle hide-costs for focused account (auto / hide / show) |
 | <kbd>w</kbd> | Cycle time window (`1d` → `3d` → `7d` → `30d` → `all`) |
 | <kbd>Ctrl+O</kbd> | Expand model breakdown for the focused tile |
 

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -118,6 +118,7 @@ const sidebars: SidebarsConfig = {
         'guides/multi-account',
         'guides/team-tracking',
         'guides/cost-attribution',
+        'guides/usage-projections',
         'guides/headless-servers',
       ],
     },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,10 @@ type DataConfig struct {
 type DashboardProviderConfig struct {
 	AccountID string `json:"account_id"`
 	Enabled   bool   `json:"enabled"`
+	// HideCosts overrides the dashboard-level setting for this account.
+	// nil means "fall through to DashboardConfig.HideCosts (and then to the
+	// plan-aware auto policy)".
+	HideCosts *bool `json:"hide_costs,omitempty"`
 }
 
 type DashboardWidgetSection struct {
@@ -57,6 +61,7 @@ func (p *DashboardProviderConfig) UnmarshalJSON(data []byte) error {
 	type rawDashboardProviderConfig struct {
 		AccountID string `json:"account_id"`
 		Enabled   *bool  `json:"enabled"`
+		HideCosts *bool  `json:"hide_costs"`
 	}
 
 	var raw rawDashboardProviderConfig
@@ -69,6 +74,7 @@ func (p *DashboardProviderConfig) UnmarshalJSON(data []byte) error {
 	if raw.Enabled != nil {
 		p.Enabled = *raw.Enabled
 	}
+	p.HideCosts = raw.HideCosts
 	return nil
 }
 
@@ -121,6 +127,10 @@ type DashboardConfig struct {
 	WidgetSections         []DashboardWidgetSection  `json:"widget_sections,omitempty"`
 	DetailSections         []DetailWidgetSection     `json:"detail_sections,omitempty"`
 	HideSectionsWithNoData bool                      `json:"hide_sections_with_no_data,omitempty"`
+	// HideCosts is the global default for suppressing monetary metrics.
+	// nil means "fall through to the plan-aware auto policy" (see
+	// core.ResolveHideCosts).
+	HideCosts *bool `json:"hide_costs,omitempty"`
 }
 
 type IntegrationState struct {
@@ -334,6 +344,7 @@ func normalizeDashboardProviders(in []DashboardProviderConfig) []DashboardProvid
 		return DashboardProviderConfig{
 			AccountID: normalizeAccountID(entry.AccountID),
 			Enabled:   entry.Enabled,
+			HideCosts: entry.HideCosts,
 		}
 	})
 	filtered := lo.Filter(normalized, func(entry DashboardProviderConfig, _ int) bool { return entry.AccountID != "" })
@@ -522,6 +533,51 @@ func SaveDashboardHideSectionsWithNoData(hide bool) error {
 func SaveDashboardHideSectionsWithNoDataTo(path string, hide bool) error {
 	return modifyConfig(path, func(cfg *Config) {
 		cfg.Dashboard.HideSectionsWithNoData = hide
+	})
+}
+
+// SaveDashboardHideCosts persists the global hide_costs toggle. Pass nil to clear
+// the override (return to plan-aware auto behavior).
+func SaveDashboardHideCosts(hide *bool) error {
+	return SaveDashboardHideCostsTo(ConfigPath(), hide)
+}
+
+func SaveDashboardHideCostsTo(path string, hide *bool) error {
+	return modifyConfig(path, func(cfg *Config) {
+		cfg.Dashboard.HideCosts = hide
+	})
+}
+
+// SaveDashboardProviderHideCosts persists the per-account hide_costs override.
+// Pass nil to clear the override (fall through to global / auto).
+//
+// If no DashboardProviderConfig exists for accountID yet, one is appended with
+// Enabled=true so the override sticks.
+func SaveDashboardProviderHideCosts(accountID string, hide *bool) error {
+	return SaveDashboardProviderHideCostsTo(ConfigPath(), accountID, hide)
+}
+
+func SaveDashboardProviderHideCostsTo(path string, accountID string, hide *bool) error {
+	accountID = normalizeAccountID(accountID)
+	if accountID == "" {
+		return fmt.Errorf("save dashboard provider hide_costs: account_id must be non-empty")
+	}
+	return modifyConfig(path, func(cfg *Config) {
+		found := false
+		for i := range cfg.Dashboard.Providers {
+			if cfg.Dashboard.Providers[i].AccountID == accountID {
+				cfg.Dashboard.Providers[i].HideCosts = hide
+				found = true
+				break
+			}
+		}
+		if !found {
+			cfg.Dashboard.Providers = append(cfg.Dashboard.Providers, DashboardProviderConfig{
+				AccountID: accountID,
+				Enabled:   true,
+				HideCosts: hide,
+			})
+		}
 	})
 }
 

--- a/internal/core/cost_visibility.go
+++ b/internal/core/cost_visibility.go
@@ -1,0 +1,58 @@
+package core
+
+import "strings"
+
+// ResolveHideCosts decides whether to suppress monetary metrics for a
+// snapshot.
+//
+// Resolution order (most specific wins):
+//  1. perAccount (DashboardProviderConfig.HideCosts) if non-nil
+//  2. global (DashboardConfig.HideCosts) if non-nil
+//  3. plan-aware auto policy derived from snapshot signals
+//
+// Returns true if costs should be hidden.
+func ResolveHideCosts(snap UsageSnapshot, perAccount *bool, global *bool) bool {
+	if perAccount != nil {
+		return *perAccount
+	}
+	if global != nil {
+		return *global
+	}
+	return autoHideCosts(snap)
+}
+
+// autoHideCosts implements the plan-aware default policy.
+//
+// Subscription / fixed-rate plans hide cost figures because the API-derived
+// dollar amounts are not actually billed to the user; pay-as-you-go and BYOK
+// accounts show costs.
+func autoHideCosts(snap UsageSnapshot) bool {
+	if snap.Raw == nil {
+		return false
+	}
+	switch snap.ProviderID {
+	case "claude_code":
+		// Subscription accounts (Pro/Max) pay a flat rate; the API-derived
+		// cost is informational only and confuses users who do not see those
+		// dollars on their statement.
+		return strings.EqualFold(snap.Raw["subscription"], "active")
+	case "codex":
+		plan := strings.ToLower(strings.TrimSpace(snap.Raw["plan_type"]))
+		switch plan {
+		case "plus", "pro", "team", "enterprise":
+			return true
+		}
+		return false
+	case "copilot":
+		plan := strings.ToLower(strings.TrimSpace(snap.Raw["copilot_plan"]))
+		switch plan {
+		case "individual", "business", "enterprise":
+			return true
+		}
+		return false
+	case "zai":
+		plan := strings.ToLower(strings.TrimSpace(snap.Raw["plan_type"]))
+		return strings.Contains(plan, "glm_coding_plan")
+	}
+	return false
+}

--- a/internal/core/cost_visibility_test.go
+++ b/internal/core/cost_visibility_test.go
@@ -1,0 +1,128 @@
+package core
+
+import "testing"
+
+func ptrBool(b bool) *bool { return &b }
+
+func TestResolveHideCosts_PerAccountWins(t *testing.T) {
+	snap := UsageSnapshot{ProviderID: "claude_code", Raw: map[string]string{"subscription": "active"}}
+	cases := []struct {
+		name       string
+		perAccount *bool
+		global     *bool
+		want       bool
+	}{
+		{"perAccount=false beats auto-hide", ptrBool(false), nil, false},
+		{"perAccount=true beats global=false", ptrBool(true), ptrBool(false), true},
+		{"perAccount=false beats global=true", ptrBool(false), ptrBool(true), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveHideCosts(snap, tc.perAccount, tc.global)
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveHideCosts_GlobalBeatsAuto(t *testing.T) {
+	// Provider whose auto policy says "show" (openai) but global says "hide".
+	snap := UsageSnapshot{ProviderID: "openai", Raw: map[string]string{}}
+	got := ResolveHideCosts(snap, nil, ptrBool(true))
+	if !got {
+		t.Fatalf("global=true should hide costs for openai (auto would show)")
+	}
+
+	// Reverse: auto says "hide" (claude_code subscription) but global says "show".
+	snap2 := UsageSnapshot{ProviderID: "claude_code", Raw: map[string]string{"subscription": "active"}}
+	got = ResolveHideCosts(snap2, nil, ptrBool(false))
+	if got {
+		t.Fatalf("global=false should show costs for claude_code subscription (auto would hide)")
+	}
+}
+
+func TestResolveHideCosts_AutoPolicy(t *testing.T) {
+	cases := []struct {
+		name string
+		snap UsageSnapshot
+		want bool
+	}{
+		// claude_code
+		{"claude_code subscription active hides",
+			UsageSnapshot{ProviderID: "claude_code", Raw: map[string]string{"subscription": "active"}}, true},
+		{"claude_code subscription none shows",
+			UsageSnapshot{ProviderID: "claude_code", Raw: map[string]string{"subscription": "none"}}, false},
+		{"claude_code missing raw shows",
+			UsageSnapshot{ProviderID: "claude_code", Raw: map[string]string{}}, false},
+		{"claude_code nil raw shows",
+			UsageSnapshot{ProviderID: "claude_code"}, false},
+
+		// codex
+		{"codex plus hides",
+			UsageSnapshot{ProviderID: "codex", Raw: map[string]string{"plan_type": "plus"}}, true},
+		{"codex pro hides",
+			UsageSnapshot{ProviderID: "codex", Raw: map[string]string{"plan_type": "pro"}}, true},
+		{"codex team hides",
+			UsageSnapshot{ProviderID: "codex", Raw: map[string]string{"plan_type": "team"}}, true},
+		{"codex enterprise hides",
+			UsageSnapshot{ProviderID: "codex", Raw: map[string]string{"plan_type": "enterprise"}}, true},
+		{"codex free shows",
+			UsageSnapshot{ProviderID: "codex", Raw: map[string]string{"plan_type": "free"}}, false},
+		{"codex unknown plan shows",
+			UsageSnapshot{ProviderID: "codex", Raw: map[string]string{"plan_type": "weird"}}, false},
+
+		// copilot
+		{"copilot individual hides",
+			UsageSnapshot{ProviderID: "copilot", Raw: map[string]string{"copilot_plan": "individual"}}, true},
+		{"copilot business hides",
+			UsageSnapshot{ProviderID: "copilot", Raw: map[string]string{"copilot_plan": "business"}}, true},
+		{"copilot enterprise hides",
+			UsageSnapshot{ProviderID: "copilot", Raw: map[string]string{"copilot_plan": "enterprise"}}, true},
+		{"copilot free shows",
+			UsageSnapshot{ProviderID: "copilot", Raw: map[string]string{"copilot_plan": "free"}}, false},
+
+		// zai
+		{"zai glm_coding_plan hides",
+			UsageSnapshot{ProviderID: "zai", Raw: map[string]string{"plan_type": "glm_coding_plan"}}, true},
+		{"zai contains glm_coding_plan hides",
+			UsageSnapshot{ProviderID: "zai", Raw: map[string]string{"plan_type": "glm_coding_plan_v2"}}, true},
+		{"zai other plan shows",
+			UsageSnapshot{ProviderID: "zai", Raw: map[string]string{"plan_type": "payg"}}, false},
+
+		// pay-as-you-go / unknown providers default to show
+		{"openai shows", UsageSnapshot{ProviderID: "openai"}, false},
+		{"anthropic shows", UsageSnapshot{ProviderID: "anthropic"}, false},
+		{"openrouter shows", UsageSnapshot{ProviderID: "openrouter"}, false},
+		{"gemini_api shows", UsageSnapshot{ProviderID: "gemini_api"}, false},
+		{"mistral shows", UsageSnapshot{ProviderID: "mistral"}, false},
+		{"groq shows", UsageSnapshot{ProviderID: "groq"}, false},
+		{"deepseek shows", UsageSnapshot{ProviderID: "deepseek"}, false},
+		{"xai shows", UsageSnapshot{ProviderID: "xai"}, false},
+		{"alibaba_cloud shows", UsageSnapshot{ProviderID: "alibaba_cloud"}, false},
+		{"ollama shows", UsageSnapshot{ProviderID: "ollama"}, false},
+		{"aider shows", UsageSnapshot{ProviderID: "aider"}, false},
+		{"moonshot-ai shows", UsageSnapshot{ProviderID: "moonshot-ai"}, false},
+		{"perplexity shows", UsageSnapshot{ProviderID: "perplexity"}, false},
+		{"truly unknown shows", UsageSnapshot{ProviderID: "newprovider123"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveHideCosts(tc.snap, nil, nil)
+			if got != tc.want {
+				t.Fatalf("ResolveHideCosts(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveHideCosts_PlanCaseInsensitive(t *testing.T) {
+	snap := UsageSnapshot{ProviderID: "codex", Raw: map[string]string{"plan_type": "PRO"}}
+	if !ResolveHideCosts(snap, nil, nil) {
+		t.Fatalf("expected uppercase PRO to hide costs")
+	}
+	snap2 := UsageSnapshot{ProviderID: "claude_code", Raw: map[string]string{"subscription": "Active"}}
+	if !ResolveHideCosts(snap2, nil, nil) {
+		t.Fatalf("expected mixed-case Active to hide costs")
+	}
+}

--- a/internal/dashboardapp/service.go
+++ b/internal/dashboardapp/service.go
@@ -56,6 +56,10 @@ func (s *Service) SaveDashboardProviders(providersCfg []config.DashboardProvider
 	return config.SaveDashboardProviders(providersCfg)
 }
 
+func (s *Service) SaveDashboardProviderHideCosts(accountID string, hide *bool) error {
+	return config.SaveDashboardProviderHideCosts(accountID, hide)
+}
+
 func (s *Service) SaveDashboardView(view string) error {
 	return config.SaveDashboardView(view)
 }

--- a/internal/providers/claude_code/claude_code_test.go
+++ b/internal/providers/claude_code/claude_code_test.go
@@ -415,6 +415,80 @@ func TestReadAccount_FullDetails(t *testing.T) {
 	}
 }
 
+func TestReadAccount_PlanType(t *testing.T) {
+	cases := []struct {
+		name             string
+		acctJSON         string
+		wantSubscription string
+		wantPlanType     string // empty means "must not be set"
+	}{
+		{
+			name: "stripe subscription emits plan_type=pro",
+			acctJSON: `{
+				"hasAvailableSubscription": true,
+				"oauthAccount": {"billingType": "stripe"}
+			}`,
+			wantSubscription: "active",
+			wantPlanType:     "pro",
+		},
+		{
+			name: "non-stripe subscription emits plan_type=subscription",
+			acctJSON: `{
+				"hasAvailableSubscription": true,
+				"oauthAccount": {"billingType": "manual"}
+			}`,
+			wantSubscription: "active",
+			wantPlanType:     "subscription",
+		},
+		{
+			name: "subscription without oauthAccount emits plan_type=subscription",
+			acctJSON: `{
+				"hasAvailableSubscription": true
+			}`,
+			wantSubscription: "active",
+			wantPlanType:     "subscription",
+		},
+		{
+			name: "no subscription does not emit plan_type",
+			acctJSON: `{
+				"hasAvailableSubscription": false,
+				"oauthAccount": {"emailAddress": "x@y.com"}
+			}`,
+			wantSubscription: "none",
+			wantPlanType:     "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			accountPath := filepath.Join(tmpDir, ".claude.json")
+			os.WriteFile(accountPath, []byte(tc.acctJSON), 0644)
+
+			p := New()
+			snap := core.UsageSnapshot{
+				Metrics: make(map[string]core.Metric),
+				Raw:     make(map[string]string),
+			}
+			if err := p.readAccount(accountPath, &snap); err != nil {
+				t.Fatalf("readAccount failed: %v", err)
+			}
+			if snap.Raw["subscription"] != tc.wantSubscription {
+				t.Errorf("subscription=%q want %q", snap.Raw["subscription"], tc.wantSubscription)
+			}
+			got, present := snap.Raw["plan_type"]
+			if tc.wantPlanType == "" {
+				if present {
+					t.Errorf("expected plan_type to be unset, got %q", got)
+				}
+				return
+			}
+			if got != tc.wantPlanType {
+				t.Errorf("plan_type=%q want %q", got, tc.wantPlanType)
+			}
+		})
+	}
+}
+
 func TestFloorToHour(t *testing.T) {
 	input := time.Date(2026, 2, 10, 14, 35, 22, 0, time.UTC)
 	expected := time.Date(2026, 2, 10, 14, 0, 0, 0, time.UTC)

--- a/internal/providers/claude_code/local_files.go
+++ b/internal/providers/claude_code/local_files.go
@@ -316,6 +316,16 @@ func (p *Provider) readAccount(path string, snap *core.UsageSnapshot) error {
 
 	if acct.HasAvailableSubscription {
 		snap.Raw["subscription"] = "active"
+		// plan_type is a derived hint for the cost-visibility policy.
+		// Stripe-billed subscriptions are typically Claude Pro; other
+		// active subscriptions (e.g. SSO/enterprise-managed) get a
+		// generic "subscription" label which still triggers fixed-rate
+		// behavior in cost gating.
+		if acct.OAuthAccount != nil && acct.OAuthAccount.BillingType == "stripe" {
+			snap.Raw["plan_type"] = "pro"
+		} else {
+			snap.Raw["plan_type"] = "subscription"
+		}
 	} else {
 		snap.Raw["subscription"] = "none"
 	}

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -56,7 +56,7 @@ func RenderDetailContent(snap core.UsageSnapshot, now time.Time, w int, warnThre
 	}
 
 	// Build and render all sections as bordered cards.
-	sections := buildDetailSections(snap, widget, w, warnThresh, critThresh, timeWindow, hideCosts)
+	sections := buildDetailSections(snap, widget, w, warnThresh, critThresh, timeWindow, hideCosts, now)
 	for _, sec := range sections {
 		renderDetailCard(&sb, sec, w)
 	}

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -35,12 +35,16 @@ func DetailTabs(snap core.UsageSnapshot) []string {
 // RenderDetailContent is the pure render function for the detail panel.
 // `now` is the reference time used for "X ago" labels — pass m.viewNow() in
 // production paths, or time.Now() in tests that don't care about pinning.
-func RenderDetailContent(snap core.UsageSnapshot, now time.Time, w int, warnThresh, critThresh float64, activeTab int, timeWindow core.TimeWindow) string {
+//
+// hideCosts suppresses monetary metrics (dollar amounts, burn rate, budget
+// gauges, forecasts). Token counts, quota percentages, and usage gauges
+// remain regardless.
+func RenderDetailContent(snap core.UsageSnapshot, now time.Time, w int, warnThresh, critThresh float64, activeTab int, timeWindow core.TimeWindow, hideCosts bool) string {
 	var sb strings.Builder
 	widget := dashboardWidget(snap.ProviderID)
 
 	// ── Compact top bar ──
-	renderDetailCompactHeader(&sb, snap, now, w)
+	renderDetailCompactHeader(&sb, snap, now, w, hideCosts)
 
 	if len(snap.Metrics) == 0 && len(snap.ModelUsage) == 0 {
 		if snap.Message != "" {
@@ -52,7 +56,7 @@ func RenderDetailContent(snap core.UsageSnapshot, now time.Time, w int, warnThre
 	}
 
 	// Build and render all sections as bordered cards.
-	sections := buildDetailSections(snap, widget, w, warnThresh, critThresh, timeWindow)
+	sections := buildDetailSections(snap, widget, w, warnThresh, critThresh, timeWindow, hideCosts)
 	for _, sec := range sections {
 		renderDetailCard(&sb, sec, w)
 	}
@@ -63,8 +67,8 @@ func RenderDetailContent(snap core.UsageSnapshot, now time.Time, w int, warnThre
 // ── Compact Header ─────────────────────────────────────────────────────────
 // Replaces the old bordered card header. Shows essential info in 2 lines.
 
-func renderDetailCompactHeader(sb *strings.Builder, snap core.UsageSnapshot, now time.Time, w int) {
-	di := computeDisplayInfo(snap, dashboardWidget(snap.ProviderID))
+func renderDetailCompactHeader(sb *strings.Builder, snap core.UsageSnapshot, now time.Time, w int, hideCosts bool) {
+	di := computeDisplayInfo(snap, dashboardWidget(snap.ProviderID), hideCosts)
 
 	// Line 1: status icon + name (left) ... provider + meta + status badge (right)
 	statusIcon := lipgloss.NewStyle().Foreground(StatusColor(snap.Status)).Render(StatusIcon(snap.Status))

--- a/internal/tui/detail_abstraction_test.go
+++ b/internal/tui/detail_abstraction_test.go
@@ -165,7 +165,7 @@ func TestRenderDetailContent_AtVariousWidths(t *testing.T) {
 	}
 
 	for _, width := range []int{40, 60, 80, 120} {
-		out := RenderDetailContent(snap, time.Now(), width, 0.3, 0.1, 0, core.TimeWindowAll)
+		out := RenderDetailContent(snap, time.Now(), width, 0.3, 0.1, 0, core.TimeWindowAll, false)
 		if len(out) == 0 {
 			t.Errorf("empty output at width %d", width)
 		}

--- a/internal/tui/detail_hide_costs_test.go
+++ b/internal/tui/detail_hide_costs_test.go
@@ -1,0 +1,77 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// snapshotWithCosts returns a snapshot that exercises the dollar-amount paths:
+// today_api_cost, 5h_block_cost, and a burn_rate-derived cost summary.
+func snapshotWithCosts() core.UsageSnapshot {
+	today := 1.23
+	block := 0.45
+	return core.UsageSnapshot{
+		ProviderID: "claude_code",
+		AccountID:  "claude-code",
+		Status:     core.StatusOK,
+		Timestamp:  time.Now(),
+		Metrics: map[string]core.Metric{
+			"today_api_cost": {Used: &today, Unit: "USD", Window: "today"},
+			"5h_block_cost":  {Used: &block, Unit: "USD", Window: "5h"},
+		},
+		Raw: map[string]string{"subscription": "active"},
+	}
+}
+
+func TestRenderDetailContent_HideCostsSuppressesDollars(t *testing.T) {
+	snap := snapshotWithCosts()
+
+	shown := RenderDetailContent(snap, time.Now(), 120, 0.20, 0.05, 0, core.TimeWindow30d, false)
+	hidden := RenderDetailContent(snap, time.Now(), 120, 0.20, 0.05, 0, core.TimeWindow30d, true)
+
+	if !strings.Contains(shown, "$1.23") {
+		t.Errorf("expected $1.23 in shown render, missing")
+	}
+	if strings.Contains(hidden, "$1.23") {
+		t.Errorf("expected $1.23 suppressed when hideCosts=true")
+	}
+	// The Spending and Forecast cards should not appear when hideCosts is on.
+	if strings.Contains(hidden, "Spending") {
+		t.Errorf("Spending card should be suppressed")
+	}
+	if strings.Contains(hidden, "Forecast") {
+		t.Errorf("Forecast card should be suppressed")
+	}
+}
+
+func TestResolveHideCosts_ModelIntegration(t *testing.T) {
+	// Subscription claude_code account: auto policy hides costs by default.
+	subSnap := core.UsageSnapshot{
+		ProviderID: "claude_code",
+		AccountID:  "claude-code",
+		Raw:        map[string]string{"subscription": "active"},
+	}
+	m := Model{}
+	if !m.resolveHideCosts(subSnap) {
+		t.Errorf("default auto policy should hide costs for subscription claude_code")
+	}
+
+	// Per-account override beats auto.
+	show := false
+	m.hideCostsByAccount = map[string]*bool{"claude-code": &show}
+	if m.resolveHideCosts(subSnap) {
+		t.Errorf("per-account override false should show costs")
+	}
+
+	// Global override beats auto when per-account is nil.
+	m2 := Model{}
+	hide := true
+	m2.hideCostsGlobal = &hide
+	apiSnap := core.UsageSnapshot{ProviderID: "openai", AccountID: "openai-key"}
+	if !m2.resolveHideCosts(apiSnap) {
+		t.Errorf("global=true should hide costs for openai")
+	}
+}

--- a/internal/tui/detail_hide_costs_test.go
+++ b/internal/tui/detail_hide_costs_test.go
@@ -26,6 +26,72 @@ func snapshotWithCosts() core.UsageSnapshot {
 	}
 }
 
+// snapshotWithBroadCostSurfaces seeds every $-rendering surface we care about:
+// compact rows (today/5h/7d/all-time), window_cost, model & provider mixes
+// (CostUSD), and a daily cost series. Exercises the full Dashboard render path.
+func snapshotWithBroadCostSurfaces() core.UsageSnapshot {
+	today := 670.86
+	block := 667.60
+	week := 670.86
+	allTime := 2750.0
+	wcost := 670.86
+	wreqs := 1889.0
+	wtoks := 5_300_000.0
+	burn := 3.26
+
+	mInput := 3_000_000.0
+	mOutput := 1_800_000.0
+	mReq := 1889.0
+	mCost := 667.60
+
+	costSeries := []core.TimePoint{
+		{Date: "2026-05-15", Value: 200.0},
+		{Date: "2026-05-16", Value: 200.0},
+		{Date: "2026-05-17", Value: 270.86},
+	}
+	reqSeries := []core.TimePoint{
+		{Date: "2026-05-15", Value: 600},
+		{Date: "2026-05-16", Value: 600},
+		{Date: "2026-05-17", Value: 689},
+	}
+	tokSeries := []core.TimePoint{
+		{Date: "2026-05-15", Value: 1_800_000},
+		{Date: "2026-05-16", Value: 1_800_000},
+		{Date: "2026-05-17", Value: 1_700_000},
+	}
+
+	return core.UsageSnapshot{
+		ProviderID: "claude_code",
+		AccountID:  "claude-code",
+		Status:     core.StatusOK,
+		Timestamp:  time.Now(),
+		Metrics: map[string]core.Metric{
+			"today_api_cost":    {Used: &today, Unit: "USD", Window: "3d"},
+			"5h_block_cost":     {Used: &block, Unit: "USD", Window: "5h"},
+			"7d_api_cost":       {Used: &week, Unit: "USD", Window: "7d"},
+			"all_time_api_cost": {Used: &allTime, Unit: "USD", Window: "all-time estimate"},
+			"window_cost":       {Used: &wcost, Unit: "USD", Window: "3d"},
+			"window_requests":   {Used: &wreqs, Unit: "requests", Window: "3d"},
+			"window_tokens":     {Used: &wtoks, Unit: "tokens", Window: "3d"},
+			"burn_rate":         {Used: &burn, Unit: "USD"},
+		},
+		ModelUsage: []core.ModelUsageRecord{{
+			RawModelID:   "claude-sonnet-4-5",
+			Canonical:    "claude-sonnet-4-5",
+			InputTokens:  &mInput,
+			OutputTokens: &mOutput,
+			Requests:     &mReq,
+			CostUSD:      &mCost,
+		}},
+		DailySeries: map[string][]core.TimePoint{
+			"analytics_cost":     costSeries,
+			"analytics_requests": reqSeries,
+			"analytics_tokens":   tokSeries,
+		},
+		Raw: map[string]string{"subscription": "active"},
+	}
+}
+
 func TestRenderDetailContent_HideCostsSuppressesDollars(t *testing.T) {
 	snap := snapshotWithCosts()
 
@@ -44,6 +110,51 @@ func TestRenderDetailContent_HideCostsSuppressesDollars(t *testing.T) {
 	}
 	if strings.Contains(hidden, "Forecast") {
 		t.Errorf("Forecast card should be suppressed")
+	}
+}
+
+// TestRenderDetailContent_HideCostsNoDollarSign is the comprehensive screenshot
+// guard: when hide-costs is on, the detail render of a snapshot bristling with
+// every $-rendering surface (compact rows, window cost, model/provider burn,
+// trends) must NOT contain a single literal "$" character.
+func TestRenderDetailContent_HideCostsNoDollarSign(t *testing.T) {
+	snap := snapshotWithBroadCostSurfaces()
+
+	// Sanity: in the SHOWN render at least one of the known $ values appears,
+	// so we know the test snapshot is actually wired into the render path.
+	shown := RenderDetailContent(snap, time.Now(), 140, 0.20, 0.05, 0, core.TimeWindow30d, false)
+	sawAny := false
+	for _, want := range []string{"$670.86", "$667.60", "$2750", "$3.26"} {
+		if strings.Contains(shown, want) {
+			sawAny = true
+			break
+		}
+	}
+	if !sawAny {
+		t.Fatalf("test fixture does not surface any expected $ values when shown — fixture is wrong, not the gating")
+	}
+
+	hidden := RenderDetailContent(snap, time.Now(), 140, 0.20, 0.05, 0, core.TimeWindow30d, true)
+
+	// No literal "$" character anywhere in the hide-costs render. This catches
+	// any new render site that emits dollars without going through the gating.
+	if idx := strings.Index(hidden, "$"); idx >= 0 {
+		start := idx - 40
+		if start < 0 {
+			start = 0
+		}
+		end := idx + 40
+		if end > len(hidden) {
+			end = len(hidden)
+		}
+		t.Fatalf("hide-costs render still contains $ at index %d: …%q…", idx, hidden[start:end])
+	}
+
+	// Belt and braces: none of the specific values should appear.
+	for _, want := range []string{"670.86", "667.60", "2750", "3.26"} {
+		if strings.Contains(hidden, want) {
+			t.Errorf("hide-costs render contains %q (should be suppressed)", want)
+		}
 	}
 }
 

--- a/internal/tui/detail_sections.go
+++ b/internal/tui/detail_sections.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/janekbaraniewski/openusage/internal/core"
@@ -12,7 +13,7 @@ import (
 // Sections are filtered and ordered according to effectiveDetailSectionOrder().
 //
 // hideCosts suppresses the Spending and Forecast cards entirely.
-func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w int, warnThresh, critThresh float64, timeWindow core.TimeWindow, hideCosts bool) []detailSection {
+func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w int, warnThresh, critThresh float64, timeWindow core.TimeWindow, hideCosts bool, now time.Time) []detailSection {
 	innerW := w - 8 // card borders + margins + padding
 	if innerW < 30 {
 		innerW = 30
@@ -22,7 +23,7 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 	candidates := make(map[core.DetailStandardSection][]detailSection)
 
 	// 1. Usage Overview — gauges and key metrics (NO summary/detail text — that's in compact header).
-	if usageLines := buildDetailUsageSection(snap, widget, innerW, warnThresh, critThresh, hideCosts); len(usageLines) > 0 {
+	if usageLines := buildDetailUsageSection(snap, widget, innerW, warnThresh, critThresh, hideCosts, now); len(usageLines) > 0 {
 		candidates[core.DetailSectionUsage] = append(candidates[core.DetailSectionUsage],
 			detailSection{id: "Usage", title: "Usage", icon: "⚡", color: colorYellow, lines: usageLines})
 	}
@@ -181,11 +182,11 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 
 // buildDetailUsageSection builds the usage overview — gauges + compact metrics.
 // Does NOT include summary/detail text (that's in the compact header now).
-func buildDetailUsageSection(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, warnThresh, critThresh float64, hideCosts bool) []string {
+func buildDetailUsageSection(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, warnThresh, critThresh float64, hideCosts bool, now time.Time) []string {
 	var lines []string
 
 	// Usage gauge bars.
-	gaugeLines := buildDetailGaugeLines(snap, widget, innerW, warnThresh, critThresh)
+	gaugeLines := buildDetailGaugeLines(snap, widget, innerW, warnThresh, critThresh, now)
 	lines = append(lines, gaugeLines...)
 
 	// Compact metric summary rows (credits, messages, sessions, etc.).
@@ -201,7 +202,7 @@ func buildDetailUsageSection(snap core.UsageSnapshot, widget core.DashboardWidge
 }
 
 // buildDetailGaugeLines builds gauge bars for the detail view.
-func buildDetailGaugeLines(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, warnThresh, critThresh float64) []string {
+func buildDetailGaugeLines(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, warnThresh, critThresh float64, now time.Time) []string {
 	maxLabelW := 18
 	gaugeW := innerW - maxLabelW - 10
 	if gaugeW < 8 {
@@ -241,7 +242,30 @@ func buildDetailGaugeLines(snap core.UsageSnapshot, widget core.DashboardWidget,
 		if len(label) > maxLabelW {
 			label = label[:maxLabelW-1] + "…"
 		}
-		gauge := RenderUsageGauge(usedPct, gaugeW, warnThresh, critThresh)
+
+		// Compute optional projection annotation for windowed usage gauges
+		// (5h / 7d / similar). pace = current% / elapsed_minutes / 100.
+		var gauge string
+		if windowDur, ok := gaugeWindowDuration(met.Window); ok {
+			if resetAt, hasReset := snap.Resets[key]; hasReset {
+				resetIn := resetAt.Sub(now)
+				elapsed := windowDur - resetIn
+				var paceFraction float64
+				if elapsed > 0 && usedPct > 0 {
+					elapsedMin := elapsed.Minutes()
+					if elapsedMin > 0 {
+						// fraction-of-window per minute
+						paceFraction = (usedPct / 100) / elapsedMin
+					}
+				}
+				gauge = RenderUsageGaugeWithProjection(usedPct, gaugeW, warnThresh, critThresh, paceFraction, resetIn)
+			} else {
+				gauge = RenderUsageGauge(usedPct, gaugeW, warnThresh, critThresh)
+			}
+		} else {
+			gauge = RenderUsageGauge(usedPct, gaugeW, warnThresh, critThresh)
+		}
+
 		labelR := lipgloss.NewStyle().Foreground(colorSubtext).Width(maxLabelW).Render(label)
 		lines = append(lines, labelR+" "+gauge)
 		if len(lines) >= maxLines {
@@ -249,6 +273,23 @@ func buildDetailGaugeLines(snap core.UsageSnapshot, widget core.DashboardWidget,
 		}
 	}
 	return lines
+}
+
+// gaugeWindowDuration returns the duration of a windowed metric (5h / 7d / 1d
+// / 30d) so projection math can compute elapsed time. Returns (0, false) when
+// the window string isn't recognized — in that case we render the plain gauge.
+func gaugeWindowDuration(window string) (time.Duration, bool) {
+	switch strings.ToLower(strings.TrimSpace(window)) {
+	case "5h":
+		return 5 * time.Hour, true
+	case "1d", "24h", "today":
+		return 24 * time.Hour, true
+	case "7d":
+		return 7 * 24 * time.Hour, true
+	case "30d":
+		return 30 * 24 * time.Hour, true
+	}
+	return 0, false
 }
 
 // buildDetailCostSection builds spending/credit summary with projections.

--- a/internal/tui/detail_sections.go
+++ b/internal/tui/detail_sections.go
@@ -10,7 +10,9 @@ import (
 
 // buildDetailSections constructs all dashboard-style sections for the detail view.
 // Sections are filtered and ordered according to effectiveDetailSectionOrder().
-func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w int, warnThresh, critThresh float64, timeWindow core.TimeWindow) []detailSection {
+//
+// hideCosts suppresses the Spending and Forecast cards entirely.
+func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w int, warnThresh, critThresh float64, timeWindow core.TimeWindow, hideCosts bool) []detailSection {
 	innerW := w - 8 // card borders + margins + padding
 	if innerW < 30 {
 		innerW = 30
@@ -25,10 +27,14 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 			detailSection{id: "Usage", title: "Usage", icon: "⚡", color: colorYellow, lines: usageLines})
 	}
 
-	// 2. Cost & Credits — spending summary with projections.
-	if costLines := buildDetailCostSection(snap, widget, innerW); len(costLines) > 0 {
-		candidates[core.DetailSectionSpending] = append(candidates[core.DetailSectionSpending],
-			detailSection{id: "Cost", title: "Spending", icon: "💰", color: colorTeal, lines: costLines})
+	// 2. Cost & Credits — spending summary with projections. Suppressed when
+	// hide-costs is on so subscription users don't see misleading
+	// API-equivalent dollar figures.
+	if !hideCosts {
+		if costLines := buildDetailCostSection(snap, widget, innerW); len(costLines) > 0 {
+			candidates[core.DetailSectionSpending] = append(candidates[core.DetailSectionSpending],
+				detailSection{id: "Cost", title: "Spending", icon: "💰", color: colorTeal, lines: costLines})
+		}
 	}
 
 	// 3. Model Burn — composition bar with per-model breakdown + token detail.
@@ -124,10 +130,13 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 			detailSection{id: "Cost", title: "Providers", lines: vendorLines, hasOwnHeader: true})
 	}
 
-	// 13. Budget projection (detail-only data).
-	if projLines := buildDetailProjectionSection(snap, innerW); len(projLines) > 0 {
-		candidates[core.DetailSectionForecast] = append(candidates[core.DetailSectionForecast],
-			detailSection{id: "Cost", title: "Forecast", icon: "📊", color: colorSapphire, lines: projLines})
+	// 13. Budget projection (detail-only data). Suppressed when hide-costs
+	// is on because every line is denominated in dollars/hours-of-credits.
+	if !hideCosts {
+		if projLines := buildDetailProjectionSection(snap, innerW); len(projLines) > 0 {
+			candidates[core.DetailSectionForecast] = append(candidates[core.DetailSectionForecast],
+				detailSection{id: "Cost", title: "Forecast", icon: "📊", color: colorSapphire, lines: projLines})
+		}
 	}
 
 	// 14. Other metrics as dot-leader rows.

--- a/internal/tui/detail_sections.go
+++ b/internal/tui/detail_sections.go
@@ -39,7 +39,7 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 	}
 
 	// 3. Model Burn — composition bar with per-model breakdown + token detail.
-	if modelLines, _ := buildProviderModelCompositionLines(snap, innerW, true); len(modelLines) > 0 {
+	if modelLines, _ := buildProviderModelCompositionLinesWithHide(snap, innerW, true, hideCosts); len(modelLines) > 0 {
 		// Add per-model token breakdown if available.
 		models := core.ExtractAnalyticsModelUsage(snap)
 		for _, model := range models {
@@ -102,15 +102,18 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 	}
 
 	// 10. Daily Usage & Trends (with zoom support).
-	if trendLines := buildDetailTrendsSection(snap, widget, innerW, timeWindow); len(trendLines) > 0 {
+	if trendLines := buildDetailTrendsSectionWithHide(snap, widget, innerW, timeWindow, hideCosts); len(trendLines) > 0 {
 		candidates[core.DetailSectionTrends] = append(candidates[core.DetailSectionTrends],
 			detailSection{id: "Trends", title: "Trends", lines: trendLines, hasOwnHeader: true})
 	}
 
-	// 10b. Dual-axis cost + requests overlay (detail-only).
-	if dualLines := buildDetailDualAxisChart(snap, widget, innerW, timeWindow); len(dualLines) > 0 {
-		candidates[core.DetailSectionCostRequests] = append(candidates[core.DetailSectionCostRequests],
-			detailSection{id: "Trends", title: "Overview", lines: dualLines, hasOwnHeader: true})
+	// 10b. Dual-axis cost + requests overlay (detail-only). Skipped entirely
+	// when hide-costs is on — the cost axis is the whole point.
+	if !hideCosts {
+		if dualLines := buildDetailDualAxisChart(snap, widget, innerW, timeWindow); len(dualLines) > 0 {
+			candidates[core.DetailSectionCostRequests] = append(candidates[core.DetailSectionCostRequests],
+				detailSection{id: "Trends", title: "Overview", lines: dualLines, hasOwnHeader: true})
+		}
 	}
 
 	// 10c. Activity Heatmap.
@@ -120,13 +123,13 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 	}
 
 	// 11. Upstream / Hosting Providers.
-	if upstreamLines, _ := buildUpstreamProviderCompositionLines(snap, innerW, true); len(upstreamLines) > 0 {
+	if upstreamLines, _ := buildUpstreamProviderCompositionLinesWithHide(snap, innerW, true, hideCosts); len(upstreamLines) > 0 {
 		candidates[core.DetailSectionUpstream] = append(candidates[core.DetailSectionUpstream],
 			detailSection{id: "Cost", title: "Hosting", lines: upstreamLines, hasOwnHeader: true})
 	}
 
 	// 12. Provider Burn (vendor breakdown).
-	if vendorLines, _ := buildProviderVendorCompositionLines(snap, innerW, true); len(vendorLines) > 0 {
+	if vendorLines, _ := buildProviderVendorCompositionLinesWithHide(snap, innerW, true, hideCosts); len(vendorLines) > 0 {
 		candidates[core.DetailSectionProviderBurn] = append(candidates[core.DetailSectionProviderBurn],
 			detailSection{id: "Cost", title: "Providers", lines: vendorLines, hasOwnHeader: true})
 	}
@@ -508,7 +511,7 @@ func buildDetailOtherMetrics(snap core.UsageSnapshot, widget core.DashboardWidge
 	for k := range compactKeys {
 		skipKeys[k] = true
 	}
-	_, modelKeys := buildProviderModelCompositionLines(snap, innerW, true)
+	_, modelKeys := buildProviderModelCompositionLinesWithHide(snap, innerW, true, hideCosts)
 	for k := range modelKeys {
 		skipKeys[k] = true
 	}

--- a/internal/tui/detail_sections.go
+++ b/internal/tui/detail_sections.go
@@ -22,7 +22,7 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 	candidates := make(map[core.DetailStandardSection][]detailSection)
 
 	// 1. Usage Overview — gauges and key metrics (NO summary/detail text — that's in compact header).
-	if usageLines := buildDetailUsageSection(snap, widget, innerW, warnThresh, critThresh); len(usageLines) > 0 {
+	if usageLines := buildDetailUsageSection(snap, widget, innerW, warnThresh, critThresh, hideCosts); len(usageLines) > 0 {
 		candidates[core.DetailSectionUsage] = append(candidates[core.DetailSectionUsage],
 			detailSection{id: "Usage", title: "Usage", icon: "⚡", color: colorYellow, lines: usageLines})
 	}
@@ -140,7 +140,7 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 	}
 
 	// 14. Other metrics as dot-leader rows.
-	if otherLines := buildDetailOtherMetrics(snap, widget, innerW); len(otherLines) > 0 {
+	if otherLines := buildDetailOtherMetrics(snap, widget, innerW, hideCosts); len(otherLines) > 0 {
 		candidates[core.DetailSectionOtherData] = append(candidates[core.DetailSectionOtherData],
 			detailSection{id: "Usage", title: "Other Data", icon: "›", color: colorDim, lines: otherLines})
 	}
@@ -181,7 +181,7 @@ func buildDetailSections(snap core.UsageSnapshot, widget core.DashboardWidget, w
 
 // buildDetailUsageSection builds the usage overview — gauges + compact metrics.
 // Does NOT include summary/detail text (that's in the compact header now).
-func buildDetailUsageSection(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, warnThresh, critThresh float64) []string {
+func buildDetailUsageSection(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, warnThresh, critThresh float64, hideCosts bool) []string {
 	var lines []string
 
 	// Usage gauge bars.
@@ -189,7 +189,7 @@ func buildDetailUsageSection(snap core.UsageSnapshot, widget core.DashboardWidge
 	lines = append(lines, gaugeLines...)
 
 	// Compact metric summary rows (credits, messages, sessions, etc.).
-	compactLines, _ := buildTileCompactMetricSummaryLines(snap, widget, innerW)
+	compactLines, _ := buildTileCompactMetricSummaryLinesWithHide(snap, widget, innerW, hideCosts)
 	if len(compactLines) > 0 {
 		if len(lines) > 0 {
 			lines = append(lines, "")
@@ -443,7 +443,7 @@ func buildDetailLanguageLines(snap core.UsageSnapshot, innerW int) []string {
 }
 
 // buildDetailOtherMetrics renders remaining metrics not covered by other sections.
-func buildDetailOtherMetrics(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int) []string {
+func buildDetailOtherMetrics(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, hideCosts bool) []string {
 	if len(snap.Metrics) == 0 {
 		return nil
 	}
@@ -463,7 +463,7 @@ func buildDetailOtherMetrics(snap core.UsageSnapshot, widget core.DashboardWidge
 		skipKeys[ck] = true
 	}
 
-	_, compactKeys := buildTileCompactMetricSummaryLines(snap, widget, innerW)
+	_, compactKeys := buildTileCompactMetricSummaryLinesWithHide(snap, widget, innerW, hideCosts)
 	for k := range compactKeys {
 		skipKeys[k] = true
 	}
@@ -495,6 +495,9 @@ func buildDetailOtherMetrics(snap core.UsageSnapshot, widget core.DashboardWidge
 			continue
 		}
 		met := snap.Metrics[key]
+		if hideCosts && isMonetaryMetricKey(key, met) {
+			continue
+		}
 		if !core.IncludeDetailMetricKey(key) {
 			continue
 		}

--- a/internal/tui/detail_sections.go
+++ b/internal/tui/detail_sections.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/samber/lo"
 )
 
 // buildDetailSections constructs all dashboard-style sections for the detail view.
@@ -225,10 +226,9 @@ func buildDetailGaugeLines(snap core.UsageSnapshot, widget core.DashboardWidget,
 
 	var gaugeAllowSet map[string]bool
 	if len(widget.GaugePriority) > 0 {
-		gaugeAllowSet = make(map[string]bool, len(widget.GaugePriority))
-		for _, k := range widget.GaugePriority {
-			gaugeAllowSet[k] = true
-		}
+		gaugeAllowSet = lo.SliceToMap(widget.GaugePriority, func(k string) (string, bool) {
+			return k, true
+		})
 	}
 
 	var lines []string
@@ -246,27 +246,23 @@ func buildDetailGaugeLines(snap core.UsageSnapshot, widget core.DashboardWidget,
 			label = label[:maxLabelW-1] + "…"
 		}
 
-		// Compute optional projection annotation for windowed usage gauges
-		// (5h / 7d / similar). pace = current% / elapsed_minutes / 100.
-		var gauge string
-		if windowDur, ok := gaugeWindowDuration(met.Window); ok {
-			if resetAt, hasReset := snap.Resets[key]; hasReset {
-				resetIn := resetAt.Sub(now)
-				elapsed := windowDur - resetIn
-				var paceFraction float64
-				if elapsed > 0 && usedPct > 0 {
-					elapsedMin := elapsed.Minutes()
-					if elapsedMin > 0 {
-						// fraction-of-window per minute
-						paceFraction = (usedPct / 100) / elapsedMin
-					}
+		// Render the projection variant only when the metric has a recognized
+		// window AND a reset timestamp; otherwise fall back to the plain
+		// gauge. Pace = current% / elapsed_minutes / 100.
+		gauge := RenderUsageGauge(usedPct, gaugeW, warnThresh, critThresh)
+		windowDur, hasWindow := gaugeWindowDuration(met.Window)
+		resetAt, hasReset := snap.Resets[key]
+		if hasWindow && hasReset {
+			resetIn := resetAt.Sub(now)
+			elapsed := windowDur - resetIn
+			var paceFraction float64
+			if elapsed > 0 && usedPct > 0 {
+				if elapsedMin := elapsed.Minutes(); elapsedMin > 0 {
+					// fraction-of-window per minute
+					paceFraction = (usedPct / 100) / elapsedMin
 				}
-				gauge = RenderUsageGaugeWithProjection(usedPct, gaugeW, warnThresh, critThresh, paceFraction, resetIn)
-			} else {
-				gauge = RenderUsageGauge(usedPct, gaugeW, warnThresh, critThresh)
 			}
-		} else {
-			gauge = RenderUsageGauge(usedPct, gaugeW, warnThresh, critThresh)
+			gauge = RenderUsageGaugeWithProjection(usedPct, gaugeW, warnThresh, critThresh, paceFraction, resetIn)
 		}
 
 		labelR := lipgloss.NewStyle().Foreground(colorSubtext).Width(maxLabelW).Render(label)
@@ -276,23 +272,6 @@ func buildDetailGaugeLines(snap core.UsageSnapshot, widget core.DashboardWidget,
 		}
 	}
 	return lines
-}
-
-// gaugeWindowDuration returns the duration of a windowed metric (5h / 7d / 1d
-// / 30d) so projection math can compute elapsed time. Returns (0, false) when
-// the window string isn't recognized — in that case we render the plain gauge.
-func gaugeWindowDuration(window string) (time.Duration, bool) {
-	switch strings.ToLower(strings.TrimSpace(window)) {
-	case "5h":
-		return 5 * time.Hour, true
-	case "1d", "24h", "today":
-		return 24 * time.Hour, true
-	case "7d":
-		return 7 * 24 * time.Hour, true
-	case "30d":
-		return 30 * 24 * time.Hour, true
-	}
-	return 0, false
 }
 
 // buildDetailCostSection builds spending/credit summary with projections.

--- a/internal/tui/detail_trends.go
+++ b/internal/tui/detail_trends.go
@@ -22,10 +22,16 @@ func cropSeriesToWindow(pts []core.TimePoint, window core.TimeWindow) []core.Tim
 // Unlike the tile view which shows one chart + sparklines, the detail view
 // renders a full Braille chart for EACH available data series.
 func buildDetailTrendsSection(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, timeWindow core.TimeWindow) []string {
+	return buildDetailTrendsSectionWithHide(snap, widget, innerW, timeWindow, false)
+}
+
+// buildDetailTrendsSectionWithHide is the hide-costs-aware variant. The Cost
+// sparkline and Cost full chart are suppressed when hideCosts is true.
+func buildDetailTrendsSectionWithHide(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, timeWindow core.TimeWindow, hideCosts bool) []string {
 	var lines []string
 
 	// Daily usage sparkline summary (compact overview).
-	dailyLines := buildProviderDailyTrendLines(snap, innerW)
+	dailyLines := buildProviderDailyTrendLinesWithHide(snap, innerW, hideCosts)
 	lines = append(lines, dailyLines...)
 
 	// Render a separate chart for each available series.
@@ -40,6 +46,10 @@ func buildDetailTrendsSection(snap core.UsageSnapshot, widget core.DashboardWidg
 		{keys: []string{"analytics_tokens", "tokens_total"}, label: "Tokens", yFmt: formatChartValue, color: colorSapphire},
 		{keys: []string{"messages"}, label: "Messages", yFmt: formatChartValue, color: colorGreen},
 		{keys: []string{"sessions"}, label: "Sessions", yFmt: formatChartValue, color: colorPeach},
+	}
+	if hideCosts {
+		// Drop the cost chart entirely — yFmt renders $-prefixed Y-axis ticks.
+		seriesCandidates = seriesCandidates[1:]
 	}
 
 	chartW := innerW - 4

--- a/internal/tui/detail_trends.go
+++ b/internal/tui/detail_trends.go
@@ -25,8 +25,7 @@ func buildDetailTrendsSection(snap core.UsageSnapshot, widget core.DashboardWidg
 	return buildDetailTrendsSectionWithHide(snap, widget, innerW, timeWindow, false)
 }
 
-// buildDetailTrendsSectionWithHide is the hide-costs-aware variant. The Cost
-// sparkline and Cost full chart are suppressed when hideCosts is true.
+// The Cost sparkline and Cost full chart are suppressed when hideCosts is true.
 func buildDetailTrendsSectionWithHide(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, timeWindow core.TimeWindow, hideCosts bool) []string {
 	var lines []string
 

--- a/internal/tui/gauge.go
+++ b/internal/tui/gauge.go
@@ -2,7 +2,9 @@ package tui
 
 import (
 	"fmt"
+	"math"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -84,6 +86,80 @@ func RenderGauge(percent float64, width int, warnThresh, critThresh float64) str
 func RenderUsageGauge(usedPercent float64, width int, warnThresh, critThresh float64) string {
 	color := usageGaugeColor(usedPercent, warnThresh, critThresh)
 	return renderGaugeWithLabel(usedPercent, width, color)
+}
+
+// RenderUsageGaugeWithProjection renders a usage gauge with an optional dim
+// annotation line below it showing time-until-reset and/or projected time to
+// 100% based on the supplied pace.
+//
+// paceFraction is the fraction of the window consumed per minute (so 0.005
+// means 0.5% per minute). The caller computes it from current% and elapsed.
+// resetIn is the time remaining until the window resets; zero or negative
+// values suppress the reset half of the annotation.
+//
+// The annotation is skipped (plain gauge returned) when:
+//   - paceFraction is NaN, ±Inf, or <= 0
+//   - usedPercent >= 100 (already at limit, projection is meaningless)
+//
+// If only one of {reset, projection} is meaningful, only that piece renders.
+func RenderUsageGaugeWithProjection(usedPercent float64, width int, warnThresh, critThresh float64, paceFraction float64, resetIn time.Duration) string {
+	gauge := RenderUsageGauge(usedPercent, width, warnThresh, critThresh)
+
+	resetPart := ""
+	if resetIn > 0 {
+		resetPart = "resets in " + formatDurationShort(resetIn)
+	}
+
+	projPart := ""
+	paceValid := !math.IsNaN(paceFraction) && !math.IsInf(paceFraction, 0) && paceFraction > 0
+	if paceValid && usedPercent < 100 {
+		remainingPct := 100 - usedPercent
+		// paceFraction is fraction-per-minute, convert to %-per-minute.
+		pctPerMinute := paceFraction * 100
+		if pctPerMinute > 0 {
+			minutesTo100 := remainingPct / pctPerMinute
+			d := time.Duration(minutesTo100 * float64(time.Minute))
+			if d > 0 {
+				projPart = "projected 100% in " + formatDurationShort(d)
+			}
+		}
+	}
+
+	if resetPart == "" && projPart == "" {
+		return gauge
+	}
+
+	var annotation string
+	switch {
+	case resetPart != "" && projPart != "":
+		annotation = resetPart + " · " + projPart
+	case resetPart != "":
+		annotation = resetPart
+	default:
+		annotation = projPart
+	}
+
+	return gauge + "\n" + dimStyle.Render(annotation)
+}
+
+// formatDurationShort renders a duration as a compact human string like
+// "1h 23m" or "42m" or "5s". Used by gauge projections / reset countdowns.
+func formatDurationShort(d time.Duration) string {
+	if d <= 0 {
+		return "0m"
+	}
+	if d >= time.Hour {
+		h := int(d / time.Hour)
+		m := int((d % time.Hour) / time.Minute)
+		if m == 0 {
+			return fmt.Sprintf("%dh", h)
+		}
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+	if d >= time.Minute {
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	}
+	return fmt.Sprintf("%ds", int(d/time.Second))
 }
 
 func RenderMiniGauge(usedPercent float64, width int) string {

--- a/internal/tui/gauge.go
+++ b/internal/tui/gauge.go
@@ -102,6 +102,11 @@ func RenderUsageGauge(usedPercent float64, width int, warnThresh, critThresh flo
 //   - usedPercent >= 100 (already at limit, projection is meaningless)
 //
 // If only one of {reset, projection} is meaningful, only that piece renders.
+//
+// When the projected time to 100% exceeds the time remaining in the window,
+// the projection half switches from "projected 100% in X" to "projected
+// ~N% by reset", where N is the linearly extrapolated percent at reset
+// (capped at 99 so the wording never contradicts the branch).
 func RenderUsageGaugeWithProjection(usedPercent float64, width int, warnThresh, critThresh float64, paceFraction float64, resetIn time.Duration) string {
 	gauge := RenderUsageGauge(usedPercent, width, warnThresh, critThresh)
 
@@ -120,7 +125,24 @@ func RenderUsageGaugeWithProjection(usedPercent float64, width int, warnThresh, 
 			minutesTo100 := remainingPct / pctPerMinute
 			d := time.Duration(minutesTo100 * float64(time.Minute))
 			if d > 0 {
-				projPart = "projected 100% in " + formatDurationShort(d)
+				// If the window will reset before we project hitting 100%,
+				// show the projected percent at reset instead of an
+				// impossible "100% in X" claim that overshoots the window.
+				if resetIn > 0 && d > resetIn {
+					projectedPct := usedPercent + pctPerMinute*resetIn.Minutes()
+					n := int(math.Round(projectedPct))
+					if n < 0 {
+						n = 0
+					}
+					// Cap below 100 so this branch never contradicts itself
+					// by claiming the projection somehow lands at 100%.
+					if n >= 100 {
+						n = 99
+					}
+					projPart = fmt.Sprintf("projected ~%d%% by reset", n)
+				} else {
+					projPart = "projected 100% in " + formatDurationShort(d)
+				}
 			}
 		}
 	}

--- a/internal/tui/gauge.go
+++ b/internal/tui/gauge.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/samber/lo"
 )
 
 var blockChars = []string{" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉"}
@@ -147,21 +148,35 @@ func RenderUsageGaugeWithProjection(usedPercent float64, width int, warnThresh, 
 		}
 	}
 
-	if resetPart == "" && projPart == "" {
+	annotation := joinAnnotationParts(resetPart, projPart)
+	if annotation == "" {
 		return gauge
 	}
-
-	var annotation string
-	switch {
-	case resetPart != "" && projPart != "":
-		annotation = resetPart + " · " + projPart
-	case resetPart != "":
-		annotation = resetPart
-	default:
-		annotation = projPart
-	}
-
 	return gauge + "\n" + dimStyle.Render(annotation)
+}
+
+// joinAnnotationParts joins non-empty annotation fragments with " · ", dropping
+// any empty entries. Used by gauge renderers that compose a dim
+// "resets … · projected …" line from independently-computed parts.
+func joinAnnotationParts(parts ...string) string {
+	return strings.Join(lo.Compact(parts), " · ")
+}
+
+// gaugeWindowDuration returns the duration of a windowed metric (5h / 7d / 1d
+// / 30d) so projection math can compute elapsed time. Returns (0, false) when
+// the window string isn't recognized — in that case we render the plain gauge.
+func gaugeWindowDuration(window string) (time.Duration, bool) {
+	switch strings.ToLower(strings.TrimSpace(window)) {
+	case "5h":
+		return 5 * time.Hour, true
+	case "1d", "24h", "today":
+		return 24 * time.Hour, true
+	case "7d":
+		return 7 * 24 * time.Hour, true
+	case "30d":
+		return 30 * 24 * time.Hour, true
+	}
+	return 0, false
 }
 
 // formatDurationShort renders a duration as a compact human string like

--- a/internal/tui/gauge_test.go
+++ b/internal/tui/gauge_test.go
@@ -26,10 +26,10 @@ func TestRenderUsageGaugeWithProjection(t *testing.T) {
 		wantNotContain []string
 	}{
 		{
-			name:         "happy_path",
-			usedPercent:  usedPercent,
-			paceFraction: 0.05, // 5%/min → 100% in 10m, well inside the 30m window
-			resetIn:      resetIn,
+			name:           "happy_path",
+			usedPercent:    usedPercent,
+			paceFraction:   0.05, // 5%/min → 100% in 10m, well inside the 30m window
+			resetIn:        resetIn,
 			wantContains:   []string{"resets in", "projected 100% in"},
 			wantNotContain: []string{"by reset"},
 		},

--- a/internal/tui/gauge_test.go
+++ b/internal/tui/gauge_test.go
@@ -28,9 +28,45 @@ func TestRenderUsageGaugeWithProjection(t *testing.T) {
 		{
 			name:         "happy_path",
 			usedPercent:  usedPercent,
-			paceFraction: 0.01,
+			paceFraction: 0.05, // 5%/min → 100% in 10m, well inside the 30m window
 			resetIn:      resetIn,
-			wantContains: []string{"resets in", "projected"},
+			wantContains:   []string{"resets in", "projected 100% in"},
+			wantNotContain: []string{"by reset"},
+		},
+		{
+			// Pace would overshoot the window: 1%/min, 50% remaining → 50m to
+			// 100%, but only 30m to reset. Should switch to "~N% by reset".
+			name:           "overshoots_window",
+			usedPercent:    usedPercent,
+			paceFraction:   0.01,
+			resetIn:        resetIn,
+			wantContains:   []string{"resets in", "projected ~80% by reset"},
+			wantNotContain: []string{"100% in"},
+		},
+		{
+			// Pace exactly hits reset: 50% used, 50% remaining, 1%/min,
+			// 50m to 100%, resetIn=50m → projected time == reset time, so
+			// we keep the "100% in" wording (only > triggers the switch).
+			name:           "projection_equals_reset",
+			usedPercent:    usedPercent,
+			paceFraction:   0.01,
+			resetIn:        50 * time.Minute,
+			wantContains:   []string{"resets in", "projected 100% in"},
+			wantNotContain: []string{"by reset"},
+		},
+		{
+			// Edge case: projected % at reset rounds up to 100, but the
+			// branch should never claim "~100% by reset" (it would
+			// contradict why we picked this branch in the first place).
+			// minutesTo100 = 90/1.499 ≈ 60.04m > resetIn (60m) → branch
+			// taken; projectedPct = 10 + 1.499*60 = 99.94 → rounds to 100
+			// → capped to 99.
+			name:           "by_reset_caps_below_100",
+			usedPercent:    10.0,
+			paceFraction:   0.01499,
+			resetIn:        60 * time.Minute,
+			wantContains:   []string{"resets in", "projected ~99% by reset"},
+			wantNotContain: []string{"~100%", "100% in"},
 		},
 		{
 			name:           "nan_pace",

--- a/internal/tui/gauge_test.go
+++ b/internal/tui/gauge_test.go
@@ -1,11 +1,121 @@
 package tui
 
 import (
+	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 )
+
+func TestRenderUsageGaugeWithProjection(t *testing.T) {
+	const usedPercent = 50.0
+	const overLimitPercent = 100.0
+	const width = 20
+	const warn = 0.30
+	const crit = 0.15
+	resetIn := 30 * time.Minute
+
+	cases := []struct {
+		name           string
+		usedPercent    float64
+		paceFraction   float64
+		resetIn        time.Duration
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:         "happy_path",
+			usedPercent:  usedPercent,
+			paceFraction: 0.01,
+			resetIn:      resetIn,
+			wantContains: []string{"resets in", "projected"},
+		},
+		{
+			name:           "nan_pace",
+			usedPercent:    usedPercent,
+			paceFraction:   math.NaN(),
+			resetIn:        resetIn,
+			wantContains:   []string{"resets in"},
+			wantNotContain: []string{"projected"},
+		},
+		{
+			name:           "inf_pace",
+			usedPercent:    usedPercent,
+			paceFraction:   math.Inf(1),
+			resetIn:        resetIn,
+			wantContains:   []string{"resets in"},
+			wantNotContain: []string{"projected"},
+		},
+		{
+			name:           "zero_pace",
+			usedPercent:    usedPercent,
+			paceFraction:   0,
+			resetIn:        resetIn,
+			wantContains:   []string{"resets in"},
+			wantNotContain: []string{"projected"},
+		},
+		{
+			name:           "negative_pace",
+			usedPercent:    usedPercent,
+			paceFraction:   -0.5,
+			resetIn:        resetIn,
+			wantContains:   []string{"resets in"},
+			wantNotContain: []string{"projected"},
+		},
+		{
+			name:           "over_limit",
+			usedPercent:    overLimitPercent,
+			paceFraction:   0.01,
+			resetIn:        resetIn,
+			wantContains:   []string{"resets in"},
+			wantNotContain: []string{"projected"},
+		},
+		{
+			name:           "reset_only",
+			usedPercent:    usedPercent,
+			paceFraction:   0,
+			resetIn:        resetIn,
+			wantContains:   []string{"resets in"},
+			wantNotContain: []string{"projected"},
+		},
+		{
+			name:           "pace_only",
+			usedPercent:    usedPercent,
+			paceFraction:   0.01,
+			resetIn:        0,
+			wantContains:   []string{"projected"},
+			wantNotContain: []string{"resets in"},
+		},
+		{
+			name:           "neither",
+			usedPercent:    usedPercent,
+			paceFraction:   0,
+			resetIn:        0,
+			wantNotContain: []string{"resets in", "projected"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := RenderUsageGaugeWithProjection(tc.usedPercent, width, warn, crit, tc.paceFraction, tc.resetIn)
+			if out == "" {
+				t.Fatal("expected non-empty output")
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected output to contain %q, got %q", want, out)
+				}
+			}
+			for _, notWant := range tc.wantNotContain {
+				if strings.Contains(out, notWant) {
+					t.Errorf("expected output to NOT contain %q, got %q", notWant, out)
+				}
+			}
+		})
+	}
+}
 
 func TestRenderStackedUsageGauge_TwoSegments(t *testing.T) {
 	segments := []GaugeSegment{

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -146,6 +146,7 @@ func (m Model) renderHelpOverlay(screenW, screenH int) string {
 		struct{ key, desc string }{"r", "Refresh"},
 		struct{ key, desc string }{"t", "Cycle theme"},
 		struct{ key, desc string }{"w", "Cycle time window"},
+		struct{ key, desc string }{"c", "toggle hide-costs for focused account (auto/hide/show)"},
 	)
 
 	groups := []keyGroup{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -163,6 +163,7 @@ type browserPickerState struct {
 type Services interface {
 	SaveTheme(themeName string) error
 	SaveDashboardProviders(providers []config.DashboardProviderConfig) error
+	SaveDashboardProviderHideCosts(accountID string, hide *bool) error
 	SaveDashboardView(view string) error
 	SaveDashboardWidgetSections(sections []config.DashboardWidgetSection) error
 	SaveDetailWidgetSections(sections []config.DetailWidgetSection) error
@@ -320,6 +321,10 @@ type themePersistedMsg struct {
 }
 type dashboardPrefsPersistedMsg struct {
 	err error
+}
+type dashboardProviderHideCostsPersistedMsg struct {
+	accountID string
+	err       error
 }
 type dashboardViewPersistedMsg struct {
 	err error
@@ -565,6 +570,33 @@ func (m Model) resolveHideCosts(snap core.UsageSnapshot) bool {
 		perAccount = m.hideCostsByAccount[snap.AccountID]
 	}
 	return core.ResolveHideCosts(snap, perAccount, m.hideCostsGlobal)
+}
+
+// cycleHideCostsOverride advances the per-account hide_costs override through
+// the tristate auto (nil) → hide (true) → show (false) → auto (nil) cycle for
+// the given accountID. Returns the new override pointer value.
+func (m *Model) cycleHideCostsOverride(accountID string) *bool {
+	if m.hideCostsByAccount == nil {
+		m.hideCostsByAccount = make(map[string]*bool)
+	}
+	current := m.hideCostsByAccount[accountID]
+	var next *bool
+	switch {
+	case current == nil:
+		t := true
+		next = &t
+	case *current:
+		f := false
+		next = &f
+	default:
+		next = nil
+	}
+	if next == nil {
+		delete(m.hideCostsByAccount, accountID)
+	} else {
+		m.hideCostsByAccount[accountID] = next
+	}
+	return next
 }
 
 func (m *Model) ensureSnapshotProvidersKnown() {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -239,6 +239,13 @@ type Model struct {
 	detailWidgetSections   []config.DetailWidgetSection
 	hideSectionsWithNoData bool
 
+	// hideCostsGlobal mirrors DashboardConfig.HideCosts; nil means "fall
+	// through to plan-aware auto".
+	hideCostsGlobal *bool
+	// hideCostsByAccount mirrors DashboardProviderConfig.HideCosts entries;
+	// missing key or nil pointer means "fall through to global / auto".
+	hideCostsByAccount map[string]*bool
+
 	timeWindow            core.TimeWindow
 	lastSnapshotRequestID uint64
 
@@ -539,6 +546,25 @@ func (m *Model) applyDashboardConfig(dashboardCfg config.DashboardConfig, accoun
 	m.setWidgetSections(dashboardCfg.WidgetSections)
 	m.setDetailWidgetSections(dashboardCfg.DetailSections)
 	m.hideSectionsWithNoData = dashboardCfg.HideSectionsWithNoData
+
+	m.hideCostsGlobal = dashboardCfg.HideCosts
+	m.hideCostsByAccount = make(map[string]*bool, len(dashboardCfg.Providers))
+	for _, pref := range dashboardCfg.Providers {
+		if pref.AccountID == "" {
+			continue
+		}
+		m.hideCostsByAccount[pref.AccountID] = pref.HideCosts
+	}
+}
+
+// resolveHideCosts returns whether monetary metrics should be suppressed for
+// the given snapshot, using the current Model's per-account and global state.
+func (m Model) resolveHideCosts(snap core.UsageSnapshot) bool {
+	var perAccount *bool
+	if m.hideCostsByAccount != nil {
+		perAccount = m.hideCostsByAccount[snap.AccountID]
+	}
+	return core.ResolveHideCosts(snap, perAccount, m.hideCostsGlobal)
 }
 
 func (m *Model) ensureSnapshotProvidersKnown() {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -872,18 +872,10 @@ func (m Model) telemetryUnmappedDetails() []TelemetryUnmappedDetail {
 			}
 		}
 	}
-	keys := core.SortedStringKeys(boolKeys(seen))
+	keys := core.SortedStringKeys(seen)
 	out := make([]TelemetryUnmappedDetail, 0, len(keys))
 	for _, k := range keys {
 		out = append(out, seen[k])
-	}
-	return out
-}
-
-func boolKeys[V any](m map[string]V) map[string]bool {
-	out := make(map[string]bool, len(m))
-	for k := range m {
-		out[k] = true
 	}
 	return out
 }

--- a/internal/tui/model_commands.go
+++ b/internal/tui/model_commands.go
@@ -37,6 +37,19 @@ func (m Model) persistDashboardPrefsCmd() tea.Cmd {
 	}
 }
 
+func (m Model) persistDashboardProviderHideCostsCmd(accountID string, hide *bool) tea.Cmd {
+	return func() tea.Msg {
+		if m.services == nil {
+			return dashboardProviderHideCostsPersistedMsg{accountID: accountID, err: fmt.Errorf("hide_costs service unavailable")}
+		}
+		err := m.services.SaveDashboardProviderHideCosts(accountID, hide)
+		if err != nil {
+			log.Printf("dashboard provider hide_costs persist (%s): %v", accountID, err)
+		}
+		return dashboardProviderHideCostsPersistedMsg{accountID: accountID, err: err}
+	}
+}
+
 func (m Model) persistDashboardViewCmd() tea.Cmd {
 	view := string(m.configuredDashboardView())
 	return func() tea.Msg {

--- a/internal/tui/model_display_info.go
+++ b/internal/tui/model_display_info.go
@@ -17,8 +17,8 @@ type providerDisplayInfo struct {
 	reason       string
 }
 
-func computeDisplayInfo(snap core.UsageSnapshot, widget core.DashboardWidget) providerDisplayInfo {
-	return normalizeProviderDisplayInfoType(computeDisplayInfoRaw(snap, widget))
+func computeDisplayInfo(snap core.UsageSnapshot, widget core.DashboardWidget, hideCosts bool) providerDisplayInfo {
+	return normalizeProviderDisplayInfoType(computeDisplayInfoRaw(snap, widget, hideCosts))
 }
 
 func normalizeProviderDisplayInfoType(info providerDisplayInfo) providerDisplayInfo {
@@ -35,9 +35,15 @@ func normalizeProviderDisplayInfoType(info providerDisplayInfo) providerDisplayI
 	return info
 }
 
-func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget) providerDisplayInfo {
+func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget, hideCosts bool) providerDisplayInfo {
 	info := providerDisplayInfo{gaugePercent: -1}
 	costSummary := core.ExtractAnalyticsCostSummary(snap)
+	if hideCosts {
+		// Burn rate ($X.XX/h) is the only field this function pulls from
+		// the cost summary that we suppress; zeroing it here keeps the
+		// downstream branches simple (they all guard on >0).
+		costSummary.BurnRateUSD = 0
+	}
 
 	switch snap.Status {
 	case core.StatusError:
@@ -162,7 +168,7 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 	}
 
 	if widget.DisplayStyle == core.DashboardDisplayStyleDetailedCredits {
-		return computeDetailedCreditsDisplayInfo(snap, info)
+		return computeDetailedCreditsDisplayInfo(snap, info, hideCosts)
 	}
 
 	if m, ok := snap.Metrics["credits"]; ok {
@@ -273,7 +279,7 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 		info.summary = strings.Join(parts, " · ")
 
 		var detailParts []string
-		if dc, ok2 := snap.Metrics["today_api_cost"]; ok2 && dc.Used != nil {
+		if dc, ok2 := snap.Metrics["today_api_cost"]; ok2 && dc.Used != nil && !hideCosts {
 			tag := metricWindowTag(dc)
 			if tag != "" {
 				detailParts = append(detailParts, fmt.Sprintf("~$%.2f %s", *dc.Used, tag))
@@ -295,7 +301,7 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 		info.reason = "billing_block_fallback"
 
 		var parts []string
-		if dc, ok2 := snap.Metrics["today_api_cost"]; ok2 && dc.Used != nil {
+		if dc, ok2 := snap.Metrics["today_api_cost"]; ok2 && dc.Used != nil && !hideCosts {
 			tag := metricWindowTag(dc)
 			if tag != "" {
 				parts = append(parts, fmt.Sprintf("~$%.2f %s", *dc.Used, tag))
@@ -309,10 +315,10 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 		info.summary = strings.Join(parts, " · ")
 
 		var detailParts []string
-		if bc, ok2 := snap.Metrics["5h_block_cost"]; ok2 && bc.Used != nil {
+		if bc, ok2 := snap.Metrics["5h_block_cost"]; ok2 && bc.Used != nil && !hideCosts {
 			detailParts = append(detailParts, fmt.Sprintf("~$%.2f 5h block", *bc.Used))
 		}
-		if wc, ok2 := snap.Metrics["7d_api_cost"]; ok2 && wc.Used != nil {
+		if wc, ok2 := snap.Metrics["7d_api_cost"]; ok2 && wc.Used != nil && !hideCosts {
 			tag := metricWindowTag(wc)
 			if tag != "" {
 				detailParts = append(detailParts, fmt.Sprintf("~$%.2f/%s", *wc.Used, tag))
@@ -331,7 +337,7 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 		return info
 	}
 
-	if m, ok := snap.Metrics["today_api_cost"]; ok && m.Used != nil {
+	if m, ok := snap.Metrics["today_api_cost"]; ok && m.Used != nil && !hideCosts {
 		info.tagEmoji = "💰"
 		info.tagLabel = "Credits"
 		info.reason = "today_api_cost"
@@ -348,10 +354,10 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 		info.summary = strings.Join(parts, " · ")
 
 		var detailParts []string
-		if bc, ok2 := snap.Metrics["5h_block_cost"]; ok2 && bc.Used != nil {
+		if bc, ok2 := snap.Metrics["5h_block_cost"]; ok2 && bc.Used != nil && !hideCosts {
 			detailParts = append(detailParts, fmt.Sprintf("~$%.2f 5h block", *bc.Used))
 		}
-		if wc, ok2 := snap.Metrics["7d_api_cost"]; ok2 && wc.Used != nil {
+		if wc, ok2 := snap.Metrics["7d_api_cost"]; ok2 && wc.Used != nil && !hideCosts {
 			wcTag := metricWindowTag(wc)
 			if wcTag != "" {
 				detailParts = append(detailParts, fmt.Sprintf("~$%.2f/%s", *wc.Used, wcTag))
@@ -369,7 +375,7 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 		return info
 	}
 
-	if m, ok := snap.Metrics["5h_block_cost"]; ok && m.Used != nil {
+	if m, ok := snap.Metrics["5h_block_cost"]; ok && m.Used != nil && !hideCosts {
 		info.tagEmoji = "⚡"
 		info.tagLabel = "Usage"
 		info.summary = fmt.Sprintf("~$%.2f / 5h block", *m.Used)
@@ -420,13 +426,13 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 		return info
 	}
 
-	if m, ok := snap.Metrics["total_cost_usd"]; ok && m.Used != nil {
+	if m, ok := snap.Metrics["total_cost_usd"]; ok && m.Used != nil && !hideCosts {
 		info.tagEmoji = "💰"
 		info.tagLabel = "Credits"
 		info.summary = fmt.Sprintf("$%.2f total", *m.Used)
 		return info
 	}
-	if m, ok := snap.Metrics["all_time_api_cost"]; ok && m.Used != nil {
+	if m, ok := snap.Metrics["all_time_api_cost"]; ok && m.Used != nil && !hideCosts {
 		info.tagEmoji = "💰"
 		info.tagLabel = "Credits"
 		info.summary = fmt.Sprintf("~$%.2f total (API est.)", *m.Used)
@@ -479,8 +485,11 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget)
 	return info
 }
 
-func computeDetailedCreditsDisplayInfo(snap core.UsageSnapshot, info providerDisplayInfo) providerDisplayInfo {
+func computeDetailedCreditsDisplayInfo(snap core.UsageSnapshot, info providerDisplayInfo, hideCosts bool) providerDisplayInfo {
 	costSummary := core.ExtractAnalyticsCostSummary(snap)
+	if hideCosts {
+		costSummary.BurnRateUSD = 0
+	}
 
 	if m, ok := snap.Metrics["credit_balance"]; ok && m.Limit != nil && m.Remaining != nil {
 		info.tagEmoji = "💰"

--- a/internal/tui/model_display_info.go
+++ b/internal/tui/model_display_info.go
@@ -456,12 +456,22 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget,
 
 	for _, key := range core.FallbackDisplayMetricKeys(snap.Metrics) {
 		m := snap.Metrics[key]
-		if m.Used != nil {
-			info.tagEmoji = "⚡"
-			info.tagLabel = "Usage"
-			info.summary = fmt.Sprintf("%s: %s %s", metricLabel(widget, key), formatNumber(*m.Used), m.Unit)
-			return info
+		if m.Used == nil {
+			continue
 		}
+		// Skip monetary metrics when hide-costs is on. Without this guard,
+		// snapshots whose only Used-valued metrics are dollar amounts (e.g.
+		// claude_code with 5h_block_cost / today_api_cost / 7d_api_cost) fall
+		// through every earlier branch — all of which already gate on
+		// !hideCosts — and leak a "5h Cost: 667.60 USD" summary into the
+		// compact header.
+		if hideCosts && isMonetaryMetricKey(key, m) {
+			continue
+		}
+		info.tagEmoji = "⚡"
+		info.tagLabel = "Usage"
+		info.summary = fmt.Sprintf("%s: %s %s", metricLabel(widget, key), formatNumber(*m.Used), m.Unit)
+		return info
 	}
 
 	if snap.Message != "" {

--- a/internal/tui/model_display_info.go
+++ b/internal/tui/model_display_info.go
@@ -575,12 +575,21 @@ func computeDetailedCreditsDisplayInfo(snap core.UsageSnapshot, info providerDis
 }
 
 func windowActivityLine(snap core.UsageSnapshot, tw core.TimeWindow) string {
+	return windowActivityLineWithHide(snap, tw, false)
+}
+
+// windowActivityLineWithHide is the hide-costs-aware variant. When hideCosts
+// is true the $ segment is dropped so the line reads "1889 reqs · 5.3M tok in
+// 3 Days" rather than including a dollar figure.
+func windowActivityLineWithHide(snap core.UsageSnapshot, tw core.TimeWindow, hideCosts bool) string {
 	var parts []string
 	if m, ok := snap.Metrics["window_requests"]; ok && m.Used != nil && *m.Used > 0 {
 		parts = append(parts, fmt.Sprintf("%.0f reqs", *m.Used))
 	}
-	if m, ok := snap.Metrics["window_cost"]; ok && m.Used != nil && *m.Used > 0.001 {
-		parts = append(parts, fmt.Sprintf("$%.2f", *m.Used))
+	if !hideCosts {
+		if m, ok := snap.Metrics["window_cost"]; ok && m.Used != nil && *m.Used > 0.001 {
+			parts = append(parts, fmt.Sprintf("$%.2f", *m.Used))
+		}
 	}
 	if m, ok := snap.Metrics["window_tokens"]; ok && m.Used != nil && *m.Used > 0 {
 		parts = append(parts, shortCompact(*m.Used)+" tok")

--- a/internal/tui/model_display_test.go
+++ b/internal/tui/model_display_test.go
@@ -19,7 +19,7 @@ func TestComputeDisplayInfo_MapsActivityFallbackToUsage(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Usage" {
 		t.Fatalf("tagLabel = %q, want Usage", got.tagLabel)
 	}
@@ -41,7 +41,7 @@ func TestComputeDisplayInfo_MapsGenericMetricsFallbackToUsage(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Usage" {
 		t.Fatalf("tagLabel = %q, want Usage", got.tagLabel)
 	}
@@ -60,7 +60,7 @@ func TestComputeDisplayInfo_PreservesCreditsTag(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Credits" {
 		t.Fatalf("tagLabel = %q, want Credits", got.tagLabel)
 	}
@@ -76,7 +76,7 @@ func TestComputeDisplayInfo_PreservesErrorStatusTag(t *testing.T) {
 		Message:    "boom",
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Error" {
 		t.Fatalf("tagLabel = %q, want Error", got.tagLabel)
 	}
@@ -98,7 +98,7 @@ func TestComputeDisplayInfo_FallbackSkipsDerivedMetrics(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if !strings.Contains(strings.ToLower(got.summary), "core rpm") {
 		t.Fatalf("summary = %q, want core rpm fallback metric", got.summary)
 	}
@@ -160,7 +160,7 @@ func TestComputeDisplayInfo_AvailableBalanceWithPeak_USD(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Credits" {
 		t.Fatalf("tagLabel = %q, want Credits", got.tagLabel)
 	}
@@ -187,7 +187,7 @@ func TestComputeDisplayInfo_AvailableBalanceWithPeak_CNY(t *testing.T) {
 			"available_balance": {Limit: &limit, Used: &used, Remaining: &remaining, Unit: "CNY"},
 		},
 	}
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if !strings.Contains(got.summary, "¥5.00 / ¥100.00 spent") {
 		t.Errorf("summary = %q, want '¥5.00 / ¥100.00 spent'", got.summary)
 	}
@@ -207,7 +207,7 @@ func TestComputeDisplayInfo_SpendLimitWithoutIndividualSpend(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Credits" {
 		t.Fatalf("tagLabel = %q, want Credits", got.tagLabel)
 	}
@@ -232,7 +232,7 @@ func TestComputeDisplayInfo_SpendLimitWithIndividualSpend(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Credits" {
 		t.Fatalf("tagLabel = %q, want Credits", got.tagLabel)
 	}
@@ -265,7 +265,7 @@ func TestComputeDisplayInfo_IndividualSpendClampedToZero(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	// team portion should be clamped to 0, not negative
 	if !strings.Contains(got.detail, "team $0") {
 		t.Fatalf("detail = %q, want 'team $0' (clamped)", got.detail)
@@ -434,7 +434,7 @@ func TestComputeDisplayInfo_UsageFiveHourBranch(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Usage" {
 		t.Fatalf("tagLabel = %q, want Usage", got.tagLabel)
 	}
@@ -462,7 +462,7 @@ func TestComputeDisplayInfo_TodayApiCostBranchWithoutFiveHour(t *testing.T) {
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Credits" {
 		t.Fatalf("tagLabel = %q, want Credits", got.tagLabel)
 	}
@@ -497,7 +497,7 @@ func TestComputeDisplayInfo_BillingBlockFallbackClassifiesAsUsage(t *testing.T) 
 		},
 	}
 
-	got := computeDisplayInfo(snap, core.DefaultDashboardWidget())
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
 	if got.tagLabel != "Usage" {
 		t.Fatalf("tagLabel = %q, want Usage", got.tagLabel)
 	}

--- a/internal/tui/model_input.go
+++ b/internal/tui/model_input.go
@@ -55,6 +55,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case dashboardPrefsPersistedMsg:
 		return m.applyPersisted(msg.err, "save failed", "saved"), nil
+	case dashboardProviderHideCostsPersistedMsg:
+		return m.applyPersisted(msg.err, "hide_costs save failed", "hide_costs saved"), nil
 	case dashboardViewPersistedMsg:
 		return m.applyPersisted(msg.err, "view save failed", "view saved"), nil
 	case dashboardWidgetSectionsPersistedMsg:
@@ -466,6 +468,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "t":
 			m.invalidateRenderCaches()
 			return m, m.persistThemeCmd(CycleTheme())
+		case "c":
+			if m.screen == screenDashboard {
+				if mdl, cmd, handled := m.toggleHideCostsOverride(); handled {
+					return mdl, cmd
+				}
+			}
 		case "w":
 			return m.cycleTimeWindow()
 		case "v":
@@ -485,6 +493,21 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleAnalyticsKey(msg)
 	}
 	return m.handleDashboardTilesKey(msg)
+}
+
+// toggleHideCostsOverride cycles the per-account hide_costs override for the
+// currently focused dashboard tile/row through auto (nil) → hide (true) →
+// show (false) → auto. Returns handled=false when no tile is focused (so the
+// keystroke can fall through to other handlers).
+func (m Model) toggleHideCostsOverride() (Model, tea.Cmd, bool) {
+	ids := m.filteredIDs()
+	accountID := m.selectedTileID(ids)
+	if accountID == "" {
+		return m, nil, false
+	}
+	next := m.cycleHideCostsOverride(accountID)
+	m.invalidateRenderCaches()
+	return m, m.persistDashboardProviderHideCostsCmd(accountID, next), true
 }
 
 func (m Model) handleDashboardTilesKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/model_input.go
+++ b/internal/tui/model_input.go
@@ -721,7 +721,7 @@ func (m Model) detailSectionStarts() []int {
 	if width < 30 {
 		width = 30
 	}
-	sections := buildDetailSections(snap, dashboardWidget(snap.ProviderID), width, m.warnThreshold, m.critThreshold, m.timeWindow, m.resolveHideCosts(snap))
+	sections := buildDetailSections(snap, dashboardWidget(snap.ProviderID), width, m.warnThreshold, m.critThreshold, m.timeWindow, m.resolveHideCosts(snap), m.viewNow())
 	if len(sections) == 0 {
 		return nil
 	}

--- a/internal/tui/model_input.go
+++ b/internal/tui/model_input.go
@@ -261,7 +261,7 @@ func (m Model) handleSnapshotsMsg(msg SnapshotsMsg) (tea.Model, tea.Cmd) {
 		m.daemon.status = DaemonRunning
 	}
 	for id, snap := range m.snapshots {
-		info := computeDisplayInfo(snap, dashboardWidget(snap.ProviderID))
+		info := computeDisplayInfo(snap, dashboardWidget(snap.ProviderID), m.resolveHideCosts(snap))
 		if info.reason != "" {
 			snap.EnsureMaps()
 			snap.Diagnostics["display_branch"] = info.reason
@@ -721,7 +721,7 @@ func (m Model) detailSectionStarts() []int {
 	if width < 30 {
 		width = 30
 	}
-	sections := buildDetailSections(snap, dashboardWidget(snap.ProviderID), width, m.warnThreshold, m.critThreshold, m.timeWindow)
+	sections := buildDetailSections(snap, dashboardWidget(snap.ProviderID), width, m.warnThreshold, m.critThreshold, m.timeWindow, m.resolveHideCosts(snap))
 	if len(sections) == 0 {
 		return nil
 	}

--- a/internal/tui/model_panels.go
+++ b/internal/tui/model_panels.go
@@ -145,7 +145,7 @@ func (m Model) renderWidgetPanelByIndex(index, w, h, bodyOffset int, selected bo
 }
 
 func (m Model) renderListItem(snap core.UsageSnapshot, selected bool, w int) string {
-	di := computeDisplayInfo(snap, dashboardWidget(snap.ProviderID))
+	di := computeDisplayInfo(snap, dashboardWidget(snap.ProviderID), m.resolveHideCosts(snap))
 
 	iconStr := lipgloss.NewStyle().Foreground(StatusColor(snap.Status)).Render(StatusIcon(snap.Status))
 	nameStyle := lipgloss.NewStyle().Foreground(colorText)

--- a/internal/tui/render_cache.go
+++ b/internal/tui/render_cache.go
@@ -27,6 +27,7 @@ func (m *Model) invalidateRenderCaches() {
 }
 
 func (m *Model) cachedDetailContent(id string, snap core.UsageSnapshot, w int, activeTab int) string {
+	hideCosts := m.resolveHideCosts(snap)
 	key := strings.Join([]string{
 		id,
 		snap.ProviderID,
@@ -43,12 +44,13 @@ func (m *Model) cachedDetailContent(id string, snap core.UsageSnapshot, w int, a
 		string(m.timeWindow),
 		strconv.FormatFloat(m.warnThreshold, 'f', 4, 64),
 		strconv.FormatFloat(m.critThreshold, 'f', 4, 64),
+		strconv.FormatBool(hideCosts),
 	}, "|")
 	if m.detailCache.key == key {
 		return m.detailCache.content
 	}
 
-	content := RenderDetailContent(snap, m.viewNow(), w, m.warnThreshold, m.critThreshold, activeTab, m.timeWindow)
+	content := RenderDetailContent(snap, m.viewNow(), w, m.warnThreshold, m.critThreshold, activeTab, m.timeWindow, hideCosts)
 	m.detailCache = detailRenderCacheEntry{
 		key:     key,
 		content: content,

--- a/internal/tui/settings_modal_sections.go
+++ b/internal/tui/settings_modal_sections.go
@@ -254,7 +254,7 @@ func (m Model) renderSettingsDetailSectionsPreview(w, h int) string {
 		"",
 	}
 	snap := settingsWidgetSectionsPreviewSnapshot()
-	all := append(lines, strings.Split(RenderDetailContent(snap, m.viewNow(), max(40, w-2), 0.20, 0.05, 0, core.TimeWindow30d), "\n")...)
+	all := append(lines, strings.Split(RenderDetailContent(snap, m.viewNow(), max(40, w-2), 0.20, 0.05, 0, core.TimeWindow30d, false), "\n")...)
 	maxOffset := max(0, len(all)-h)
 	offset := clamp(m.settings.previewOffset, 0, maxOffset)
 	visible := all

--- a/internal/tui/telemetry_mapping_input_test.go
+++ b/internal/tui/telemetry_mapping_input_test.go
@@ -21,6 +21,7 @@ func (f *fakeServices) SaveTheme(string) error { return nil }
 func (f *fakeServices) SaveDashboardProviders([]config.DashboardProviderConfig) error {
 	return nil
 }
+func (f *fakeServices) SaveDashboardProviderHideCosts(string, *bool) error { return nil }
 func (f *fakeServices) SaveDashboardView(string) error                                    { return nil }
 func (f *fakeServices) SaveDashboardWidgetSections([]config.DashboardWidgetSection) error { return nil }
 func (f *fakeServices) SaveDetailWidgetSections([]config.DetailWidgetSection) error       { return nil }

--- a/internal/tui/telemetry_mapping_input_test.go
+++ b/internal/tui/telemetry_mapping_input_test.go
@@ -21,7 +21,7 @@ func (f *fakeServices) SaveTheme(string) error { return nil }
 func (f *fakeServices) SaveDashboardProviders([]config.DashboardProviderConfig) error {
 	return nil
 }
-func (f *fakeServices) SaveDashboardProviderHideCosts(string, *bool) error { return nil }
+func (f *fakeServices) SaveDashboardProviderHideCosts(string, *bool) error                { return nil }
 func (f *fakeServices) SaveDashboardView(string) error                                    { return nil }
 func (f *fakeServices) SaveDashboardWidgetSections([]config.DashboardWidgetSection) error { return nil }
 func (f *fakeServices) SaveDetailWidgetSections([]config.DetailWidgetSection) error       { return nil }

--- a/internal/tui/tiles.go
+++ b/internal/tui/tiles.go
@@ -374,7 +374,7 @@ func (m Model) renderTile(snap core.UsageSnapshot, selected, modelMixExpanded bo
 	}
 
 	widget := dashboardWidget(snap.ProviderID)
-	di := computeDisplayInfo(snap, widget)
+	di := computeDisplayInfo(snap, widget, m.resolveHideCosts(snap))
 	provColor := ProviderColor(snap.ProviderID)
 	accentSep := lipgloss.NewStyle().Foreground(provColor).Render(strings.Repeat("━", innerW))
 	dimSep := surface1Style.Render(strings.Repeat("─", innerW))

--- a/internal/tui/tiles_cache.go
+++ b/internal/tui/tiles_cache.go
@@ -16,12 +16,13 @@ func (m *Model) cachedTileBodyLines(
 	innerW int,
 	modelMixExpanded bool,
 ) []string {
-	key := tileBodyCacheKey(snap, widget, m.timeWindow, innerW, modelMixExpanded, m.hideSectionsWithNoData)
+	hideCosts := m.resolveHideCosts(snap)
+	key := tileBodyCacheKey(snap, widget, m.timeWindow, innerW, modelMixExpanded, m.hideSectionsWithNoData, hideCosts)
 	if lines, ok := m.tileBodyCache[key]; ok {
 		return lines
 	}
 
-	lines := m.buildTileBodyLines(snap, widget, di, innerW, modelMixExpanded)
+	lines := m.buildTileBodyLines(snap, widget, di, innerW, modelMixExpanded, hideCosts)
 	if m.tileBodyCache == nil {
 		m.tileBodyCache = make(map[string][]string)
 	}
@@ -36,6 +37,7 @@ func tileBodyCacheKey(
 	innerW int,
 	modelMixExpanded bool,
 	hideEmpty bool,
+	hideCosts bool,
 ) string {
 	return strings.Join([]string{
 		snap.ProviderID,
@@ -50,6 +52,7 @@ func tileBodyCacheKey(
 		strconv.Itoa(innerW),
 		strconv.FormatBool(modelMixExpanded),
 		strconv.FormatBool(hideEmpty),
+		strconv.FormatBool(hideCosts),
 		tileWidgetCacheKey(widget),
 	}, "|")
 }
@@ -80,6 +83,7 @@ func (m *Model) buildTileBodyLines(
 	di providerDisplayInfo,
 	innerW int,
 	modelMixExpanded bool,
+	hideCosts bool,
 ) []string {
 	truncate := func(s string) string {
 		if lipglossWidth := len([]rune(s)); lipglossWidth > innerW {
@@ -130,16 +134,16 @@ func (m *Model) buildTileBodyLines(
 	if di.detail != "" {
 		topUsageLines = append(topUsageLines, tileSummaryStyle.Render(truncate(di.detail)))
 	}
-	if wl := windowActivityLine(snap, m.timeWindow); wl != "" {
+	if wl := windowActivityLineWithHide(snap, m.timeWindow, hideCosts); wl != "" {
 		topUsageLines = append(topUsageLines, dimStyle.Render(truncate(wl)))
 	}
 	if len(topUsageLines) > 0 {
 		sectionsByID[core.DashboardSectionTopUsageProgress] = section{withSectionPadding(topUsageLines)}
 	}
 
-	compactMetricLines, compactMetricKeys := buildTileCompactMetricSummaryLines(snap, widget, innerW)
+	compactMetricLines, compactMetricKeys := buildTileCompactMetricSummaryLinesWithHide(snap, widget, innerW, hideCosts)
 
-	modelBurnLines, modelBurnKeys := buildProviderModelCompositionLines(snap, innerW, modelMixExpanded)
+	modelBurnLines, modelBurnKeys := buildProviderModelCompositionLinesWithHide(snap, innerW, modelMixExpanded, hideCosts)
 	if len(modelBurnLines) > 0 {
 		sectionsByID[core.DashboardSectionModelBurn] = section{withSectionPadding(modelBurnLines)}
 	}
@@ -198,18 +202,18 @@ func (m *Model) buildTileBodyLines(
 		compactMetricKeys = addUsedKeys(compactMetricKeys, codeStatsKeys)
 	}
 
-	dailyUsageLines := buildProviderDailyTrendLines(snap, innerW)
+	dailyUsageLines := buildProviderDailyTrendLinesWithHide(snap, innerW, hideCosts)
 	if len(dailyUsageLines) > 0 {
 		sectionsByID[core.DashboardSectionDailyUsage] = section{withSectionPadding(dailyUsageLines)}
 	}
 
-	upstreamProviderLines, upstreamProviderKeys := buildUpstreamProviderCompositionLines(snap, innerW, modelMixExpanded)
+	upstreamProviderLines, upstreamProviderKeys := buildUpstreamProviderCompositionLinesWithHide(snap, innerW, modelMixExpanded, hideCosts)
 	if len(upstreamProviderLines) > 0 {
 		sectionsByID[core.DashboardSectionUpstreamProviders] = section{withSectionPadding(upstreamProviderLines)}
 	}
 	compactMetricKeys = addUsedKeys(compactMetricKeys, upstreamProviderKeys)
 
-	providerBurnLines, providerBurnKeys := buildProviderVendorCompositionLines(snap, innerW, modelMixExpanded)
+	providerBurnLines, providerBurnKeys := buildProviderVendorCompositionLinesWithHide(snap, innerW, modelMixExpanded, hideCosts)
 	if len(providerBurnLines) > 0 {
 		sectionsByID[core.DashboardSectionProviderBurn] = section{withSectionPadding(providerBurnLines)}
 	}
@@ -222,7 +226,7 @@ func (m *Model) buildTileBodyLines(
 	otherLines = appendOtherGroup(otherLines, geminiQuotaLines)
 	compactMetricKeys = addUsedKeys(compactMetricKeys, geminiQuotaKeys)
 
-	metricLines := m.buildTileMetricLines(snap, widget, innerW, compactMetricKeys)
+	metricLines := m.buildTileMetricLinesWithHide(snap, widget, innerW, compactMetricKeys, hideCosts)
 	otherLines = appendOtherGroup(otherLines, metricLines)
 
 	if snap.Message != "" && snap.Status != core.StatusError {

--- a/internal/tui/tiles_composition.go
+++ b/internal/tui/tiles_composition.go
@@ -69,6 +69,14 @@ type toolMixEntry struct {
 }
 
 func buildProviderModelCompositionLines(snap core.UsageSnapshot, innerW int, expanded bool) ([]string, map[string]bool) {
+	return buildProviderModelCompositionLinesWithHide(snap, innerW, expanded, false)
+}
+
+// buildProviderModelCompositionLinesWithHide is the hide-costs-aware variant.
+// When hideCosts is true: when burn mode would be "cost", we fall back to
+// "tokens" or "requests" so the section no longer summarises dollars; the
+// heading is rebranded "Model Usage" and per-model rows drop their $ suffix.
+func buildProviderModelCompositionLinesWithHide(snap core.UsageSnapshot, innerW int, expanded bool, hideCosts bool) ([]string, map[string]bool) {
 	allModels, usedKeys := collectProviderModelMix(snap)
 	if len(allModels) == 0 {
 		return nil, nil
@@ -86,6 +94,18 @@ func buildProviderModelCompositionLines(snap core.UsageSnapshot, innerW int, exp
 	}
 
 	mode, total := selectBurnMode(totalTokens, totalCost, totalRequests)
+	if hideCosts && mode == "cost" {
+		// Re-pick a non-cost mode so the heading and bar are denominated in
+		// something we're willing to show. Prefer tokens, then requests.
+		switch {
+		case totalTokens > 0:
+			mode, total = "tokens", totalTokens
+		case totalRequests > 0:
+			mode, total = "requests", totalRequests
+		default:
+			return nil, nil
+		}
+	}
 	if total <= 0 {
 		return nil, nil
 	}
@@ -108,6 +128,12 @@ func buildProviderModelCompositionLines(snap core.UsageSnapshot, innerW int, exp
 		headerSuffix = fmt.Sprintf("$%.2f", total)
 	default:
 		headerSuffix = shortCompact(total) + " tok"
+	}
+	if hideCosts {
+		// The whole section is no longer about cost, so the "Burn" naming
+		// reads as a stale dollar reference. Rebrand to "Model Usage" — token
+		// volume is what's actually being summarised.
+		headingName = "Model Usage"
 	}
 
 	lines := []string{
@@ -133,7 +159,7 @@ func buildProviderModelCompositionLines(snap core.UsageSnapshot, innerW int, exp
 		switch mode {
 		case "tokens":
 			valueStr = fmt.Sprintf("%2.0f%% %s tok", pct, shortCompact(model.totalTokens()))
-			if model.cost > 0 {
+			if model.cost > 0 && !hideCosts {
 				valueStr += fmt.Sprintf(" · %s", formatUSD(model.cost))
 			}
 		case "cost":

--- a/internal/tui/tiles_composition_providers.go
+++ b/internal/tui/tiles_composition_providers.go
@@ -8,6 +8,13 @@ import (
 )
 
 func buildProviderVendorCompositionLines(snap core.UsageSnapshot, innerW int, expanded bool) ([]string, map[string]bool) {
+	return buildProviderVendorCompositionLinesWithHide(snap, innerW, expanded, false)
+}
+
+// buildProviderVendorCompositionLinesWithHide is the hide-costs-aware variant.
+// When hideCosts is true and burn mode resolves to "cost", we fall back to
+// tokens/requests so the section never renders dollar segments.
+func buildProviderVendorCompositionLinesWithHide(snap core.UsageSnapshot, innerW int, expanded bool, hideCosts bool) ([]string, map[string]bool) {
 	allProviders, usedKeys := collectProviderVendorMix(snap)
 	if len(allProviders) == 0 {
 		return nil, nil
@@ -25,6 +32,16 @@ func buildProviderVendorCompositionLines(snap core.UsageSnapshot, innerW int, ex
 	}
 
 	mode, total := selectBurnMode(totalTokens, totalCost, totalRequests)
+	if hideCosts && mode == "cost" {
+		switch {
+		case totalTokens > 0:
+			mode, total = "tokens", totalTokens
+		case totalRequests > 0:
+			mode, total = "requests", totalRequests
+		default:
+			return nil, nil
+		}
+	}
 	if total <= 0 {
 		return nil, nil
 	}
@@ -42,6 +59,16 @@ func buildProviderVendorCompositionLines(snap core.UsageSnapshot, innerW int, ex
 		heading = "Provider Burn (credits)"
 	} else if mode == "requests" {
 		heading = "Provider Activity (requests)"
+	}
+	if hideCosts {
+		// Rebrand away from "Burn" which connotes spend. Section is now token
+		// or request flow only.
+		switch mode {
+		case "requests":
+			heading = "Provider Activity (requests)"
+		default:
+			heading = "Provider Usage (tokens)"
+		}
 	}
 
 	providerClients := make([]clientMixEntry, 0, len(allProviders))
@@ -86,7 +113,7 @@ func buildProviderVendorCompositionLines(snap core.UsageSnapshot, innerW int, ex
 		valueStr := fmt.Sprintf("%2.0f%% %s req", pct, shortCompact(provider.requests))
 		if mode == "tokens" {
 			valueStr = fmt.Sprintf("%2.0f%% %s tok · %s req", pct, shortCompact(provider.input+provider.output), shortCompact(provider.requests))
-			if provider.cost > 0 {
+			if provider.cost > 0 && !hideCosts {
 				valueStr += fmt.Sprintf(" · %s", formatUSD(provider.cost))
 			}
 		} else if mode == "cost" {
@@ -116,6 +143,11 @@ func collectProviderVendorMix(snap core.UsageSnapshot) ([]providerMixEntry, map[
 }
 
 func buildUpstreamProviderCompositionLines(snap core.UsageSnapshot, innerW int, expanded bool) ([]string, map[string]bool) {
+	return buildUpstreamProviderCompositionLinesWithHide(snap, innerW, expanded, false)
+}
+
+// buildUpstreamProviderCompositionLinesWithHide is the hide-costs-aware variant.
+func buildUpstreamProviderCompositionLinesWithHide(snap core.UsageSnapshot, innerW int, expanded bool, hideCosts bool) ([]string, map[string]bool) {
 	allProviders, usedKeys := collectUpstreamProviderMix(snap)
 	if len(allProviders) == 0 {
 		return nil, nil
@@ -133,6 +165,16 @@ func buildUpstreamProviderCompositionLines(snap core.UsageSnapshot, innerW int, 
 	}
 
 	mode, total := selectBurnMode(totalTokens, totalCost, totalRequests)
+	if hideCosts && mode == "cost" {
+		switch {
+		case totalTokens > 0:
+			mode, total = "tokens", totalTokens
+		case totalRequests > 0:
+			mode, total = "requests", totalRequests
+		default:
+			return nil, nil
+		}
+	}
 	if total <= 0 {
 		return nil, nil
 	}
@@ -194,7 +236,7 @@ func buildUpstreamProviderCompositionLines(snap core.UsageSnapshot, innerW int, 
 		valueStr := fmt.Sprintf("%2.0f%% %s req", pct, shortCompact(provider.requests))
 		if mode == "tokens" {
 			valueStr = fmt.Sprintf("%2.0f%% %s tok · %s req", pct, shortCompact(provider.input+provider.output), shortCompact(provider.requests))
-			if provider.cost > 0 {
+			if provider.cost > 0 && !hideCosts {
 				valueStr += fmt.Sprintf(" · %s", formatUSD(provider.cost))
 			}
 		} else if mode == "cost" {
@@ -243,6 +285,10 @@ func buildProviderColorMap(providers []providerMixEntry, providerID string) map[
 }
 
 func buildProviderDailyTrendLines(snap core.UsageSnapshot, innerW int) []string {
+	return buildProviderDailyTrendLinesWithHide(snap, innerW, false)
+}
+
+func buildProviderDailyTrendLinesWithHide(snap core.UsageSnapshot, innerW int, hideCosts bool) []string {
 	type trendDef struct {
 		label string
 		keys  []string
@@ -253,6 +299,11 @@ func buildProviderDailyTrendLines(snap core.UsageSnapshot, innerW int) []string 
 		{label: "Cost", keys: []string{"analytics_cost", "cost"}, color: colorTeal, unit: "USD"},
 		{label: "Req", keys: []string{"analytics_requests", "requests"}, color: colorYellow, unit: "requests"},
 		{label: "Tokens", keys: []string{"analytics_tokens"}, color: colorSapphire, unit: "tokens"},
+	}
+	if hideCosts {
+		// Strip the Cost row outright — the rendered "last" label is a $ value
+		// and the sparkline's only context is monetary.
+		defs = defs[1:]
 	}
 
 	lines := []string{}

--- a/internal/tui/tiles_gauge.go
+++ b/internal/tui/tiles_gauge.go
@@ -1,7 +1,10 @@
 package tui
 
 import (
+	"fmt"
+	"math"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/janekbaraniewski/openusage/internal/core"
@@ -36,7 +39,11 @@ func (m Model) buildTileGaugeLines(snap core.UsageSnapshot, widget core.Dashboar
 		}
 	}
 
+	now := m.viewNow()
+	annotationIndent := strings.Repeat(" ", maxLabelW+1)
+
 	var lines []string
+	renderedGauges := 0
 	for _, key := range keys {
 		if gaugeAllowSet != nil && !gaugeAllowSet[key] {
 			continue
@@ -64,7 +71,16 @@ func (m Model) buildTileGaugeLines(snap core.UsageSnapshot, widget core.Dashboar
 
 		labelR := lipgloss.NewStyle().Foreground(colorSubtext).Width(maxLabelW).Render(label)
 		lines = append(lines, labelR+" "+gauge)
-		if maxLines > 0 && len(lines) >= maxLines {
+
+		// Append a dim projection annotation when the metric has a
+		// recognized window + a reset timestamp. Pace mirrors the detail
+		// view computation (current% / elapsed minutes / 100).
+		if annot := tileGaugeProjectionAnnotation(snap, key, met, usedPct, now); annot != "" {
+			lines = append(lines, annotationIndent+dimStyle.Render(annot))
+		}
+
+		renderedGauges++
+		if maxLines > 0 && renderedGauges >= maxLines {
 			break
 		}
 	}
@@ -190,4 +206,78 @@ func metricUsedPercent(key string, met core.Metric) float64 {
 
 func metricHasGauge(key string, met core.Metric) bool {
 	return metricUsedPercent(key, met) >= 0
+}
+
+// tileGaugeProjectionAnnotation returns a compact annotation string suitable
+// for the dashboard tile gauge (no leading indent or styling applied). It
+// returns "" when neither a reset countdown nor a meaningful pace projection
+// is available, so the caller can skip the line entirely.
+//
+// Returned forms (always dim-styled by caller):
+//   - "resets 1h 23m · 100% in 42m"     (pace lands inside the window)
+//   - "resets 3h 42m · ~85% by reset"   (pace would overshoot the window)
+//   - "resets 1h 23m"                   (no pace yet, e.g. usedPct == 0 or no elapsed time)
+//   - "100% in 42m"                     (pace known but no reset timestamp)
+//   - ""                                 (nothing meaningful to show)
+func tileGaugeProjectionAnnotation(snap core.UsageSnapshot, key string, met core.Metric, usedPct float64, now time.Time) string {
+	windowDur, ok := gaugeWindowDuration(met.Window)
+	if !ok {
+		return ""
+	}
+	resetAt, hasReset := snap.Resets[key]
+	if !hasReset {
+		return ""
+	}
+	resetIn := resetAt.Sub(now)
+
+	var resetPart string
+	if resetIn > 0 {
+		resetPart = "resets " + formatDurationShort(resetIn)
+	}
+
+	var projPart string
+	if usedPct > 0 && usedPct < 100 {
+		elapsed := windowDur - resetIn
+		if elapsed > 0 {
+			elapsedMin := elapsed.Minutes()
+			if elapsedMin > 0 {
+				paceFraction := (usedPct / 100) / elapsedMin
+				if !math.IsNaN(paceFraction) && !math.IsInf(paceFraction, 0) && paceFraction > 0 {
+					pctPerMinute := paceFraction * 100
+					if pctPerMinute > 0 {
+						remainingPct := 100 - usedPct
+						minutesTo100 := remainingPct / pctPerMinute
+						d := time.Duration(minutesTo100 * float64(time.Minute))
+						if d > 0 {
+							// If we would not reach 100% before reset,
+							// surface the projected % at reset instead.
+							if resetIn > 0 && d > resetIn {
+								projectedPct := usedPct + pctPerMinute*resetIn.Minutes()
+								n := int(math.Round(projectedPct))
+								if n < 0 {
+									n = 0
+								}
+								if n >= 100 {
+									n = 99
+								}
+								projPart = fmt.Sprintf("~%d%% by reset", n)
+							} else {
+								projPart = "100% in " + formatDurationShort(d)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	switch {
+	case resetPart != "" && projPart != "":
+		return resetPart + " · " + projPart
+	case resetPart != "":
+		return resetPart
+	case projPart != "":
+		return projPart
+	}
+	return ""
 }

--- a/internal/tui/tiles_gauge.go
+++ b/internal/tui/tiles_gauge.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/samber/lo"
 )
 
 func (m Model) buildTileGaugeLines(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int) []string {
@@ -33,10 +34,9 @@ func (m Model) buildTileGaugeLines(snap core.UsageSnapshot, widget core.Dashboar
 	// metrics are eligible for gauge rendering.
 	var gaugeAllowSet map[string]bool
 	if len(widget.GaugePriority) > 0 {
-		gaugeAllowSet = make(map[string]bool, len(widget.GaugePriority))
-		for _, k := range widget.GaugePriority {
-			gaugeAllowSet[k] = true
-		}
+		gaugeAllowSet = lo.SliceToMap(widget.GaugePriority, func(k string) (string, bool) {
+			return k, true
+		})
 	}
 
 	now := m.viewNow()
@@ -271,13 +271,5 @@ func tileGaugeProjectionAnnotation(snap core.UsageSnapshot, key string, met core
 		}
 	}
 
-	switch {
-	case resetPart != "" && projPart != "":
-		return resetPart + " · " + projPart
-	case resetPart != "":
-		return resetPart
-	case projPart != "":
-		return projPart
-	}
-	return ""
+	return joinAnnotationParts(resetPart, projPart)
 }

--- a/internal/tui/tiles_gauge_test.go
+++ b/internal/tui/tiles_gauge_test.go
@@ -1,0 +1,339 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// makeUsageMetric returns a Metric with the given used+limit+window suitable
+// for driving buildTileGaugeLines through metricUsedPercent.
+func makeUsageMetric(used, limit float64, window string) core.Metric {
+	u, l := used, limit
+	return core.Metric{
+		Used:   &u,
+		Limit:  &l,
+		Window: window,
+		Unit:   "requests",
+	}
+}
+
+func tileGaugeTestModel(now time.Time) Model {
+	return Model{
+		warnThreshold: 0.30,
+		critThreshold: 0.15,
+		referenceTime: now,
+	}
+}
+
+func tileGaugeTestWidget() core.DashboardWidget {
+	return core.DashboardWidget{
+		GaugeMaxLines: 2,
+		GaugePriority: []string{"rate_limit_5h"},
+	}
+}
+
+func TestBuildTileGaugeLines_ProjectionShownWhenExpected(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	// 50% used, 2.5h remaining in a 5h window → elapsed 2.5h. Pace projects
+	// reaching 100% in roughly another 2.5h.
+	met := makeUsageMetric(50, 100, "5h")
+	snap := core.UsageSnapshot{
+		ProviderID: "test",
+		Metrics:    map[string]core.Metric{"rate_limit_5h": met},
+		Resets:     map[string]time.Time{"rate_limit_5h": now.Add(2*time.Hour + 30*time.Minute)},
+	}
+
+	m := tileGaugeTestModel(now)
+	widget := tileGaugeTestWidget()
+
+	lines := m.buildTileGaugeLines(snap, widget, 60)
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines (gauge + annotation), got %d: %v", len(lines), lines)
+	}
+	// Gauge is first, annotation is second.
+	annotation := lines[1]
+	if !strings.Contains(annotation, "resets") {
+		t.Errorf("expected annotation to contain 'resets', got %q", annotation)
+	}
+	if !strings.Contains(annotation, "100%") {
+		t.Errorf("expected annotation to contain '100%%' projection, got %q", annotation)
+	}
+}
+
+func TestBuildTileGaugeLines_SuppressedWhenNoReset(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	met := makeUsageMetric(50, 100, "5h")
+	snap := core.UsageSnapshot{
+		ProviderID: "test",
+		Metrics:    map[string]core.Metric{"rate_limit_5h": met},
+		// Resets intentionally empty: no reset timestamp known.
+	}
+
+	m := tileGaugeTestModel(now)
+	widget := tileGaugeTestWidget()
+
+	lines := m.buildTileGaugeLines(snap, widget, 60)
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 line (gauge only), got %d: %v", len(lines), lines)
+	}
+	if strings.Contains(lines[0], "resets") || strings.Contains(lines[0], "100% in") {
+		t.Errorf("expected no projection annotation, got %q", lines[0])
+	}
+}
+
+func TestBuildTileGaugeLines_SuppressedWhenWindowUnrecognized(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	// "1m" is not in gaugeWindowDuration's allowlist (5h/1d/24h/today/7d/30d).
+	met := makeUsageMetric(50, 100, "1m")
+	snap := core.UsageSnapshot{
+		ProviderID: "test",
+		Metrics:    map[string]core.Metric{"rate_limit_5h": met},
+		Resets:     map[string]time.Time{"rate_limit_5h": now.Add(30 * time.Second)},
+	}
+
+	m := tileGaugeTestModel(now)
+	widget := tileGaugeTestWidget()
+
+	lines := m.buildTileGaugeLines(snap, widget, 60)
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 line (gauge only) for unrecognized window, got %d: %v", len(lines), lines)
+	}
+}
+
+func TestBuildTileGaugeLines_SuppressedWhenUsageZero(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	// Pace cannot be computed when used == 0; but we still expect the
+	// reset half of the annotation when a reset is known.
+	met := makeUsageMetric(0, 100, "5h")
+	snap := core.UsageSnapshot{
+		ProviderID: "test",
+		Metrics:    map[string]core.Metric{"rate_limit_5h": met},
+		Resets:     map[string]time.Time{"rate_limit_5h": now.Add(2 * time.Hour)},
+	}
+
+	m := tileGaugeTestModel(now)
+	widget := tileGaugeTestWidget()
+
+	lines := m.buildTileGaugeLines(snap, widget, 60)
+	if len(lines) != 2 {
+		t.Fatalf("expected gauge + reset-only annotation, got %d: %v", len(lines), lines)
+	}
+	annot := lines[1]
+	if !strings.Contains(annot, "resets") {
+		t.Errorf("expected reset half to render even with 0%% usage, got %q", annot)
+	}
+	if strings.Contains(annot, "100% in") {
+		t.Errorf("expected NO projection half when usage is zero, got %q", annot)
+	}
+}
+
+func TestBuildTileGaugeLines_SuppressedWhenAtOrOverLimit(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	met := makeUsageMetric(100, 100, "5h")
+	snap := core.UsageSnapshot{
+		ProviderID: "test",
+		Metrics:    map[string]core.Metric{"rate_limit_5h": met},
+		Resets:     map[string]time.Time{"rate_limit_5h": now.Add(1 * time.Hour)},
+	}
+
+	m := tileGaugeTestModel(now)
+	widget := tileGaugeTestWidget()
+
+	lines := m.buildTileGaugeLines(snap, widget, 60)
+	if len(lines) != 2 {
+		t.Fatalf("expected gauge + reset-only annotation at 100%%, got %d: %v", len(lines), lines)
+	}
+	annot := lines[1]
+	if strings.Contains(annot, "100% in") {
+		t.Errorf("expected NO projection annotation when already at limit, got %q", annot)
+	}
+	if !strings.Contains(annot, "resets") {
+		t.Errorf("expected reset annotation at limit, got %q", annot)
+	}
+}
+
+func TestBuildTileGaugeLines_SuppressedWhenWindowJustStarted(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	// resetIn == windowDur → elapsed == 0 → no projection. Reset still renders.
+	met := makeUsageMetric(5, 100, "5h")
+	snap := core.UsageSnapshot{
+		ProviderID: "test",
+		Metrics:    map[string]core.Metric{"rate_limit_5h": met},
+		Resets:     map[string]time.Time{"rate_limit_5h": now.Add(5 * time.Hour)},
+	}
+
+	m := tileGaugeTestModel(now)
+	widget := tileGaugeTestWidget()
+
+	lines := m.buildTileGaugeLines(snap, widget, 60)
+	if len(lines) != 2 {
+		t.Fatalf("expected gauge + reset-only annotation, got %d: %v", len(lines), lines)
+	}
+	annot := lines[1]
+	if strings.Contains(annot, "100% in") {
+		t.Errorf("expected NO projection annotation when window just started, got %q", annot)
+	}
+}
+
+func TestBuildTileGaugeLines_HideCostsDoesNotSuppressProjection(t *testing.T) {
+	// Projection is a usage feature, not a cost feature. buildTileGaugeLines
+	// does not take hideCosts; this test pins that behavior by asserting the
+	// projection still renders regardless of how the caller resolves
+	// hideCosts. We simulate the surrounding call by toggling
+	// Model.hideCostsGlobal in case future refactors plumb it through.
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	met := makeUsageMetric(50, 100, "5h")
+	snap := core.UsageSnapshot{
+		ProviderID: "test",
+		Metrics:    map[string]core.Metric{"rate_limit_5h": met},
+		Resets:     map[string]time.Time{"rate_limit_5h": now.Add(2*time.Hour + 30*time.Minute)},
+	}
+	widget := tileGaugeTestWidget()
+
+	hidden := true
+	mHidden := tileGaugeTestModel(now)
+	mHidden.hideCostsGlobal = &hidden
+	hiddenLines := mHidden.buildTileGaugeLines(snap, widget, 60)
+	if len(hiddenLines) < 2 {
+		t.Fatalf("expected projection annotation even with hide_costs=true, got %d lines: %v", len(hiddenLines), hiddenLines)
+	}
+	if !strings.Contains(hiddenLines[1], "100%") || !strings.Contains(hiddenLines[1], "resets") {
+		t.Errorf("expected full projection annotation under hide_costs, got %q", hiddenLines[1])
+	}
+
+	// Sanity: same input with hide_costs unset produces an identical
+	// gauge+annotation pair.
+	mNoHide := tileGaugeTestModel(now)
+	noHideLines := mNoHide.buildTileGaugeLines(snap, widget, 60)
+	if len(noHideLines) != len(hiddenLines) {
+		t.Fatalf("hide_costs changed gauge line count (hidden=%d, default=%d)", len(hiddenLines), len(noHideLines))
+	}
+}
+
+func TestBuildTileGaugeLines_RespectsMaxLines(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	// Two gauge-eligible metrics with projections. With GaugeMaxLines=1 the
+	// second gauge should be skipped entirely (not just its annotation).
+	snap := core.UsageSnapshot{
+		ProviderID: "test",
+		Metrics: map[string]core.Metric{
+			"rate_limit_5h": makeUsageMetric(50, 100, "5h"),
+			"rate_limit_7d": makeUsageMetric(40, 100, "7d"),
+		},
+		Resets: map[string]time.Time{
+			"rate_limit_5h": now.Add(2*time.Hour + 30*time.Minute),
+			"rate_limit_7d": now.Add(3 * 24 * time.Hour),
+		},
+	}
+	m := tileGaugeTestModel(now)
+	widget := core.DashboardWidget{
+		GaugeMaxLines: 1,
+		GaugePriority: []string{"rate_limit_5h", "rate_limit_7d"},
+	}
+
+	lines := m.buildTileGaugeLines(snap, widget, 60)
+	// One gauge + one annotation = 2 entries. The second gauge must be
+	// suppressed because GaugeMaxLines=1 counts gauges, not annotation rows.
+	if len(lines) != 2 {
+		t.Fatalf("expected exactly 2 entries (1 gauge + 1 annotation), got %d: %v", len(lines), lines)
+	}
+}
+
+func TestTileGaugeProjectionAnnotation_FitsInWindow(t *testing.T) {
+	// 5h window, started 1h ago (resetIn=4h), 50% used → pace = 0.5%/min,
+	// remaining 50% → 100min to 100%. 100m < 240m to reset → "100% in" branch.
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	met := makeUsageMetric(50, 100, "5h")
+	snap := core.UsageSnapshot{
+		Resets: map[string]time.Time{"rate_limit_5h": now.Add(4 * time.Hour)},
+	}
+
+	out := tileGaugeProjectionAnnotation(snap, "rate_limit_5h", met, 50, now)
+	if !strings.Contains(out, "resets") {
+		t.Errorf("expected reset half, got %q", out)
+	}
+	if !strings.Contains(out, "100% in") {
+		t.Errorf("expected '100%% in' projection when pace fits in window, got %q", out)
+	}
+	if strings.Contains(out, "by reset") {
+		t.Errorf("did not expect 'by reset' wording when pace fits, got %q", out)
+	}
+}
+
+func TestTileGaugeProjectionAnnotation_OvershootsWindow(t *testing.T) {
+	// User's reported scenario: 5h window started 1h 18m ago, 22% used.
+	// Pace = 0.22/78 = 0.002820/min → pctPerMinute = 0.2820.
+	// remaining 78% → 276m to 100%, but only 222m to reset.
+	// projectedPct = 22 + 0.2820*222 ≈ 84.6 → "~85% by reset".
+	now := time.Date(2026, 5, 18, 17, 18, 0, 0, time.UTC)
+	met := makeUsageMetric(22, 100, "5h")
+	resetAt := now.Add(3*time.Hour + 42*time.Minute) // 222 minutes
+	snap := core.UsageSnapshot{
+		Resets: map[string]time.Time{"rate_limit_5h": resetAt},
+	}
+
+	out := tileGaugeProjectionAnnotation(snap, "rate_limit_5h", met, 22, now)
+	if !strings.Contains(out, "resets") {
+		t.Errorf("expected reset half, got %q", out)
+	}
+	if !strings.Contains(out, "by reset") {
+		t.Errorf("expected 'by reset' wording when projection overshoots window, got %q", out)
+	}
+	if strings.Contains(out, "100% in") {
+		t.Errorf("did not expect '100%% in' wording when projection overshoots, got %q", out)
+	}
+	// Should report a percent in the 80s. Be specific to lock the math.
+	if !strings.Contains(out, "~85%") {
+		t.Errorf("expected projected ~85%% at reset, got %q", out)
+	}
+}
+
+func TestTileGaugeProjectionAnnotation_OvershootCapsBelow100(t *testing.T) {
+	// Engineer the rare case where projectedPct rounds up to 100% at
+	// reset but we ARE still overshooting the window. The helper must
+	// cap the printed value at 99 to avoid wording that contradicts the
+	// branch ("we won't hit 100" → "but here is ~100").
+	//
+	// 5h window, resetIn=2m → elapsed=298m. usedPct=99, pctPerMin =
+	// 99/298 ≈ 0.332. minutesTo100 = 1/0.332 ≈ 3.01m > 2m → branch taken.
+	// projectedPct = 99 + 0.332*2 ≈ 99.66 → rounds to 100 → capped to 99.
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	met := makeUsageMetric(99, 100, "5h")
+	resetAt := now.Add(2 * time.Minute)
+	snap := core.UsageSnapshot{
+		Resets: map[string]time.Time{"rate_limit_5h": resetAt},
+	}
+
+	out := tileGaugeProjectionAnnotation(snap, "rate_limit_5h", met, 99, now)
+	if !strings.Contains(out, "by reset") {
+		t.Errorf("expected 'by reset' wording, got %q", out)
+	}
+	if strings.Contains(out, "~100%") {
+		t.Errorf("'by reset' branch must cap at ~99%%, got %q", out)
+	}
+	if !strings.Contains(out, "~99%") {
+		t.Errorf("expected ~99%% printed (rounded down from ~99.66), got %q", out)
+	}
+}
+
+func TestTileGaugeProjectionAnnotation_PaceOnlyWhenResetInPast(t *testing.T) {
+	// resetIn < 0 → resetPart suppressed by the helper; projection half
+	// still renders because elapsed (= windowDur - resetIn) is positive
+	// and pace is meaningful.
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	met := makeUsageMetric(50, 100, "5h")
+	snap := core.UsageSnapshot{
+		Resets: map[string]time.Time{"rate_limit_5h": now.Add(-10 * time.Minute)},
+	}
+
+	out := tileGaugeProjectionAnnotation(snap, "rate_limit_5h", met, 50, now)
+	if strings.Contains(out, "resets") {
+		t.Errorf("expected no reset half when reset is in the past, got %q", out)
+	}
+	if !strings.Contains(out, "100% in") {
+		t.Errorf("expected pace projection when reset has passed but pace is meaningful, got %q", out)
+	}
+}

--- a/internal/tui/tiles_metrics.go
+++ b/internal/tui/tiles_metrics.go
@@ -336,6 +336,10 @@ func compactMetricAmount(v float64, unit string) string {
 }
 
 func (m Model) buildTileMetricLines(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, skipKeys map[string]bool) []string {
+	return m.buildTileMetricLinesWithHide(snap, widget, innerW, skipKeys, false)
+}
+
+func (m Model) buildTileMetricLinesWithHide(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, skipKeys map[string]bool, hideCosts bool) []string {
 	if len(snap.Metrics) == 0 {
 		return nil
 	}
@@ -360,6 +364,9 @@ func (m Model) buildTileMetricLines(snap core.UsageSnapshot, widget core.Dashboa
 			continue
 		}
 		if metricHasGauge(key, met) {
+			continue
+		}
+		if hideCosts && isMonetaryMetricKey(key, met) {
 			continue
 		}
 		value := formatTileMetricValue(key, met)

--- a/internal/tui/tiles_metrics.go
+++ b/internal/tui/tiles_metrics.go
@@ -17,6 +17,14 @@ type compactMetricRowSpec struct {
 }
 
 func buildTileCompactMetricSummaryLines(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int) ([]string, map[string]bool) {
+	return buildTileCompactMetricSummaryLinesWithHide(snap, widget, innerW, false)
+}
+
+// buildTileCompactMetricSummaryLinesWithHide is the hide-costs-aware variant.
+// When hideCosts is true, monetary keys (USD-valued, burn rate, anything that
+// would render dollars) are dropped from both row collection and segment
+// emission so $-amounts never reach the screen.
+func buildTileCompactMetricSummaryLinesWithHide(snap core.UsageSnapshot, widget core.DashboardWidget, innerW int, hideCosts bool) ([]string, map[string]bool) {
 	if len(snap.Metrics) == 0 || len(widget.CompactRows) == 0 {
 		return nil, nil
 	}
@@ -47,7 +55,7 @@ func buildTileCompactMetricSummaryLines(snap core.UsageSnapshot, widget core.Das
 	consumed := make(map[string]bool)
 	var lines []string
 	for _, spec := range specs {
-		segments, usedKeys := collectCompactMetricSegments(spec, widget, snap.Metrics, consumed)
+		segments, usedKeys := collectCompactMetricSegments(spec, widget, snap.Metrics, consumed, hideCosts)
 		if len(segments) == 0 {
 			continue
 		}
@@ -71,7 +79,26 @@ func buildTileCompactMetricSummaryLines(snap core.UsageSnapshot, widget core.Das
 	return lines, consumed
 }
 
-func collectCompactMetricSegments(spec compactMetricRowSpec, widget core.DashboardWidget, metrics map[string]core.Metric, consumed map[string]bool) ([]string, []string) {
+// isMonetaryMetricKey reports whether a metric key/value would render a dollar
+// amount in the TUI. Used by hide-costs filters at every call site that emits
+// USD-formatted text.
+func isMonetaryMetricKey(key string, met core.Metric) bool {
+	if key == "burn_rate" {
+		return true
+	}
+	if met.Unit == "USD" {
+		return true
+	}
+	if strings.HasSuffix(key, "_usd") || strings.HasSuffix(key, "_cost") {
+		return true
+	}
+	if strings.Contains(key, "cost") || strings.Contains(key, "spend") || strings.Contains(key, "price") {
+		return true
+	}
+	return false
+}
+
+func collectCompactMetricSegments(spec compactMetricRowSpec, widget core.DashboardWidget, metrics map[string]core.Metric, consumed map[string]bool, hideCosts bool) ([]string, []string) {
 	maxSegments := spec.maxSegments
 	if maxSegments <= 0 {
 		maxSegments = 4
@@ -110,6 +137,9 @@ func collectCompactMetricSegments(spec compactMetricRowSpec, widget core.Dashboa
 		if !ok {
 			continue
 		}
+		if hideCosts && isMonetaryMetricKey(key, met) {
+			continue
+		}
 		add(key, met)
 	}
 
@@ -124,6 +154,9 @@ func collectCompactMetricSegments(spec compactMetricRowSpec, widget core.Dashboa
 			}
 			met := metrics[key]
 			if !spec.match(key, met) {
+				continue
+			}
+			if hideCosts && isMonetaryMetricKey(key, met) {
 				continue
 			}
 			add(key, met)


### PR DESCRIPTION
Closes #140.

Adds two related features requested by @durandom:

## Cost visibility (\`hide_costs\`)

Nullable bool config field at \`dashboard.hide_costs\` (global) and \`dashboard.providers[].hide_costs\` (per-account). Three-layer resolution: per-account > global > automatic.

Automatic mode hides costs on fixed-rate plans where dollar figures aren't meaningful charges:
- Claude Code subscription (Pro/Max)
- Codex Plus/Pro/Team/Enterprise
- Copilot Individual/Business/Enterprise
- Z.AI GLM Coding Plan

Press \`c\` in the dashboard to toggle the override for the focused account. Cycles \`auto → hide → show → auto\` and persists to \`~/.config/openusage/settings.json\`.

## Burn-rate projection on usage gauges

Windowed usage gauges now show a dim annotation under the bar:

- Pace fits the window: \`resets in 1h 23m · projected 100% in 42m\`
- Pace overshoots the window: \`resets in 3h 42m · projected ~85% by reset\`

The second form prevents the misleading "100% in X" claim when the window will reset before that point. Projected percent at reset is clamped to \`[0, 99]\` so the overshoot branch never contradicts itself.

Annotation appears on both detail-view and dashboard-tile gauges. Suppression rules (NaN/Inf pace, zero usage, over-limit, just-started window) are shared between both renders.

## Docs

New guide: \`docs/site/docs/guides/usage-projections.md\` walks through both annotation forms, the linear extrapolation formula, eligible windows, suppression rules, and limitations (linear assumption — recent bursts will skew, \`~N%\` is not a forecast).

Updated reference docs:
- \`docs/site/docs/reference/configuration.md\` — \`dashboard.hide_costs\` field
- \`docs/site/docs/customization/keybindings.md\` — \`c\` keystroke
- \`configs/example_settings.json\` — example entry

Cross-linked from \`cost-attribution.md\` and \`providers/claude-code.md\`.

## Tests

- \`RenderUsageGaugeWithProjection\` edge cases (NaN, Inf, zero, negative, over-limit, just-started, overshoot)
- Tile gauge projection rendering and \`GaugeMaxLines\` accounting
- Cost suppression catches stray \`$\` signs across detail and tile views
- \`ResolveHideCosts\` three-layer resolution + auto-policy per provider
- Detail summary fallback now respects \`hide_costs\` (regression test pinned)

## Follow-ups in flight on this branch (not yet committed)

Per local feedback, exploring a dual annotation on long-window gauges (7d+) to also show a "recent pace" projection alongside the window-average pace. This requires a rolling sample ring on \`Model\` to track sub-day history that doesn't exist in the snapshot data. Will land as additional commits on this branch before un-drafting.

---

cc @durandom — happy to iterate on the wording or UX before merging.