### PR TITLE
docs: surface all usage patterns in getting-started + tmux findability

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,23 @@ Remote API platforms (OpenAI, Anthropic, OpenRouter, …) appear in the periodic
 
 ### Add to tmux
 
-OpenUsage also renders a tmux status segment for the active AI tool, with 12 built-in presets and full theming.
+Show your Claude Code, Codex, Cursor, Copilot, and OpenRouter usage — cost, quota, burn rate, and the active tool — right in your **tmux status bar**. Run the interactive installer (position, preset, optional real provider icons), then reload tmux:
 
 ```bash
-openusage tmux install --write                 # writes a sentinel-bracketed block
+openusage tmux install                         # interactive wizard: position, preset, icons
 tmux source-file ~/.config/tmux/tmux.conf      # reload
-openusage tmux --preset claude-focused         # try other presets
+```
+
+It renders e.g. `🤖 5h 15% $6.79/today`, with the icon tinted in the provider's brand color. Want real provider logos instead of emoji? The wizard offers to install a bundled icon font and configure your terminal — see [provider icons](docs/site/docs/guides/tmux-integration.md#provider-icons-custom-font).
+
+```bash
+openusage tmux install --write                 # non-interactive (scripting): just write the snippet
+openusage tmux --preset claude-focused         # preview other presets (12 built-in)
+openusage tmux font setup                       # configure icons for kitty/Ghostty/WezTerm
 openusage tmux doctor                          # diagnose if something is off
 ```
 
-See the [tmux integration guide](docs/site/docs/guides/tmux-integration.md) for the format grammar, theming, and watch-mode alerts.
+See the [tmux integration guide](docs/site/docs/guides/tmux-integration.md) for the format grammar, theming, the icon font, and watch-mode alerts.
 
 ## Track coding agent usage across multiple platforms
 

