### PR TITLE
fix(tmux): prepend status segment to inner edge of status-right

### DIFF
--- a/docs/site/docs/guides/tmux-integration.md
+++ b/docs/site/docs/guides/tmux-integration.md
@@ -42,19 +42,34 @@ The block sits between two sentinel comments, so nothing outside it is touched:
 set -g status-interval 5
 set -g status-right-length 200
 set -g status-left-length 80
-set -ga status-right "#(openusage tmux --preset compact)"
+run-shell -b 'seg="$(printf "#%s" "(openusage tmux --preset compact)")"; cur="$(tmux show -gqv status-right)"; case "$cur" in *"$seg"*) exit 0 ;; *) tmux set -g status-right "$seg $cur" ;; esac'
 # <<< openusage tmux <<<
 ```
+
+### Why a `run-shell` line instead of `set -ga status-right`?
+
+The segment is **prepended** to `status-right` so it sits at the inner (left) edge of the right side, next to the center of the bar, ahead of your existing segments (clock, battery, and the like). A plain `set -ga status-right` would *append* it to the far-right edge instead.
+
+tmux has no native "prepend" for an option, so the block reads the current `status-right` and re-sets it with the openusage segment in front. The line is written carefully:
+
+- It runs at config-load time and is **idempotent**: the `case "$cur" in *"$seg"*) exit 0` guard skips the insert when the segment is already present, so repeated `tmux source-file` calls never stack copies.
+- It avoids a literal `#(` in the `run-shell` argument. tmux expands `#(...)` inside `run-shell` arguments at *parse* time, which would run `openusage` immediately and freeze its output. The shell rebuilds the leading `#` at runtime via `printf`, and `tmux set` (without `-F`) stores both the openusage segment and your existing `#(...)` segments unexpanded for live rendering.
 
 The install helper looks for your tmux config in this order: `$XDG_CONFIG_HOME/tmux/tmux.conf`, `~/.config/tmux/tmux.conf`, `~/.tmux.conf`. If none exist, it creates `~/.config/tmux/tmux.conf`.
 
 ## Manual install
 
-If you prefer to edit your tmux config by hand, paste this near the top of `~/.tmux.conf` (or its XDG-located equivalent):
+If you prefer to edit your tmux config by hand, splice the `#(openusage …)` command directly into your own `status-right` (or `status-left`) at the spot you want it. Editing by hand, *you* control the position, so there is no need for the `run-shell` prepend the installer uses. For example, first on the right side:
 
 ```
 set -g status-interval 5
 set -g status-right-length 200
+set -g status-right "#(openusage tmux --preset compact) | %H:%M | %d-%b"
+```
+
+Or append it to the far-right edge instead:
+
+```
 set -ga status-right "#(openusage tmux --preset compact)"
 ```
 

--- a/docs/site/docs/reference/cli.md
+++ b/docs/site/docs/reference/cli.md
@@ -210,7 +210,7 @@ openusage tmux install --write --position both --bind-popup u
 | Flag | Default | Purpose |
 | --- | --- | --- |
 | `--write` | off | Apply to tmux.conf. Creates a `.bak` of any existing content. |
-| `--position SIDE` | `right` | `left`, `right`, or `both`. |
+| `--position SIDE` | `right` | `left`, `right`, or `both`. `right` prepends the segment to the inner (left) edge of `status-right` so it sits ahead of your existing segments rather than at the far-right edge. |
 | `--preset NAME` | `compact` | Embedded preset to wire in. |
 | `--interval N` | 5 | Sets `status-interval`. |
 | `--right-length N` | 200 | Sets `status-right-length`. |

