### PR TITLE
ci: bump minor on feat: commits in 0.x releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "package-name": "openusage",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false,
       "changelog-sections": [


### PR DESCRIPTION
Flip \`bump-patch-for-minor-pre-major\` to \`false\` so \`feat:\` commits produce a minor bump (\`0.10.x → 0.11.0\`) instead of a patch bump.

## Why

PR #155 (cost-visibility) merged with several \`feat:\` commits. Release-please opened #158 targeting \`v0.10.7\` because the current config (\`bump-patch-for-minor-pre-major: true\`) keeps everything in 0.10.x patch territory until a breaking change ships.

For an actively-developing 0.x project, bumping minor on features is the more conventional pattern — versions communicate "new behavior available" rather than "patch number incrementing forever."

## What changes

- \`feat:\` → minor bump (\`0.10.6 → 0.11.0\`)
- \`fix:\` → patch bump (\`0.10.6 → 0.10.7\`)
- Breaking changes → still minor in 0.x (\`bump-minor-pre-major: true\` unchanged)
- All other commit types unaffected

## Expected side-effect after merge

Release-please workflow will fire on the merge commit, recompute the next version as \`0.11.0\`, and either close #158 + open a new PR, or update #158 in place — whatever the action's standard behavior is for config drift.

## Risk

Low. Config-only change, no code touched. Reversible by flipping the flag back.