### PR TITLE
fix: bound the telemetry DB (retention + corruption) and restore the tmux 5h quota

### DIFF
--- a/cmd/openusage/statusline.go
+++ b/cmd/openusage/statusline.go
@@ -378,14 +378,14 @@ const (
 // daemon is slow/down, fall back to the last-good value within fiveHourMaxAge.
 // Never makes a network call and never blocks longer than the daemon timeout.
 func fiveHourUsagePct() (float64, bool) {
-	if pct, age, ok := readFiveHourCache(); ok && age < fiveHourRefreshInterval {
+	if pct, age, ok := claude_code.ReadFiveHourCache(); ok && age < fiveHourRefreshInterval {
 		return pct, true
 	}
 	if pct, ok := fetchFiveHourPctFromDaemon(); ok {
-		writeFiveHourCache(pct)
+		claude_code.WriteFiveHourCache(pct)
 		return pct, true
 	}
-	if pct, age, ok := readFiveHourCache(); ok && age < fiveHourMaxAge {
+	if pct, age, ok := claude_code.ReadFiveHourCache(); ok && age < fiveHourMaxAge {
 		return pct, true
 	}
 	return 0, false
@@ -412,67 +412,9 @@ func fetchFiveHourPctFromDaemon() (float64, bool) {
 	return 0, false
 }
 
-type fiveHourCacheEntry struct {
-	Pct float64   `json:"pct"`
-	TS  time.Time `json:"ts"`
-}
-
-func fiveHourCachePath() string {
-	home, _ := os.UserHomeDir()
-	if home == "" {
-		return ""
-	}
-	return filepath.Join(home, ".cache", "openusage", "statusline-5h.json")
-}
-
-// writeFiveHourCache overwrites the single cache file atomically (temp + rename)
-// so concurrent statusline renders from parallel sessions can never read or
-// leave a half-written file.
-func writeFiveHourCache(pct float64) {
-	p := fiveHourCachePath()
-	if p == "" {
-		return
-	}
-	_ = os.MkdirAll(filepath.Dir(p), 0o755)
-	b, err := json.Marshal(fiveHourCacheEntry{Pct: pct, TS: time.Now()})
-	if err != nil {
-		return
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(p), ".statusline-5h-*.tmp")
-	if err != nil {
-		return
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.Write(b); err != nil {
-		tmp.Close()
-		_ = os.Remove(tmpName)
-		return
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		return
-	}
-	if err := os.Rename(tmpName, p); err != nil {
-		_ = os.Remove(tmpName)
-	}
-}
-
-// readFiveHourCache returns the cached %, its age, and whether it was readable.
-func readFiveHourCache() (float64, time.Duration, bool) {
-	p := fiveHourCachePath()
-	if p == "" {
-		return 0, 0, false
-	}
-	b, err := os.ReadFile(p)
-	if err != nil {
-		return 0, 0, false
-	}
-	var c fiveHourCacheEntry
-	if json.Unmarshal(b, &c) != nil || c.TS.IsZero() {
-		return 0, 0, false
-	}
-	return c.Pct, time.Since(c.TS), true
-}
+// The 5h usage cache lives in the claude_code package so the tmux status bar
+// and this statusline share one file and one format — a write from either
+// surface (or the daemon poll) warms the fallback for both.
 
 // readStatuslineInput reads and decodes the stdin payload. A terminal (no pipe)
 // or malformed JSON yields a zero-value input so the command still renders.

--- a/docs/site/docs/daemon/storage.md
+++ b/docs/site/docs/daemon/storage.md
@@ -104,12 +104,27 @@ Hard-stuck spool files (corrupt JSON, repeated dedup misses) remain on disk unti
 
 ## Retention
 
-Configured under `data.retention_days` in settings.json (default `30`). Two prune jobs run inside the daemon:
+Configured under `data.retention_days` in settings.json (default `30`). The
+daemon keeps the database bounded to this window from both ends — it stops old
+data coming in and prunes old data already stored:
 
-- `PruneOldEvents` — deletes rows from `usage_events` older than the window.
-- `PruneRawEventPayloads` — deletes the heavier blob in `raw_events` older than the window, keeping the row for traceability if needed.
+- **Ingest floor** — collected events whose timestamp is older than the
+  retention window are dropped before they are written. This matters for
+  local-file providers (codex, opencode, and other tools whose session logs
+  carry their full history): without the floor, every collect cycle would
+  re-import months of old-dated events and fight the pruner. A direct
+  consequence is that **history is bounded by `retention_days` even for local
+  sources** — raising the window later does not recover events already dropped.
+- `PruneOldEvents` — deletes rows from `usage_events` older than the window, in
+  bounded batches so a large backlog (for example, one accumulated while the
+  daemon was unstable) always makes progress instead of timing out. It runs at
+  startup, then on a tight catch-up cadence until the backlog is drained and a
+  relaxed cadence afterward.
+- `PruneRawEventPayloads` — clears the heavier payload blob from old raw events,
+  keeping the row for traceability.
 
-Both run on startup and on a periodic timer. After a long downtime, expect the first cycle to take longer.
+After a long downtime, expect the first cycles to clear a backlog before the
+database settles to its steady-state size.
 
 ```json
 {
@@ -138,11 +153,13 @@ sqlite3 ~/.local/state/openusage/telemetry.db ".backup '/path/to/backup.db'"
 On detected corruption (failed page checksum, unreadable header), the daemon:
 
 1. Closes the bad handle.
-2. Renames the file to `telemetry.db.corrupt.{unix-ts}`.
+2. Renames the file to `telemetry.db.corrupt.{timestamp}`.
 3. Removes orphaned `-shm` and `-wal` files.
 4. Reinitializes a fresh `telemetry.db`.
 
-Hooks fired during this window go to the spool and drain into the new DB on next pipeline cycle. The corrupt copy is left in place — delete it once you've confirmed nothing useful remains.
+Hooks fired during this window go to the spool and drain into the new DB on next pipeline cycle. Only the **most recent** corrupt copy is kept for forensics; older `telemetry.db.corrupt.*` snapshots are removed automatically on startup so they cannot accumulate on disk.
+
+To reduce the chance of corruption in the first place, read paths (the dashboard read model) open the database **read-only**: a reader can never modify — and therefore never corrupt — the writer's file, and its queries do not take the write lock or contend with the daemon's writes.
 
 ## Manual cleanup
 

--- a/internal/daemon/retention_floor_test.go
+++ b/internal/daemon/retention_floor_test.go
@@ -1,0 +1,40 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/telemetry"
+)
+
+func TestFilterReqsOlderThan(t *testing.T) {
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	floor := now.Add(-30 * 24 * time.Hour)
+
+	reqs := []telemetry.IngestRequest{
+		{TurnID: "old", OccurredAt: now.Add(-90 * 24 * time.Hour)}, // dropped
+		{TurnID: "edge", OccurredAt: floor.Add(time.Minute)},       // kept (just inside)
+		{TurnID: "recent", OccurredAt: now.Add(-time.Hour)},        // kept
+		{TurnID: "zero"}, // kept (zero == now)
+		{TurnID: "older", OccurredAt: now.Add(-31 * 24 * time.Hour)}, // dropped
+	}
+
+	kept, dropped := filterReqsOlderThan(reqs, floor)
+	if dropped != 2 {
+		t.Errorf("dropped = %d, want 2", dropped)
+	}
+	keptIDs := map[string]bool{}
+	for _, r := range kept {
+		keptIDs[r.TurnID] = true
+	}
+	for _, want := range []string{"edge", "recent", "zero"} {
+		if !keptIDs[want] {
+			t.Errorf("expected %q to be kept", want)
+		}
+	}
+	for _, gone := range []string{"old", "older"} {
+		if keptIDs[gone] {
+			t.Errorf("expected %q to be dropped", gone)
+		}
+	}
+}

--- a/internal/daemon/server_collect.go
+++ b/internal/daemon/server_collect.go
@@ -98,6 +98,17 @@ func (s *Service) collectAndFlush(ctx context.Context) int {
 		allReqs = append(allReqs, reqs...)
 	}
 
+	// Drop collected events older than the retention window before they enter
+	// the store. Local-file telemetry sources (codex/opencode session logs,
+	// etc.) carry their full history, so without this floor every collect cycle
+	// re-ingests months of old-dated events that retention then deletes — a
+	// tug-of-war that keeps the DB bloated and retention permanently behind.
+	// Live hook events are always recent, so this only filters the re-import.
+	allReqs, droppedOld := filterReqsOlderThan(allReqs, s.retentionFloor())
+	if droppedOld > 0 && s.shouldLog("collect_floor_drop", time.Minute) {
+		s.infof("collect_floor_drop", "dropped_pre_retention=%d", droppedOld)
+	}
+
 	direct, retries := s.ingestBatch(ctx, allReqs)
 	if direct.ingested > 0 {
 		s.dataIngested.Store(true)
@@ -165,30 +176,79 @@ func (s *Service) pruneTelemetryOrphans(ctx context.Context) {
 }
 
 func (s *Service) runRetentionLoop(ctx context.Context) {
-	s.pruneOldData(ctx)
-	ticker := time.NewTicker(6 * time.Hour)
-	defer ticker.Stop()
+	// Steady-state cadence once the backlog is drained; a tighter cadence while
+	// catching up so a large one-time backlog (e.g. months accumulated while
+	// retention was stalled) drains in minutes instead of over many 6h ticks.
+	const idleInterval = 6 * time.Hour
+	const catchUpInterval = 1 * time.Minute
+
+	timer := time.NewTimer(0) // first run immediately
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			s.infof("retention_loop_stop", "reason=context_done")
 			return
-		case <-ticker.C:
-			s.pruneOldData(ctx)
+		case <-timer.C:
+			complete := s.pruneOldData(ctx)
+			if complete {
+				timer.Reset(idleInterval)
+			} else {
+				timer.Reset(catchUpInterval)
+			}
 		}
 	}
 }
 
-func (s *Service) pruneOldData(ctx context.Context) {
+// retentionDaysOrDefault resolves the configured retention window, defaulting
+// to 30 days when unset or invalid.
+func (s *Service) retentionDaysOrDefault() int {
+	cfg, err := config.Load()
+	if err != nil {
+		return 30
+	}
+	if cfg.Data.RetentionDays > 0 {
+		return cfg.Data.RetentionDays
+	}
+	return 30
+}
+
+// retentionFloor is the oldest occurred_at that collected events may have and
+// still be worth ingesting. Events before it would be pruned almost
+// immediately, so they are dropped at the door instead.
+func (s *Service) retentionFloor() time.Time {
+	return s.now().Add(-time.Duration(s.retentionDaysOrDefault()) * 24 * time.Hour)
+}
+
+// filterReqsOlderThan returns the requests whose OccurredAt is at or after floor
+// (keeping any with a zero timestamp, which are treated as "now"), plus the
+// count dropped. The input slice is filtered in place.
+func filterReqsOlderThan(reqs []telemetry.IngestRequest, floor time.Time) ([]telemetry.IngestRequest, int) {
+	kept := reqs[:0]
+	dropped := 0
+	for _, r := range reqs {
+		if !r.OccurredAt.IsZero() && r.OccurredAt.Before(floor) {
+			dropped++
+			continue
+		}
+		kept = append(kept, r)
+	}
+	return kept, dropped
+}
+
+// pruneOldData runs one retention pass and reports whether the event backlog is
+// fully drained. A false return means the prune stopped early (budget/context)
+// and the caller should reschedule soon to keep catching up.
+func (s *Service) pruneOldData(ctx context.Context) (complete bool) {
 	if s == nil || s.store == nil {
-		return
+		return true
 	}
 	cfg, err := config.Load()
 	if err != nil {
 		if s.shouldLog("retention_config_error", 30*time.Second) {
 			s.warnf("retention_config_error", "error=%v", err)
 		}
-		return
+		return true
 	}
 	retentionDays := cfg.Data.RetentionDays
 	if retentionDays <= 0 {
@@ -208,13 +268,14 @@ func (s *Service) pruneOldData(ctx context.Context) {
 		s.infof("balance_prune", "thinned=%d retention_days=%d", thinned, retentionDays)
 	}
 
-	deleted, err := s.store.PruneOldEvents(pruneCtx, retentionDays)
+	deleted, drained, err := s.store.PruneOldEvents(pruneCtx, retentionDays)
 	if err != nil {
 		if s.shouldLog("retention_prune_error", 30*time.Second) {
 			s.warnf("retention_prune_error", "error=%v", err)
 		}
-		return
+		return false
 	}
+	complete = drained
 	if deleted > 0 {
 		s.infof("retention_prune", "deleted=%d retention_days=%d", deleted, retentionDays)
 		orphanCtx, orphanCancel := context.WithTimeout(ctx, 10*time.Second)
@@ -226,8 +287,14 @@ func (s *Service) pruneOldData(ctx context.Context) {
 			s.infof("retention_orphan_prune", "removed=%d", orphaned)
 		}
 
-		// Reclaim disk space after significant deletions.
-		if deleted > 1000 {
+		// Reclaim disk space only after a large backlog cleanup. A full VACUUM
+		// rewrites the whole file under an exclusive lock, blocking every reader
+		// for its duration (a source of read-model timeouts), so it must not run
+		// on routine daily deletions. Freed pages from small deletes are reused
+		// by SQLite in place; the file only needs compacting after a big purge
+		// (e.g. a first run that clears months of accumulated backlog).
+		const vacuumThreshold = 20000
+		if deleted > vacuumThreshold {
 			vacCtx, vacCancel := context.WithTimeout(ctx, 5*time.Minute)
 			defer vacCancel()
 			if err := s.store.Vacuum(vacCtx); err != nil {
@@ -240,4 +307,5 @@ func (s *Service) pruneOldData(ctx context.Context) {
 			}
 		}
 	}
+	return complete
 }

--- a/internal/daemon/service_darwin.go
+++ b/internal/daemon/service_darwin.go
@@ -153,7 +153,12 @@ func launchdPlist(exePath, socketPath, stdoutPath, stderrPath string, env map[st
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
-	<true/>
+	<dict>
+		<key>Crashed</key>
+		<true/>
+	</dict>
+	<key>ThrottleInterval</key>
+	<integer>30</integer>
 	<key>StandardOutPath</key>
 	<string>%s</string>
 	<key>StandardErrorPath</key>

--- a/internal/providers/claude_code/claude_code.go
+++ b/internal/providers/claude_code/claude_code.go
@@ -456,9 +456,24 @@ func (p *Provider) readUsageAPI(ctx context.Context, orgUUID string, snap *core.
 
 	p.setCachedUsage(usage)
 	applyUsageResponse(usage, snap, time.Now())
+	cacheFiveHourFromSnapshot(snap)
 
 	snap.Raw["usage_api_ok"] = "true"
 	return nil
+}
+
+// cacheFiveHourFromSnapshot persists the freshly-resolved 5h usage % to the
+// shared disk cache. Surfaces that render under a tight time budget (the tmux
+// status bar, the statusline) cannot afford the slow live usage fetch, so any
+// full fetch — most importantly the daemon's 30s poll — warms this fallback
+// for them. Best-effort: a missing metric or unwritable cache is ignored.
+func cacheFiveHourFromSnapshot(snap *core.UsageSnapshot) {
+	if snap == nil {
+		return
+	}
+	if m, ok := snap.Metrics["usage_five_hour"]; ok && m.Used != nil {
+		WriteFiveHourCache(*m.Used)
+	}
 }
 
 func (p *Provider) getCachedUsage() *usageResponse {

--- a/internal/providers/claude_code/usage_cache.go
+++ b/internal/providers/claude_code/usage_cache.go
@@ -1,0 +1,86 @@
+package claude_code
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// The 5-hour usage utilization comes from the claude.ai usage API, which is
+// slow to reach (cookie extraction + network round-trip). Surfaces that render
+// under a tight time budget — the tmux status bar (~800ms self-kill) and the
+// Claude Code statusline — cannot afford that fetch on every render. So any
+// process that *does* obtain the value (the daemon's 30s poll, a TUI poll, a
+// generous-budget render) writes it to a tiny shared cache file, and the
+// budget-limited surfaces read it back instead of fetching live.
+//
+// The file format is intentionally the same shape the statusline has always
+// written (`{"pct":..,"ts":..}`) so the cache is shared, not duplicated: a
+// write from any surface warms the fallback for all of them.
+
+// usageCacheEntry is the on-disk shape of the shared 5h-usage cache.
+type usageCacheEntry struct {
+	Pct float64   `json:"pct"`
+	TS  time.Time `json:"ts"`
+}
+
+// UsageCachePath returns the shared 5h-usage cache file, or "" when the home
+// directory cannot be resolved (in which case caching is silently skipped).
+func UsageCachePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".cache", "openusage", "statusline-5h.json")
+}
+
+// WriteFiveHourCache overwrites the shared cache atomically (temp + rename) so
+// concurrent readers from parallel render processes can never observe a
+// half-written file. Best-effort: any error is swallowed.
+func WriteFiveHourCache(pct float64) {
+	p := UsageCachePath()
+	if p == "" {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(p), 0o755)
+	b, err := json.Marshal(usageCacheEntry{Pct: pct, TS: time.Now()})
+	if err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(p), ".statusline-5h-*.tmp")
+	if err != nil {
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpName)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return
+	}
+	if err := os.Rename(tmpName, p); err != nil {
+		_ = os.Remove(tmpName)
+	}
+}
+
+// ReadFiveHourCache returns the cached 5h usage %, its age, and whether it was
+// readable. Callers decide their own staleness tolerance from the age.
+func ReadFiveHourCache() (pct float64, age time.Duration, ok bool) {
+	p := UsageCachePath()
+	if p == "" {
+		return 0, 0, false
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return 0, 0, false
+	}
+	var c usageCacheEntry
+	if json.Unmarshal(b, &c) != nil || c.TS.IsZero() {
+		return 0, 0, false
+	}
+	return c.Pct, time.Since(c.TS), true
+}

--- a/internal/providers/claude_code/usage_cache_test.go
+++ b/internal/providers/claude_code/usage_cache_test.go
@@ -1,0 +1,56 @@
+package claude_code
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFiveHourCacheRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if _, _, ok := ReadFiveHourCache(); ok {
+		t.Fatalf("expected no cache before any write")
+	}
+
+	WriteFiveHourCache(42.5)
+
+	pct, age, ok := ReadFiveHourCache()
+	if !ok {
+		t.Fatalf("expected cache to be readable after write")
+	}
+	if pct != 42.5 {
+		t.Errorf("pct = %v, want 42.5", pct)
+	}
+	if age < 0 || age > time.Minute {
+		t.Errorf("age = %v, want a small non-negative duration", age)
+	}
+
+	// The on-disk file must live at the shared statusline path so the bar and
+	// the statusline read the same cache.
+	want := filepath.Join(home, ".cache", "openusage", "statusline-5h.json")
+	if got := UsageCachePath(); got != want {
+		t.Errorf("UsageCachePath() = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("cache file not at shared path: %v", err)
+	}
+}
+
+func TestReadFiveHourCacheRejectsCorrupt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := UsageCachePath()
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok := ReadFiveHourCache(); ok {
+		t.Errorf("expected corrupt cache to be rejected")
+	}
+}

--- a/internal/telemetry/read_model.go
+++ b/internal/telemetry/read_model.go
@@ -78,14 +78,25 @@ func ApplyCanonicalTelemetryViewWithOptions(
 	}
 
 	done := trace("db open+configure")
-	db, err := sql.Open("sqlite3", dbPath)
+	// The read model only reads. Open read-only so reads never take the write
+	// lock and never risk corrupting the writer's file; this is what keeps a
+	// busy poller/checkpoint from blocking dashboard reads past their timeout.
+	db, err := openReadOnlyDB(dbPath)
 	if err != nil {
-		return snaps, fmt.Errorf("open telemetry read model db: %w", err)
+		// Read-only open can fail in rare states (e.g. a WAL DB whose writer
+		// is not yet up, so -shm is absent). Fall back to a read-write handle.
+		// This path runs inside the writer process, so it adds no corruption
+		// risk beyond the previous behavior.
+		db, err = sql.Open("sqlite3", dbPath)
+		if err != nil {
+			return snaps, fmt.Errorf("open telemetry read model db: %w", err)
+		}
+		if cfgErr := configureSQLiteConnection(db); cfgErr != nil {
+			_ = db.Close()
+			return snaps, fmt.Errorf("configure telemetry read model db: %w", cfgErr)
+		}
 	}
 	defer db.Close()
-	if err := configureSQLiteConnection(db); err != nil {
-		return snaps, fmt.Errorf("configure telemetry read model db: %w", err)
-	}
 	done()
 
 	done = trace("hydrateRootsFromLimitSnapshots")

--- a/internal/telemetry/retention_test.go
+++ b/internal/telemetry/retention_test.go
@@ -1,0 +1,131 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPruneCorruptBackupsKeepsNewest(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "telemetry.db")
+
+	// Three corrupt snapshots with increasing modtimes, plus a -wal sidecar
+	// for the newest that should survive alongside it.
+	mk := func(name string, age time.Duration) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		mt := time.Now().Add(-age)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	oldest := mk("telemetry.db.corrupt.20260101T000000", 72*time.Hour)
+	middle := mk("telemetry.db.corrupt.bak", 48*time.Hour)
+	newest := mk("telemetry.db.corrupt.20260601T000000", 1*time.Hour)
+	// An unrelated file must be left untouched.
+	keepMe := mk("telemetry.db", 0)
+
+	pruneCorruptBackups(dbPath, 1)
+
+	if _, err := os.Stat(newest); err != nil {
+		t.Errorf("newest corrupt backup should be kept: %v", err)
+	}
+	if _, err := os.Stat(keepMe); err != nil {
+		t.Errorf("live db file must not be touched: %v", err)
+	}
+	for _, gone := range []string{oldest, middle} {
+		if _, err := os.Stat(gone); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, err=%v", filepath.Base(gone), err)
+		}
+	}
+}
+
+func TestPruneOldEventsBatchedRemovesBacklog(t *testing.T) {
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "telemetry.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	if err := store.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Insert a backlog larger than one batch so the loop must iterate, split
+	// across "old" (beyond retention) and "recent" (within retention).
+	const oldCount = pruneEventsBatch + 1500
+	const recentCount = 50
+	insert := func(n int, occurredAt time.Time) {
+		for i := 0; i < n; i++ {
+			id := fmt.Sprintf("%s-%d", occurredAt.Format("20060102"), i)
+			ts := occurredAt.Format(time.RFC3339Nano)
+			if _, err := db.Exec(`INSERT INTO usage_raw_events
+				(raw_event_id, ingested_at, source_system, source_channel, source_schema_version, source_payload, source_payload_hash)
+				VALUES (?, ?, 'test', 'api', 'v1', '{}', ?)`, id, ts, id); err != nil {
+				t.Fatalf("insert raw: %v", err)
+			}
+			if _, err := db.Exec(`INSERT INTO usage_events
+				(event_id, occurred_at, provider_id, account_id, agent_name, event_type, status, dedup_key, raw_event_id, normalization_version)
+				VALUES (?, ?, 'p', 'a', 'test', 'tool_usage', 'ok', ?, ?, 'v1')`, id, ts, id, id); err != nil {
+				t.Fatalf("insert event: %v", err)
+			}
+		}
+	}
+	insert(oldCount, time.Now().Add(-90*24*time.Hour))
+	insert(recentCount, time.Now().Add(-1*time.Hour))
+
+	deleted, complete, err := store.PruneOldEvents(context.Background(), 30)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if !complete {
+		t.Errorf("expected backlog to be fully drained")
+	}
+	if deleted != oldCount {
+		t.Errorf("deleted = %d, want %d", deleted, oldCount)
+	}
+
+	var remaining int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM usage_events`).Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != recentCount {
+		t.Errorf("remaining = %d, want %d (recent events must survive)", remaining, recentCount)
+	}
+}
+
+func TestPruneOldEventsCancelledContextReturnsProgress(t *testing.T) {
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "telemetry.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	store := NewStore(db)
+	if err := store.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	// Should return cleanly (0, not-complete, nil) rather than erroring on a dead context.
+	deleted, complete, err := store.PruneOldEvents(ctx, 30)
+	if err != nil {
+		t.Errorf("cancelled prune should not error, got %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 on pre-cancelled context", deleted)
+	}
+	if complete {
+		t.Errorf("complete should be false when context is cancelled before draining")
+	}
+}

--- a/internal/telemetry/sqlite.go
+++ b/internal/telemetry/sqlite.go
@@ -45,6 +45,46 @@ func configureSQLiteConnection(db *sql.DB) error {
 	return nil
 }
 
+// configureSQLiteReadOnlyConnection prepares a read-only handle. Unlike the
+// writer config it runs NO write pragmas: journal_mode/synchronous take the
+// write lock and would serialize every read behind the poller, which is what
+// drove read-model timeouts. query_only is intentionally NOT set because the
+// read model materializes a TEMP table (in the separate temp database, which
+// stays writable even when the main DB is opened read-only).
+//
+// The handle stays single-connection: the materialize + aggregate queries
+// share one connection-local TEMP table, so they must run on the same
+// connection. Cross-request concurrency is unaffected — each read-model call
+// opens its own handle.
+func configureSQLiteReadOnlyConnection(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+	if _, err := db.Exec(`PRAGMA busy_timeout = 5000;`); err != nil {
+		return fmt.Errorf("set busy_timeout: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	return nil
+}
+
+// openReadOnlyDB opens path with the main database read-only, so it cannot take
+// the write lock or modify (and thus corrupt) the writer's file; in WAL mode
+// (writer process keeping -wal/-shm present) its reads run concurrently with
+// the writer. Returns an error if the handle cannot be validated; callers
+// decide whether to fall back.
+func openReadOnlyDB(path string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite3", "file:"+path+"?mode=ro&_busy_timeout=5000")
+	if err != nil {
+		return nil, err
+	}
+	if err := configureSQLiteReadOnlyConnection(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
 // quickIntegrityCheck runs PRAGMA quick_check(1) which examines the first
 // page of each B-tree. It catches the most common corruption patterns
 // (duplicate page refs, free-list errors) in O(tables) time rather than the

--- a/internal/telemetry/store.go
+++ b/internal/telemetry/store.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -84,12 +85,75 @@ func OpenStore(path string) (*Store, error) {
 		}
 	}
 
+	// Reclaim disk from past corruption rotations. Each corruption event renames
+	// the DB to "<path>.corrupt.<ts>" and starts fresh; these snapshots are
+	// corrupt by definition and never read again, so they only waste disk (they
+	// have grown to multiple GB in the field). Keep the most recent one for
+	// forensics and delete the rest.
+	pruneCorruptBackups(path, 1)
+
 	store := NewStore(db)
 	if err := store.Init(context.Background()); err != nil {
 		db.Close()
 		return nil, err
 	}
 	return store, nil
+}
+
+// pruneCorruptBackups removes old "<dbPath>.corrupt.*" snapshots, keeping the
+// newest `keep` by modification time. Best-effort: errors are logged but never
+// fatal. Companion -wal/-shm files for each removed snapshot are removed too.
+func pruneCorruptBackups(dbPath string, keep int) {
+	if keep < 0 {
+		keep = 0
+	}
+	matches, err := filepath.Glob(dbPath + ".corrupt.*")
+	if err != nil || len(matches) == 0 {
+		return
+	}
+	// Only consider the base snapshot files, not their -wal/-shm sidecars.
+	bases := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if strings.HasSuffix(m, "-wal") || strings.HasSuffix(m, "-shm") {
+			continue
+		}
+		bases = append(bases, m)
+	}
+	if len(bases) <= keep {
+		return
+	}
+	// Sort newest-first by modtime so the first `keep` are retained.
+	type backup struct {
+		path string
+		mod  time.Time
+	}
+	infos := make([]backup, 0, len(bases))
+	for _, b := range bases {
+		fi, statErr := os.Stat(b)
+		if statErr != nil {
+			continue
+		}
+		infos = append(infos, backup{path: b, mod: fi.ModTime()})
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].mod.After(infos[j].mod) })
+
+	var freed int64
+	removed := 0
+	for _, b := range infos[min(keep, len(infos)):] {
+		if fi, statErr := os.Stat(b.path); statErr == nil {
+			freed += fi.Size()
+		}
+		if rmErr := os.Remove(b.path); rmErr != nil {
+			log.Printf("telemetry: could not remove stale corrupt backup %s: %v", b.path, rmErr)
+			continue
+		}
+		_ = os.Remove(b.path + "-wal")
+		_ = os.Remove(b.path + "-shm")
+		removed++
+	}
+	if removed > 0 {
+		log.Printf("telemetry: removed %d stale corrupt DB backup(s), reclaimed %d MB", removed, freed/(1024*1024))
+	}
 }
 
 func NewStore(db *sql.DB) *Store {
@@ -769,21 +833,51 @@ func nullableFloat64(v *float64) interface{} {
 	return *v
 }
 
-// PruneOldEvents deletes usage_events older than retentionDays and returns the count deleted.
-func (s *Store) PruneOldEvents(ctx context.Context, retentionDays int) (int64, error) {
+// pruneEventsBatch is the number of rows PruneOldEvents deletes per statement.
+// Bounded so each DELETE holds the write lock briefly and the loop always makes
+// forward progress even under poll/checkpoint contention — a single unbounded
+// DELETE of a large backlog can lose its write-lock race and time out, which is
+// how retention silently stalled in the field (months of data accumulating
+// despite a correct 30-day policy).
+const pruneEventsBatch = 5000
+
+// PruneOldEvents deletes usage_events older than retentionDays in bounded
+// batches. It returns the number of rows deleted and whether the backlog was
+// fully drained (complete=false means it stopped early — context cancelled or
+// a batch error after partial progress — so a backlog remains and the caller
+// should reschedule soon rather than wait a full interval).
+func (s *Store) PruneOldEvents(ctx context.Context, retentionDays int) (deleted int64, complete bool, err error) {
 	if s == nil || s.db == nil || retentionDays <= 0 {
-		return 0, nil
+		return 0, true, nil
 	}
 	cutoff := fmt.Sprintf("-%d day", retentionDays)
-	result, err := s.db.ExecContext(ctx, `
-		DELETE FROM usage_events
-		WHERE occurred_at < datetime('now', ?)
-	`, cutoff)
-	if err != nil {
-		return 0, fmt.Errorf("telemetry: prune old events: %w", err)
+	for {
+		if ctx.Err() != nil {
+			return deleted, false, nil
+		}
+		// mattn/go-sqlite3 isn't built with the DELETE...LIMIT extension, so
+		// scope the delete via a subselect on the indexed occurred_at column.
+		result, execErr := s.db.ExecContext(ctx, `
+			DELETE FROM usage_events
+			WHERE event_id IN (
+				SELECT event_id FROM usage_events
+				WHERE occurred_at < datetime('now', ?)
+				ORDER BY occurred_at ASC
+				LIMIT ?
+			)
+		`, cutoff, pruneEventsBatch)
+		if execErr != nil {
+			if deleted > 0 {
+				return deleted, false, nil
+			}
+			return 0, false, fmt.Errorf("telemetry: prune old events: %w", execErr)
+		}
+		n, _ := result.RowsAffected()
+		deleted += n
+		if n < pruneEventsBatch {
+			return deleted, true, nil
+		}
 	}
-	deleted, _ := result.RowsAffected()
-	return deleted, nil
 }
 
 func (s *Store) PruneOrphanRawEvents(ctx context.Context, limit int) (int64, error) {

--- a/internal/telemetry/store_test.go
+++ b/internal/telemetry/store_test.go
@@ -460,9 +460,12 @@ func TestStorePruneOldEvents_DeletesExpiredEventsOnly(t *testing.T) {
 	}
 
 	// Prune with 30-day retention: should delete the 2 old events.
-	deleted, err := store.PruneOldEvents(context.Background(), 30)
+	deleted, complete, err := store.PruneOldEvents(context.Background(), 30)
 	if err != nil {
 		t.Fatalf("PruneOldEvents: %v", err)
+	}
+	if !complete {
+		t.Fatalf("expected prune to fully drain the backlog")
 	}
 	if deleted != 2 {
 		t.Fatalf("deleted = %d, want 2", deleted)
@@ -494,7 +497,7 @@ func TestStorePruneOldEvents_DeletesExpiredEventsOnly(t *testing.T) {
 	}
 
 	// Edge case: retentionDays <= 0 should be a no-op.
-	noOp, err := store.PruneOldEvents(context.Background(), 0)
+	noOp, _, err := store.PruneOldEvents(context.Background(), 0)
 	if err != nil {
 		t.Fatalf("PruneOldEvents(0): %v", err)
 	}

--- a/internal/tmux/context.go
+++ b/internal/tmux/context.go
@@ -198,10 +198,48 @@ func BuildContext(ctx context.Context, opts BuildOptions) (Context, error) {
 	// conversation log. Failures are non-fatal: the formatter falls back to
 	// the snapshot Metrics map when the synthetic key is missing.
 	if c.Provider == "claude_code" {
+		reconcileFiveHourUsage(&c)
 		populateClaudeCodeSynthetics(&c, opts)
 	}
 
 	return c, nil
+}
+
+// fiveHourCacheMaxAge bounds how stale the disk-cached 5h usage % may be before
+// the bar stops trusting it. The 5h window moves slowly and the daemon refreshes
+// the cache every poll, so a generous bound keeps the segment populated through
+// transient daemon/usage-API slowness while still expiring after a long idle.
+const fiveHourCacheMaxAge = 15 * time.Minute
+
+// reconcileFiveHourUsage keeps the bar's 5h segment (block_pct) populated even
+// when the live snapshot lacks usage_five_hour. The metric originates from the
+// slow claude.ai usage API, which the budget-limited render frequently can't
+// reach (a slow daemon read-model forces a direct fallback that times out on
+// the fetch). So:
+//   - when the snapshot HAS the metric, persist it so future budget-limited
+//     renders have a warm fallback;
+//   - when it's MISSING, inject a recent cached value so block_pct resolves
+//     instead of the segment silently dropping.
+func reconcileFiveHourUsage(c *Context) {
+	if m, ok := c.Snapshot.Metrics["usage_five_hour"]; ok && m.Used != nil {
+		claude_code.WriteFiveHourCache(*m.Used)
+		return
+	}
+	pct, age, ok := claude_code.ReadFiveHourCache()
+	if !ok || age > fiveHourCacheMaxAge {
+		return
+	}
+	if c.Snapshot.Metrics == nil {
+		c.Snapshot.Metrics = map[string]core.Metric{}
+	}
+	limit := 100.0
+	used := pct
+	c.Snapshot.Metrics["usage_five_hour"] = core.Metric{
+		Used:   &used,
+		Limit:  &limit,
+		Unit:   "%",
+		Window: "5h",
+	}
 }
 
 // populateClaudeCodeSynthetics computes the active billing block (cost,

--- a/internal/tmux/fivehour_cache_test.go
+++ b/internal/tmux/fivehour_cache_test.go
@@ -1,0 +1,74 @@
+package tmux
+
+import (
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/janekbaraniewski/openusage/internal/providers/claude_code"
+)
+
+func ptr(v float64) *float64 { return &v }
+
+// When the live snapshot carries usage_five_hour, reconcile persists it so a
+// later budget-limited render has a warm fallback.
+func TestReconcileFiveHourWritesCacheWhenPresent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	c := &Context{
+		Provider: "claude_code",
+		Snapshot: core.UsageSnapshot{
+			ProviderID: "claude_code",
+			Metrics:    map[string]core.Metric{"usage_five_hour": {Used: ptr(7), Unit: "%", Window: "5h"}},
+		},
+	}
+	reconcileFiveHourUsage(c)
+
+	if pct, _, ok := claude_code.ReadFiveHourCache(); !ok || pct != 7 {
+		t.Fatalf("cache not warmed: ok=%v pct=%v, want ok=true pct=7", ok, pct)
+	}
+}
+
+// When the live snapshot is missing usage_five_hour (the slow usage API didn't
+// resolve within budget), reconcile injects a recent cached value so block_pct
+// still renders instead of the 5h segment silently dropping.
+func TestReconcileFiveHourInjectsFromCacheWhenMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	claude_code.WriteFiveHourCache(13)
+
+	c := &Context{
+		Provider: "claude_code",
+		Snapshot: core.UsageSnapshot{
+			ProviderID: "claude_code",
+			Metrics:    map[string]core.Metric{"today_api_cost": {Used: ptr(98.7), Unit: "USD"}},
+		},
+	}
+	reconcileFiveHourUsage(c)
+
+	m, ok := c.Snapshot.Metrics["usage_five_hour"]
+	if !ok || m.Used == nil {
+		t.Fatalf("usage_five_hour not injected from cache")
+	}
+	if *m.Used != 13 {
+		t.Errorf("injected pct = %v, want 13", *m.Used)
+	}
+	// block_pct must now resolve through the normal alias chain.
+	r := &renderer{ctx: *c}
+	if v, ok := r.resolve("block_pct"); !ok || v != "13" {
+		t.Errorf("block_pct resolve = %q ok=%v, want \"13\" ok=true", v, ok)
+	}
+}
+
+// A cold cache leaves the segment empty rather than fabricating a value.
+func TestReconcileFiveHourNoCacheLeavesMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	c := &Context{
+		Provider: "claude_code",
+		Snapshot: core.UsageSnapshot{ProviderID: "claude_code", Metrics: map[string]core.Metric{}},
+	}
+	reconcileFiveHourUsage(c)
+
+	if _, ok := c.Snapshot.Metrics["usage_five_hour"]; ok {
+		t.Errorf("expected no injection when cache is cold")
+	}
+}


### PR DESCRIPTION
## Why

The tmux status bar stopped showing the 5h usage quota (`✷ $X/today` with no `5h N%`). Investigating that surfaced deeper telemetry-storage problems: a daemon that had restarted 150+ times, recurring DB corruption leaving ~4 GB of orphaned `.corrupt.*` snapshots, and retention that was configured (30 days) but completely ineffective — the live DB held 7 months of data.

## Root causes

1. **Bar quota dropped** — the 5h % comes from the slow claude.ai usage API. Under the bar's ~800 ms render budget (and when a busy daemon read forced a direct fallback), that fetch couldn't complete, so the segment silently vanished.
2. **Retention never bounded the DB** — two independent bugs:
   - Local-file providers (codex, opencode, …) re-ingest their *entire* session history every collect cycle. The pruner deleted everything past the window; the next poll re-imported it; they fought forever.
   - `PruneOldEvents` ran as one unbounded `DELETE` that lost the write-lock race under contention and timed out, never clearing a backlog.
3. **Read-model timeouts** — the read model opened a read-write connection and ran `journal_mode=WAL` (a write) on every request, serializing reads behind the poller's writes.
4. **Restart loop** — the launchd plist used `KeepAlive=true`, relaunching the daemon on *any* exit.

## What this changes

- **tmux bar**: cache the 5h % to a shared disk file on every successful Claude Code fetch (incl. the daemon's 30 s poll) and read it back as a fallback when the live snapshot lacks it. The statusline shares the same cache.
- **Retention**: an **ingest-time floor** drops collected events older than the window before they're written (history is now bounded by `retention_days` even for local sources); `PruneOldEvents` deletes in **bounded batches** with an **adaptive catch-up cadence**; VACUUM only after large cleanups.
- **Corruption hygiene**: keep only the newest `.corrupt.*` snapshot, delete the rest on startup.
- **Concurrency**: the read model opens **read-only** (`mode=ro`, no write pragmas) — reads never take the write lock or corrupt the writer's file; safe RW fallback retained.
- **launchd**: `KeepAlive={Crashed:true}` + `ThrottleInterval=30` so a clean "already running" exit can't tight-loop.

## Verified on a live system (before → after)

| | Before | After |
|---|---|---|
| State dir on disk | 8.9 GB | 391 MB |
| Live DB | 167 MB, 7 months | 99 MB, bounded to 30 days |
| Events past retention | 50,574 (churning back) | 0, stays 0 |
| Daemon read latency | timing out at 5 s | 0.58 s |
| tmux bar | `✷ $X/today` | `✷ 5h 20% $X/today` |

## Tests

New: corrupt-backup cleanup, batched prune (+ cancelled-context, + completeness flag), ingest floor, 5h cache round-trip, tmux fallback injection. `go build ./...`, `go vet`, `gofmt`, and all touched-package suites green. (The only failing test in the repo, `daemon` `TestChangeDetectorReturnsFalse_WhenNoFiles`, fails on clean `main` too — a machine-state flake.)

## Docs

`docs/site/docs/daemon/storage.md` updated (ingest floor, batched/adaptive prune, corrupt-backup retention, read-only reads). Docs site builds with `[SUCCESS]`, no broken links.

## Not included

Tiered hourly/daily rollups (downsampling) were scoped but deferred: with retention now holding the DB at ~30 d / ~100 MB and reads at 0.58 s, rollups are a future query-speed optimization rather than a size necessity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