--- a/docs/site/docs/getting-started/ways-to-use.md
+++ b/docs/site/docs/getting-started/ways-to-use.md
@@ -1,0 +1,102 @@
+---
+title: Ways to use OpenUsage
+description: The surfaces OpenUsage exposes — live terminal dashboard, headless CLI reports, the Claude Code statusline, a tmux status segment, an always-on background daemon, multi-machine aggregation, and machine-readable export.
+sidebar_position: 2
+sidebar_label: Ways to use it
+---
+
+OpenUsage is more than the dashboard. The same usage data is available through
+several surfaces — pick whichever fits how you work. They all read the same
+providers and (optionally) the same local history.
+
+| Surface | Command | Use it when |
+| --- | --- | --- |
+| [Live dashboard](#live-terminal-dashboard) | `openusage` | You want the full interactive view |
+| [CLI reports](#headless-cli-reports) | `openusage daily` (`--json`) | Scripting, CI, a quick check |
+| [Claude Code statusline](#claude-code-statusline) | `openusage statusline --install` | You live in Claude Code |
+| [tmux status bar](#tmux-status-bar) | `openusage tmux install` | You live in tmux |
+| [Background daemon](#always-on-background-daemon) | `openusage telemetry daemon install` | You want history over time |
+| [Multiple machines](#across-multiple-machines) | `openusage hub` / `hub-view` | You work across several machines |
+| [Export](#export--scripting) | `openusage export --json` | You want to pipe data into your own tools |
+
+## Live terminal dashboard
+
+The default. Auto-detects your tools and shows live tiles with a master/detail
+panel and an Analytics screen (Tab).
+
+```bash
+openusage
+```
+
+See [first run](./first-run.md).
+
+## Headless CLI reports
+
+The same parsing and pricing as the dashboard, printed once and exited — handy
+for scripts, CI, cron, and quick checks. Add `--json` for machine-readable
+output.
+
+```bash
+openusage daily          # also: weekly, monthly
+openusage session        # grouped by session
+openusage blocks         # by 5-hour billing block, with burn rate + projection
+openusage daily --json
+```
+
+See the [headless reports & statusline guide](../guides/cli-reports.md).
+
+## Claude Code statusline
+
+Put session/today/block cost, burn rate, and context usage right in Claude
+Code's own status line.
+
+```bash
+openusage statusline --install
+```
+
+See the [reports & statusline guide](../guides/cli-reports.md).
+
+## tmux status bar
+
+A one-line provider-usage segment in your tmux status bar, updated on tmux's
+interval. The interactive installer also offers real provider icons.
+
+```bash
+openusage tmux install
+```
+
+See the [tmux integration guide](../guides/tmux-integration.md).
+
+## Always-on background daemon
+
+Run a background collector that ingests snapshots into a local SQLite store, so
+reports and analytics span time even when the app isn't open. Local-first — the
+daemon listens only on a Unix socket.
+
+```bash
+openusage telemetry daemon install
+```
+
+See [Daemon & Telemetry](../daemon/overview.md).
+
+## Across multiple machines
+
+Aggregate usage from several machines into one view: run a hub that collects
+from each, and view the combined picture.
+
+```bash
+openusage hub          # aggregate snapshots from multiple machines
+openusage hub-view     # view a remote hub's aggregated data in the TUI
+```
+
+See the [multi-machine guide](../guides/multi-machine.md).
+
+## Export & scripting
+
+Emit current usage snapshots to a file or stdout for your own tooling.
+
+```bash
+openusage export --json
+```
+
+See the [CLI reference](../reference/cli.md).

--- a/docs/site/docs/guides/tmux-integration.md
+++ b/docs/site/docs/guides/tmux-integration.md
@@ -1,9 +1,18 @@
 ---
-title: tmux integration
-description: A first-class tmux status bar for OpenUsage. Provider-agnostic, themed, configurable, and impossible to wedge.
+title: tmux integration — Claude Code, Codex & Cursor usage in your status bar
+description: Show Claude Code, Codex, Cursor, Copilot, and OpenRouter usage (cost, quota, burn rate) in your tmux status bar with OpenUsage — an interactive installer, real provider icons, and full theming.
+keywords:
+  - tmux ai usage
+  - claude code tmux
+  - claude code tmux status bar
+  - tmux status bar ai cost
+  - codex cursor tmux usage
+  - openusage tmux
 ---
 
 # tmux integration
+
+> Show your **Claude Code, Codex, Cursor, Copilot, and OpenRouter** usage — cost, quota, burn rate, and the active tool — right in your **tmux status bar**.
 
 OpenUsage ships a `tmux` subcommand that renders a one-line status segment of your current AI tool usage. It is provider-agnostic (it picks the most-recently-used local tool), themed against the same 18-theme palette as the dashboard, and offers four output shapes:
 

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -11,6 +11,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'getting-started/install',
         'getting-started/quickstart',
+        'getting-started/ways-to-use',
         'getting-started/first-run',
         'getting-started/upgrade',
         'getting-started/uninstall',


### PR DESCRIPTION
tmux (and the Claude Code statusline) were buried in deep guides and absent from getting-started. This surfaces every way to use OpenUsage and improves discoverability.

### New: getting-started → "Ways to use it"
A single overview page listing all surfaces, each with a copy-paste command and a link:
- Live terminal dashboard
- Headless CLI reports (`daily`/`weekly`/`monthly`/`session`/`blocks`, `--json`)
- Claude Code statusline
- tmux status bar
- Always-on background daemon
- Multiple machines (hub / hub-view)
- Export / scripting

Added to the getting-started sidebar (right after Quickstart).

### tmux findability (SEO/AEO)
- Guide title/description rewritten to target real queries ("claude code tmux", "tmux ai usage", "tmux status bar ai cost") + `keywords` frontmatter + a one-line lead.

### README
- Rewrote the "Add to tmux" section to lead with the **interactive wizard**, mention the brand-tinted icons and the **provider-icon font**, and keep the scripting flow. (It previously only showed the old `--write` snippet.)

Docs build `[SUCCESS]`, no broken links.

### Still open (not in this PR)
The marketing site (openusage.sh) has **no tmux content** — that's the biggest remaining lever for a Google/LLM query like "claude usage tmux integration". A dedicated marketing/landing page (matching the existing SEO pages + sitemap + JSON-LD) would address it; flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)