### PR TITLE
ci: refresh Dependabot PRs after auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,7 +1,7 @@
 name: Dependabot auto-merge
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 permissions:
@@ -32,21 +32,25 @@ jobs:
 
       - name: Approve the PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::AUTOMATION_TOKEN is required so Dependabot auto-merges trigger follow-up workflows."
+            exit 1
+          fi
           gh pr review --approve "$PR_URL" --body "Auto-approved by policy."
 
       - name: Add auto-approved label
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr edit "$PR_URL" --add-label auto-approved
 
       - name: Enable auto-merge (squash)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-rebase-on-main.yaml
+++ b/.github/workflows/dependabot-rebase-on-main.yaml
@@ -3,6 +3,8 @@ name: Dependabot rebase open PRs on main update
 on:
   push:
     branches: [main]
+  schedule:
+    - cron: "17 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -14,6 +16,7 @@ jobs:
   refresh-dependabot-prs:
     name: Refresh open Dependabot PRs
     uses: ./.github/workflows/refresh-dependabot-prs.yaml
-    secrets: inherit
+    secrets:
+      AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- run the Dependabot auto-merge workflow as pull_request_target so repository automation secrets are available without checking out PR code
- use AUTOMATION_TOKEN for Dependabot approval, labeling, and auto-merge so the resulting main push can trigger follow-up workflows
- pass AUTOMATION_TOKEN explicitly into the reusable Dependabot branch refresh workflow

## Why

Dependabot PRs were merging as app/github-actions through GITHUB_TOKEN. Those pushes do not trigger the push-based branch refresh workflow, so the remaining Dependabot PRs stayed BEHIND under strict required checks.

## Validation

- ruby YAML parse for the three Dependabot workflow files