### PR TITLE
ci(actions): pin build job name so required check matches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,11 @@ jobs:
           path: coverage.out
 
   build:
-    name: Build
+    # Pin the per-matrix display name so the required status-check context
+    # stays "Build (<os>)" and does not leak the `bin` matrix axis
+    # (otherwise it becomes "Build (ubuntu-latest, openusage)" and branch
+    # protection never sees the context it requires).
+    name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Why PRs are stuck

Branch protection on `main` requires these status-check contexts:

- `Build (ubuntu-latest)`
- `Build (macos-latest)`

But the Build matrix was refactored into an **`include:`-only** matrix with an extra `bin` key. GitHub derives matrix job names from *all* include keys, so the jobs now report as:

- `Build (ubuntu-latest, openusage)`
- `Build (macos-latest, openusage)`
- `Build (windows-latest, openusage.exe)`

The required contexts (`Build (ubuntu-latest)` / `Build (macos-latest)`) are therefore **never reported**, so GitHub leaves them in the `Expected` state forever and every PR is `BLOCKED` from auto-merge (e.g. #206) even though all jobs pass.

(`Test` was unaffected because its matrix uses a top-level `os:` vector, so `Test (ubuntu-latest)` still matches.)

## Fix

Pin an explicit per-matrix display name on the Build job:

```yaml
name: Build (${{ matrix.os }})
```

This keeps the check context as `Build (<os>)` regardless of other matrix axes, matching the long-standing required contexts and making it resilient to future matrix changes. No branch-protection change needed.

## Docs

No user-facing docs affected — CI workflow naming only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)