### PR TITLE
deps(docs): bump ws to 8.20.1 (CVE-2026-45736)

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -19657,9 +19657,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
## Summary

- Bumps the transitive `ws` dep in `docs/site/package-lock.json` from `8.20.0` → `8.20.1` (pulled in by `webpack-dev-server` inside `@docusaurus/core`).
- The other `ws@7.5.10` under `webpack-bundle-analyzer` is below the vulnerable range (`>= 8.0.0, < 8.20.1`) and is left alone.
- No `package.json` changes; `npm update ws` was sufficient.

Fixes [Dependabot alert #21](https://github.com/janekbaraniewski/openusage/security/dependabot/21) — GHSA-58qx-3vcg-4xpx / CVE-2026-45736 (uninitialized memory disclosure in `WebSocket.close()` when a `TypedArray` is passed as the close reason).

No docs changes are needed — this is a transitive security bump with no user-facing behaviour change.

## Test plan

- [x] `npm ls ws --all` shows `webpack-dev-server → ws@8.20.1` (the only branch that was in the vulnerable range)
- [x] `npm audit` reports 0 vulnerabilities after the bump
- [x] `DOCS_PREVIEW=1 npm run build` in `docs/site/` finishes with `[SUCCESS]` and no broken-link warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)