--- a/internal/tmux/install.go
+++ b/internal/tmux/install.go
@@ -119,15 +119,17 @@ func BuildSnippet(opts InstallOptions) string {
 	fmt.Fprintf(&b, "set -g status-right-length %d\n", opts.RightLength)
 	fmt.Fprintf(&b, "set -g status-left-length %d\n", opts.LeftLength)
 
-	cmd := fmt.Sprintf("#(%s tmux --preset %s)", binary, opts.Preset)
 	switch opts.Position {
 	case "left":
+		// Append to status-left so the segment sits at the inner (right)
+		// edge of the left side, next to the window list.
+		cmd := fmt.Sprintf("#(%s tmux --preset %s)", binary, opts.Preset)
 		fmt.Fprintf(&b, "set -ga status-left %q\n", cmd)
 	case "both":
 		fmt.Fprintf(&b, "set -ga status-left %q\n", fmt.Sprintf("#(%s tmux --preset compact --segment tool)", binary))
-		fmt.Fprintf(&b, "set -ga status-right %q\n", cmd)
+		b.WriteString(prependStatusRight(binary, opts.Preset))
 	default: // right
-		fmt.Fprintf(&b, "set -ga status-right %q\n", cmd)
+		b.WriteString(prependStatusRight(binary, opts.Preset))
 	}
 
 	if key := strings.TrimSpace(opts.BindPopup); key != "" {
@@ -140,6 +142,30 @@ func BuildSnippet(opts InstallOptions) string {
 	b.WriteString(sentinelEnd)
 	b.WriteString("\n")
 	return b.String()
+}
+
+// prependStatusRight returns a run-shell line that inserts the openusage
+// segment at the inner (left) edge of status-right at config-load time,
+// instead of appending it to the far-right edge. This places the usage
+// info next to the center of the bar, ahead of the user's existing
+// right-side segments (clock, battery, etc.).
+//
+// The line is idempotent: a guard skips the insert when the segment is
+// already present, so repeated `tmux source-file` calls do not stack copies.
+//
+// We deliberately avoid writing a literal "#(" into the conf. tmux expands
+// #(...) inside run-shell arguments at parse time, which would execute
+// openusage immediately and freeze its output into the option. Instead the
+// shell rebuilds the leading "#" at runtime via printf (so tmux never sees a
+// command substitution to expand) and `tmux set` (no -F) stores the segment
+// unexpanded, preserving both our segment and the user's existing #(...)
+// segments for live rendering.
+func prependStatusRight(binary, preset string) string {
+	inner := fmt.Sprintf("(%s tmux --preset %s)", binary, preset)
+	return fmt.Sprintf(
+		`run-shell -b 'seg="$(printf "#%%s" "%s")"; cur="$(tmux show -gqv status-right)"; case "$cur" in *"$seg"*) exit 0 ;; *) tmux set -g status-right "$seg $cur" ;; esac'`+"\n",
+		inner,
+	)
 }
 
 // withInstallDefaults fills the zero/empty fields of opts with defaults so

--- a/internal/tmux/install_test.go
+++ b/internal/tmux/install_test.go
@@ -217,6 +217,50 @@ func TestBuildSnippetPositionVariants(t *testing.T) {
 	}
 }
 
+// TestBuildSnippetRightPrepends asserts the right-side segment is inserted at
+// the inner edge of status-right (prepended) rather than appended to the
+// far-right edge, and that it never writes a literal "#(" that tmux would
+// expand at parse time.
+func TestBuildSnippetRightPrepends(t *testing.T) {
+	for _, pos := range []string{"right", "both"} {
+		snip := BuildSnippet(InstallOptions{Position: pos})
+
+		// The right segment must be installed via run-shell prepend, not a
+		// plain `set -ga status-right` append.
+		if strings.Contains(snip, "set -ga status-right") {
+			t.Fatalf("%s: still appends to status-right (far-right edge):\n%s", pos, snip)
+		}
+		if !strings.Contains(snip, "run-shell") || !strings.Contains(snip, `tmux set -g status-right "$seg $cur"`) {
+			t.Fatalf("%s: missing prepend run-shell line:\n%s", pos, snip)
+		}
+		// The idempotency guard must be present.
+		if !strings.Contains(snip, `case "$cur" in *"$seg"*) exit 0`) {
+			t.Fatalf("%s: missing idempotency guard:\n%s", pos, snip)
+		}
+
+		// Isolate the run-shell line: a literal "#(" inside a run-shell
+		// argument is expanded by tmux at parse time, so the "#" must be
+		// rebuilt at runtime via printf instead. (A "#(" in a plain
+		// `set status-left/right` line is fine; tmux stores it unexpanded.)
+		var runLine string
+		for _, line := range strings.Split(snip, "\n") {
+			if strings.HasPrefix(line, "run-shell") {
+				runLine = line
+				break
+			}
+		}
+		if runLine == "" {
+			t.Fatalf("%s: no run-shell line found:\n%s", pos, snip)
+		}
+		if strings.Contains(runLine, "#(") {
+			t.Fatalf("%s: run-shell line contains a literal #( that tmux expands at parse time:\n%s", pos, runLine)
+		}
+		if !strings.Contains(runLine, `printf "#%s"`) {
+			t.Fatalf("%s: segment prefix is not rebuilt at runtime via printf:\n%s", pos, runLine)
+		}
+	}
+}
+
 func TestBuildSnippetBindings(t *testing.T) {
 	snip := BuildSnippet(InstallOptions{BindPopup: "u", BindRefresh: "r"})
 	if !strings.Contains(snip, "bind-key u display-popup") {


### PR DESCRIPTION
## Problem

After `openusage tmux install`, the status segment renders at the **far-right edge** of the bar, behind the user's existing clock/battery/git segments. The expectation is for it to be the **leftmost segment of the right side** (inner edge, next to the center).

The cause: the managed block used `set -ga status-right "#(openusage …)"`, which *appends* to `status-right`.

## Fix

tmux has no native prepend for an option, so the managed block now emits a `run-shell` line that reads the current `status-right` and re-sets it with the openusage segment in front:

```
run-shell -b 'seg="$(printf "#%s" "(openusage tmux --preset compact)")"; cur="$(tmux show -gqv status-right)"; case "$cur" in *"$seg"*) exit 0 ;; *) tmux set -g status-right "$seg $cur" ;; esac'
```

Key properties, all verified against a real `tmux 3.6a` server:

- **Inner-edge placement**: openusage becomes the first segment on the right side; existing segments follow.
- **Idempotent**: the `*"$seg"*) exit 0` guard skips the insert when already present, so repeated `tmux source-file` calls never stack copies.
- **No premature expansion**: tmux expands `#(...)` inside `run-shell` arguments at *parse* time. Writing a literal `#(openusage …)` there would run openusage immediately and freeze its output. The `#` is rebuilt at runtime via `printf`, and `tmux set` (no `-F`) stores both our segment and the user's existing `#(...)` segments unexpanded for live rendering.

`left` position still appends to `status-left` (inner edge of the left side); `both` prepends the right segment and appends the left tool indicator.

## Tests

- Added `TestBuildSnippetRightPrepends`: asserts `right`/`both` install via the `run-shell` prepend (not `set -ga status-right`), include the idempotency guard, and keep a literal `#(` out of the run-shell argument.
- Existing install/uninstall/position/binding tests still pass.
- End-to-end: generated snippet sourced into a throwaway tmux server with a realistic pre-existing `status-right` — segment lands at the inner edge, user segments preserved, reload does not double.

## Docs

- `docs/site/docs/guides/tmux-integration.md`: updated the managed-block example and added a "Why a `run-shell` line instead of `set -ga status-right`?" section; clarified manual-install positioning.
- `docs/site/docs/reference/cli.md`: documented that `--position right` prepends to the inner edge.
- Docs site builds with `[SUCCESS]`, no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)