### PR TITLE
feat(claude_code): OAuth usage-API fallback so the 5h/7d gauge works off-macOS

### DIFF
--- a/docs/site/docs/providers/claude-code.md
+++ b/docs/site/docs/providers/claude-code.md
@@ -146,6 +146,12 @@ Family is matched by substring on the model name (e.g. `claude-3-5-sonnet-…` �
 - Source: `GET https://claude.ai/api/organizations/{org_uuid}/usage` with session cookies imported via Settings → 5 KEYS. Returns aggregate per-day usage for the entire organization.
 - Transform: when available, the response is cached in memory and applied on top of the local data. Errors fall back to the cached response (if any) so transient failures don't blank the tile.
 
+### 5h / 7d utilization gauge (`usage_five_hour`, `usage_seven_day`)
+
+- Source (macOS): the Claude **desktop app's** session cookies, decrypted from the macOS keychain, are used to call the usage API above.
+- Source (fallback, all platforms): when desktop-app cookie extraction is unavailable — anywhere but macOS, or when the desktop app isn't installed — the provider reads the Claude Code CLI's own OAuth access token from `~/.claude/.credentials.json` and calls `GET https://api.anthropic.com/api/oauth/usage`. This needs no organization UUID (the token is account-scoped) and no desktop app, so the 5h/7d gauges work on Linux and Windows. An expired token is skipped (Claude Code refreshes it on next use).
+- Transform: the response (same `five_hour` / `seven_day` utilization shape from either source) populates the gauges and warms the shared 5h cache read by the statusline and tmux segments.
+
 ### Auth status
 
 - Source: derived from data presence. If neither `stats-cache.json`, `~/.claude.json`, nor any JSONL produced data, status becomes `error` (`No Claude Code stats data accessible`). Otherwise `ok` with the message `Claude Code CLI · costs are API-equivalent estimates, not subscription charges`.
@@ -171,7 +177,8 @@ On Linux the provider also probes `~/.config/claude/projects/` as a fallback.
 
 ## API endpoints used
 
-- Optional: `GET https://claude.ai/api/organizations/{org_uuid}/usage` — only when browser-session cookies are imported. See [Daemon integrations](../daemon/integrations.md).
+- Optional: `GET https://claude.ai/api/organizations/{org_uuid}/usage` — only when browser-session cookies are imported (macOS desktop app). See [Daemon integrations](../daemon/integrations.md).
+- Optional: `GET https://api.anthropic.com/api/oauth/usage` — off-macOS fallback for the 5h/7d utilization gauge, authenticated with the Claude Code OAuth token from `~/.claude/.credentials.json`.
 
 ## Caveats
 

--- a/internal/providers/claude_code/claude_code.go
+++ b/internal/providers/claude_code/claude_code.go
@@ -436,12 +436,21 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 func (p *Provider) readUsageAPI(ctx context.Context, orgUUID string, snap *core.UsageSnapshot) error {
 	cookies, err := getClaudeSessionCookies()
 	if err != nil {
+		usage, oauthErr := fetchUsageAPIOAuth(ctx)
+		if oauthErr == nil {
+			p.setCachedUsage(usage)
+			applyUsageResponse(usage, snap, time.Now())
+			cacheFiveHourFromSnapshot(snap)
+			snap.Raw["usage_api_ok"] = "true"
+			snap.Raw["usage_api_source"] = "oauth"
+			return nil
+		}
 		if cached := p.getCachedUsage(); cached != nil {
 			applyUsageResponse(cached, snap, time.Now())
 			snap.Raw["usage_api_cached"] = "true"
 			return nil
 		}
-		return fmt.Errorf("cookie extraction: %w", err)
+		return fmt.Errorf("cookie extraction: %v; oauth fallback: %w", err, oauthErr)
 	}
 
 	usage, err := fetchUsageAPI(ctx, orgUUID, cookies)

--- a/internal/providers/claude_code/usage_api.go
+++ b/internal/providers/claude_code/usage_api.go
@@ -224,3 +224,87 @@ func fetchUsageAPI(ctx context.Context, orgUUID string, cookies map[string]strin
 
 	return &usage, nil
 }
+
+// oauthUsageURL is Anthropic's OAuth-scoped usage endpoint. It is a package
+// variable rather than a constant so tests can point it at an httptest server.
+var oauthUsageURL = "https://api.anthropic.com/api/oauth/usage"
+
+// readClaudeCodeOAuthToken loads the Claude Code CLI's OAuth access token from
+// ~/.claude/.credentials.json. It errors if the file is missing, the token is
+// absent, or the token has already expired (Claude Code refreshes it on next
+// use, so a stale value would only produce 401s).
+func readClaudeCodeOAuthToken() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+
+	credsPath := filepath.Join(home, ".claude", ".credentials.json")
+	credsData, err := os.ReadFile(credsPath)
+	if err != nil {
+		return "", fmt.Errorf("reading Claude Code credentials: %w", err)
+	}
+
+	var creds struct {
+		ClaudeAiOauth struct {
+			AccessToken string `json:"accessToken"`
+			ExpiresAt   int64  `json:"expiresAt"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(credsData, &creds); err != nil {
+		return "", fmt.Errorf("parsing Claude Code credentials: %w", err)
+	}
+	token := creds.ClaudeAiOauth.AccessToken
+	if token == "" {
+		return "", fmt.Errorf("no OAuth access token in %s", credsPath)
+	}
+	if exp := creds.ClaudeAiOauth.ExpiresAt; exp > 0 && time.Now().UnixMilli() >= exp {
+		return "", fmt.Errorf("Claude Code OAuth token expired (refreshed on next Claude Code use)")
+	}
+	return token, nil
+}
+
+// fetchUsageAPIOAuth queries Anthropic's OAuth usage endpoint with the Claude
+// Code CLI's own access token. This is the fallback where desktop-app cookie
+// extraction is unavailable (anywhere but macOS), and it needs no org UUID:
+// the token is scoped to the account. The endpoint returns the same
+// five_hour/seven_day utilization shape as the claude.ai usage API, so the
+// response decodes into the same struct.
+func fetchUsageAPIOAuth(ctx context.Context) (*usageResponse, error) {
+	token, err := readClaudeCodeOAuthToken()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", oauthUsageURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	var usage usageResponse
+	if err := json.Unmarshal(body, &usage); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	return &usage, nil
+}

--- a/internal/providers/claude_code/usage_api_oauth_test.go
+++ b/internal/providers/claude_code/usage_api_oauth_test.go
@@ -11,12 +11,21 @@ import (
 	"time"
 )
 
-// writeCredentials drops a fake ~/.claude/.credentials.json under a temp HOME
-// and points os.UserHomeDir at it via HOME.
-func writeCredentials(t *testing.T, body string) {
+// setTempHome points os.UserHomeDir at a fresh temp dir. HOME covers
+// Unix-likes; USERPROFILE is what os.UserHomeDir reads on Windows.
+func setTempHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+// writeCredentials drops a fake ~/.claude/.credentials.json under a temp home
+// directory.
+func writeCredentials(t *testing.T, body string) {
+	t.Helper()
+	home := setTempHome(t)
 	dir := filepath.Join(home, ".claude")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -84,7 +93,7 @@ func TestReadClaudeCodeOAuthToken(t *testing.T) {
 }
 
 func TestReadClaudeCodeOAuthToken_MissingFile(t *testing.T) {
-	t.Setenv("HOME", t.TempDir()) // no .claude/.credentials.json
+	setTempHome(t) // no .claude/.credentials.json
 	if _, err := readClaudeCodeOAuthToken(); err == nil {
 		t.Fatal("expected error for missing credentials file")
 	}

--- a/internal/providers/claude_code/usage_api_oauth_test.go
+++ b/internal/providers/claude_code/usage_api_oauth_test.go
@@ -1,0 +1,145 @@
+package claude_code
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// writeCredentials drops a fake ~/.claude/.credentials.json under a temp HOME
+// and points os.UserHomeDir at it via HOME.
+func writeCredentials(t *testing.T, body string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+}
+
+func TestReadClaudeCodeOAuthToken(t *testing.T) {
+	future := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
+	past := strconv.FormatInt(time.Now().Add(-time.Hour).UnixMilli(), 10)
+
+	tests := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid unexpired token",
+			body: `{"claudeAiOauth":{"accessToken":"tok-123","expiresAt":` + future + `}}`,
+			want: "tok-123",
+		},
+		{
+			name: "no expiry field is accepted",
+			body: `{"claudeAiOauth":{"accessToken":"tok-abc"}}`,
+			want: "tok-abc",
+		},
+		{
+			name:    "expired token rejected",
+			body:    `{"claudeAiOauth":{"accessToken":"tok-123","expiresAt":` + past + `}}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty token rejected",
+			body:    `{"claudeAiOauth":{"accessToken":""}}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed json rejected",
+			body:    `{not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeCredentials(t, tt.body)
+			got, err := readClaudeCodeOAuthToken()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got token %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("token = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadClaudeCodeOAuthToken_MissingFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no .claude/.credentials.json
+	if _, err := readClaudeCodeOAuthToken(); err == nil {
+		t.Fatal("expected error for missing credentials file")
+	}
+}
+
+func TestFetchUsageAPIOAuth(t *testing.T) {
+	var gotAuth, gotBeta string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotBeta = r.Header.Get("anthropic-beta")
+		_, _ = w.Write([]byte(`{"five_hour":{"utilization":42,"resets_at":"2999-01-01T00:00:00Z"},` +
+			`"seven_day":{"utilization":13,"resets_at":"2999-01-01T00:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	old := oauthUsageURL
+	oauthUsageURL = srv.URL
+	defer func() { oauthUsageURL = old }()
+
+	futureMs := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
+	writeCredentials(t, `{"claudeAiOauth":{"accessToken":"tok-xyz","expiresAt":`+futureMs+`}}`)
+
+	usage, err := fetchUsageAPIOAuth(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.FiveHour == nil || usage.FiveHour.Utilization != 42 {
+		t.Fatalf("five_hour utilization = %+v, want 42", usage.FiveHour)
+	}
+	if usage.SevenDay == nil || usage.SevenDay.Utilization != 13 {
+		t.Fatalf("seven_day utilization = %+v, want 13", usage.SevenDay)
+	}
+	if gotAuth != "Bearer tok-xyz" {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer tok-xyz")
+	}
+	if gotBeta != "oauth-2025-04-20" {
+		t.Errorf("anthropic-beta header = %q, want %q", gotBeta, "oauth-2025-04-20")
+	}
+}
+
+func TestFetchUsageAPIOAuth_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid token"}`))
+	}))
+	defer srv.Close()
+
+	old := oauthUsageURL
+	oauthUsageURL = srv.URL
+	defer func() { oauthUsageURL = old }()
+
+	futureMs := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
+	writeCredentials(t, `{"claudeAiOauth":{"accessToken":"tok","expiresAt":`+futureMs+`}}`)
+
+	if _, err := fetchUsageAPIOAuth(context.Background()); err == nil {
+		t.Fatal("expected error on 401 response")
+	}
+}


### PR DESCRIPTION
Hey there! I'm looking forward to using this project. Thanks for making this!

On Linux, the usage gauge wasn't working for me. This is expected, since [internal/providers/claude_code/usage_api.go](https://github.com/janekbaraniewski/openusage/blob/fd8d37d4d8b2f22f1e7cd05db506fc88fb50a53f/internal/providers/claude_code/usage_api.go#L40) only supports macOS.

"I" fixed this by using ClaudeCLI's oauth token as a fallback instead of the macOS-only path. Happy to upstream this!

Tested on Linux

More details courtesy of Claude below.

## Problem

The Claude Code 5h/7d utilization gauge (`usage_five_hour` / `usage_seven_day`)
is sourced from the Claude usage API. Today the provider authenticates it by
decrypting the Claude **desktop app's** session cookies out of the macOS
keychain — `getClaudeSessionCookies()` returns an error on every non-macOS
`GOOS`. So on Linux and Windows the gauge never populates, and the shared 5h
cache that feeds the statusline and tmux segments stays empty.

## Fix

When cookie extraction is unavailable, fall back to the Claude Code CLI's own
OAuth access token from `~/.claude/.credentials.json` and call
`GET https://api.anthropic.com/api/oauth/usage`:

- The token is **account-scoped**, so no organization UUID is required.
- The endpoint returns the same `five_hour` / `seven_day` utilization shape, so
  it decodes into the existing `usageResponse` struct and flows through the same
  `applyUsageResponse` / cache-warming path.
- An **expired** token is skipped rather than sent (Claude Code refreshes it on
  next use, so a stale value would only yield 401s).
- **macOS behavior is unchanged** — OAuth is only attempted *after* the existing
  cookie path fails, so it's a pure fallback. As a bonus it also covers macOS
  users who run the CLI without the desktop app installed.

## Tests

- `readClaudeCodeOAuthToken()` is split out from the HTTP call and the request
  URL is a package var, so both are unit-tested (valid/missing/empty/expired/
  malformed credentials, header assertions, and non-200 handling) using
  `t.TempDir` + `httptest`, no network.
- `go build ./...`, `go vet`, and `go test -race ./internal/providers/claude_code/`
  all pass.

## Docs

`docs/site/docs/providers/claude-code.md` updated to describe the OAuth source
and endpoint; `DOCS_PREVIEW=1 npm run build` completes with `[SUCCESS]` and no
broken-link warnings.

## Notes for reviewers

- No new dependencies.
- The credential file is read locally and the token is only ever sent to
  Anthropic's own `api.anthropic.com` — the same trust boundary Claude Code
  already uses.