### PR TITLE
feat(opencode): add rolling/weekly/monthly quota display via console scraping

### DIFF
--- a/internal/providers/opencode/console_rpc.go
+++ b/internal/providers/opencode/console_rpc.go
@@ -317,12 +317,19 @@ func parseWorkspaceIDsFromBody(body string) []string {
 
 // SubscriptionUsage is the parsed shape of a subscription.get response.
 // Contains rolling 5-hour, weekly, and monthly usage percentages with reset timers.
+//
+// The *OK fields distinguish "field present in the response with a value of
+// 0" from "field absent" — a usagePercent of 0 is a legitimate reading (the
+// quota window just reset) and must not be treated the same as "not found".
 type SubscriptionUsage struct {
 	RollingUsagePct float64
+	RollingUsageOK  bool
 	RollingResetSec int
 	WeeklyUsagePct  float64
+	WeeklyUsageOK   bool
 	WeeklyResetSec  int
 	MonthlyUsagePct float64
+	MonthlyUsageOK  bool
 	MonthlyResetSec int
 	RenewAt         string
 }
@@ -562,8 +569,9 @@ func parseGoUsagePageHTML(html string) (SubscriptionUsage, BillingInfo) {
 	rollingBlockRE := regexp.MustCompile(`rollingUsage:\$R\[\d+\]=\{([^}]+)\}`)
 	if matches := rollingBlockRE.FindStringSubmatch(scriptMatch); len(matches) > 1 {
 		block := matches[1]
-		if v := extractFloatField(block, "usagePercent"); v > 0 {
+		if v, ok := extractFloatFieldOK(block, "usagePercent"); ok {
 			subscription.RollingUsagePct = v
+			subscription.RollingUsageOK = true
 		}
 		if v := extractFloatField(block, "resetInSec"); v > 0 {
 			subscription.RollingResetSec = int(v)
@@ -573,8 +581,9 @@ func parseGoUsagePageHTML(html string) (SubscriptionUsage, BillingInfo) {
 	weeklyBlockRE := regexp.MustCompile(`weeklyUsage:\$R\[\d+\]=\{([^}]+)\}`)
 	if matches := weeklyBlockRE.FindStringSubmatch(scriptMatch); len(matches) > 1 {
 		block := matches[1]
-		if v := extractFloatField(block, "usagePercent"); v > 0 {
+		if v, ok := extractFloatFieldOK(block, "usagePercent"); ok {
 			subscription.WeeklyUsagePct = v
+			subscription.WeeklyUsageOK = true
 		}
 		if v := extractFloatField(block, "resetInSec"); v > 0 {
 			subscription.WeeklyResetSec = int(v)
@@ -584,8 +593,9 @@ func parseGoUsagePageHTML(html string) (SubscriptionUsage, BillingInfo) {
 	monthlyBlockRE := regexp.MustCompile(`monthlyUsage:\$R\[\d+\]=\{([^}]+)\}`)
 	if matches := monthlyBlockRE.FindStringSubmatch(scriptMatch); len(matches) > 1 {
 		block := matches[1]
-		if v := extractFloatField(block, "usagePercent"); v > 0 {
+		if v, ok := extractFloatFieldOK(block, "usagePercent"); ok {
 			subscription.MonthlyUsagePct = v
+			subscription.MonthlyUsageOK = true
 		}
 		if v := extractFloatField(block, "resetInSec"); v > 0 {
 			subscription.MonthlyResetSec = int(v)
@@ -635,6 +645,19 @@ func extractStringField(fields, key string) string {
 		return matches[1]
 	}
 	return ""
+}
+
+// extractFloatFieldOK pulls a numeric value from a Seroval object fragment,
+// reporting via ok whether the field was present at all — distinguishing
+// "field:0" (found, value 0) from "field absent" (not found).
+func extractFloatFieldOK(fields, key string) (float64, bool) {
+	re := regexp.MustCompile(key + `:(-?[0-9]+(?:\.[0-9]+)?)`)
+	matches := re.FindStringSubmatch(fields)
+	if len(matches) < 2 {
+		return 0, false
+	}
+	f, _ := strconv.ParseFloat(matches[1], 64)
+	return f, true
 }
 
 // extractFloatField pulls a numeric value from a Seroval object fragment.

--- a/internal/providers/opencode/console_rpc.go
+++ b/internal/providers/opencode/console_rpc.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -17,11 +18,20 @@ import (
 // OpenCode console exposes data behind SolidStart server functions reachable
 // at https://opencode.ai/_server. Each function has a content-hash ID
 // (sha256 of its server-side source); these IDs change on every backend
-// deploy. Pinned IDs below were captured 2026-04-30 from the user's HAR.
+// deploy. Pinned IDs below were captured 2026-04-30 from the user's HAR
+// and cross-referenced against CodexBar's captures.
 // The IDs are paired with a stable "purpose" name so we can grep / replace
 // them in one place when they rotate.
 const (
 	consoleBaseURL = "https://opencode.ai"
+
+	// workspaces — returns the user's workspace list (each containing an
+	// id field like "wrk_..."). No args required.
+	rpcWorkspacesID = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f"
+
+	// subscription.get — returns rolling 5-hour and weekly usage
+	// percentages with reset timers. Args: [workspaceID].
+	rpcSubscriptionID = "7abeebee372f304e050aaaf92be863f4a86490e382f8c79db68fd94040d691b4"
 
 	// queryBillingInfo — returns balance, monthly limit, monthly usage,
 	// auto-reload config, payment method, subscription state.
@@ -218,6 +228,241 @@ func (c *ConsoleClient) DiscoverWorkspaceID(ctx context.Context) (string, error)
 		return "", fmt.Errorf("console: workspace redirect missing id (%s)", location)
 	}
 	return "", fmt.Errorf("console: workspace redirect missing id (HTTP %d)", resp.StatusCode)
+}
+
+// FetchWorkspaceIDsViaRPC discovers workspace IDs by calling the workspaces
+// server function. This is more reliable than the /auth redirect approach
+// used by DiscoverWorkspaceID. Returns the first workspace ID found, or
+// an error if none could be parsed.
+func (c *ConsoleClient) FetchWorkspaceIDsViaRPC(ctx context.Context) (string, error) {
+	if c.Cookie == "" || c.CookieName == "" {
+		return "", errors.New("console: missing session cookie")
+	}
+
+	// Try GET first, fall back to POST if empty.
+	body, err := c.callGET(ctx, rpcWorkspacesID)
+	if err != nil {
+		return "", fmt.Errorf("console: workspaces GET: %w", err)
+	}
+	ids := parseWorkspaceIDsFromResponse(body)
+	if len(ids) > 0 {
+		return ids[0], nil
+	}
+
+	// POST fallback — some SolidStart deployments only honour POST.
+	body, err = c.callPOST(ctx, rpcWorkspacesID)
+	if err != nil {
+		return "", fmt.Errorf("console: workspaces POST: %w", err)
+	}
+	ids = parseWorkspaceIDsFromResponse(body)
+	if len(ids) == 0 {
+		return "", errors.New("console: no workspace IDs found in workspaces response")
+	}
+	return ids[0], nil
+}
+
+// parseWorkspaceIDsFromResponse extracts workspace IDs (wrk_...) from a
+// server response. Tries JSON parsing first, then falls back to regex.
+func parseWorkspaceIDsFromResponse(body []byte) []string {
+	parsed, err := ParseSeroval(body)
+	if err != nil {
+		return parseWorkspaceIDsFromBody(string(body))
+	}
+	return collectWorkspaceIDsFromJSON(parsed)
+}
+
+// collectWorkspaceIDsFromJSON recursively walks a parsed JSON structure
+// looking for strings matching the workspace ID pattern.
+func collectWorkspaceIDsFromJSON(v any) []string {
+	var ids []string
+	switch val := v.(type) {
+	case map[string]any:
+		for _, child := range val {
+			ids = append(ids, collectWorkspaceIDsFromJSON(child)...)
+		}
+	case []any:
+		for _, child := range val {
+			ids = append(ids, collectWorkspaceIDsFromJSON(child)...)
+		}
+	case string:
+		if len(val) > 4 && strings.HasPrefix(val, "wrk_") {
+			ids = append(ids, val)
+		}
+	}
+	seen := make(map[string]bool, len(ids))
+	unique := ids[:0]
+	for _, id := range ids {
+		if !seen[id] {
+			seen[id] = true
+			unique = append(unique, id)
+		}
+	}
+	return unique
+}
+
+// parseWorkspaceIDsFromBody uses regex to find workspace IDs in raw text.
+func parseWorkspaceIDsFromBody(body string) []string {
+	re := regexp.MustCompile(`wrk_[A-Za-z0-9]+`)
+	matches := re.FindAllString(body, -1)
+	seen := make(map[string]bool, len(matches))
+	unique := matches[:0]
+	for _, m := range matches {
+		if !seen[m] {
+			seen[m] = true
+			unique = append(unique, m)
+		}
+	}
+	return unique
+}
+
+// SubscriptionUsage is the parsed shape of a subscription.get response.
+// Contains rolling 5-hour and weekly usage percentages with reset timers.
+type SubscriptionUsage struct {
+	RollingUsagePct float64
+	RollingResetSec int
+	WeeklyUsagePct  float64
+	WeeklyResetSec  int
+	RenewAt         string
+}
+
+// QuerySubscriptionUsage fetches the rolling 5-hour and weekly usage
+// percentages for the given workspace. These represent OpenCode's
+// rate-limit quota consumption, not dollar spend.
+func (c *ConsoleClient) QuerySubscriptionUsage(ctx context.Context, workspaceID string) (SubscriptionUsage, error) {
+	if workspaceID == "" {
+		return SubscriptionUsage{}, errors.New("console: workspace ID required")
+	}
+
+	referer := fmt.Sprintf("%s/workspace/%s/billing", c.baseURL, workspaceID)
+	payload := buildArgsPayload(workspaceID)
+	argsJSON, err := json.Marshal(payload)
+	if err != nil {
+		return SubscriptionUsage{}, fmt.Errorf("console: encode args: %w", err)
+	}
+
+	u := fmt.Sprintf("%s/_server?id=%s&args=%s", c.baseURL, rpcSubscriptionID, url.QueryEscape(string(argsJSON)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return SubscriptionUsage{}, err
+	}
+	c.applyHeaders(req, rpcSubscriptionID)
+	req.Header.Set("Referer", referer)
+	req.Header.Set("Accept", "text/javascript, application/json;q=0.9, */*;q=0.8")
+
+	body, err := c.do(req)
+	if err != nil {
+		return SubscriptionUsage{}, fmt.Errorf("console: subscription usage: %w", err)
+	}
+
+	return parseSubscriptionUsage(body)
+}
+
+// parseSubscriptionUsage extracts rolling/weekly usage from a subscription.get
+// response. The response may be Seroval-encoded or plain JSON.
+func parseSubscriptionUsage(body []byte) (SubscriptionUsage, error) {
+	parsed, err := ParseSeroval(body)
+	if err != nil {
+		// Try regex fallback on raw text (CodexBar-style parsing).
+		return parseSubscriptionUsageFallback(string(body))
+	}
+
+	result := SubscriptionUsage{}
+	m, ok := parsed.(map[string]any)
+	if !ok {
+		return SubscriptionUsage{}, fmt.Errorf("console: subscription response not an object: %T", parsed)
+	}
+
+	// Try nested "usage" key first.
+	usageMap := m
+	if nested, ok := m["usage"].(map[string]any); ok {
+		usageMap = nested
+	}
+
+	// Parse rolling usage.
+	if rolling, ok := usageMap["rollingUsage"].(map[string]any); ok {
+		result.RollingUsagePct = floatFieldFromMap(rolling, "usagePercent")
+		result.RollingResetSec = int(floatFieldFromMap(rolling, "resetInSec"))
+	}
+
+	// Parse weekly usage.
+	if weekly, ok := usageMap["weeklyUsage"].(map[string]any); ok {
+		result.WeeklyUsagePct = floatFieldFromMap(weekly, "usagePercent")
+		result.WeeklyResetSec = int(floatFieldFromMap(weekly, "resetInSec"))
+	}
+
+	// Parse renewAt if present.
+	if v, ok := m["renewAt"]; ok {
+		switch val := v.(type) {
+		case string:
+			result.RenewAt = val
+		case float64:
+			result.RenewAt = fmt.Sprintf("%v", val)
+		}
+	}
+
+	if result.RollingUsagePct == 0 && result.WeeklyUsagePct == 0 {
+		return SubscriptionUsage{}, errors.New("console: subscription response missing usage fields")
+	}
+	return result, nil
+}
+
+// parseSubscriptionUsageFallback uses regex to extract usage data from raw
+// text responses, matching CodexBar's fallback parsing strategy.
+func parseSubscriptionUsageFallback(text string) (SubscriptionUsage, error) {
+	result := SubscriptionUsage{}
+
+	if pct := extractDoubleFromText(text, `rollingUsage[^}]*?usagePercent\s*:\s*([0-9]+(?:\.[0-9]+)?)`); pct != nil {
+		result.RollingUsagePct = *pct
+	}
+	if sec := extractIntFromText(text, `rollingUsage[^}]*?resetInSec\s*:\s*([0-9]+)`); sec != nil {
+		result.RollingResetSec = *sec
+	}
+	if pct := extractDoubleFromText(text, `weeklyUsage[^}]*?usagePercent\s*:\s*([0-9]+(?:\.[0-9]+)?)`); pct != nil {
+		result.WeeklyUsagePct = *pct
+	}
+	if sec := extractIntFromText(text, `weeklyUsage[^}]*?resetInSec\s*:\s*([0-9]+)`); sec != nil {
+		result.WeeklyResetSec = *sec
+	}
+
+	if result.RollingUsagePct == 0 && result.WeeklyUsagePct == 0 {
+		return SubscriptionUsage{}, errors.New("console: subscription response missing usage fields")
+	}
+	return result, nil
+}
+
+func floatFieldFromMap(m map[string]any, key string) float64 {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return 0
+	}
+	if f, ok := v.(float64); ok {
+		return f
+	}
+	return 0
+}
+
+func extractDoubleFromText(text, pattern string) *float64 {
+	re := regexp.MustCompile(pattern)
+	matches := re.FindStringSubmatch(text)
+	if len(matches) < 2 {
+		return nil
+	}
+	if f, err := strconv.ParseFloat(matches[1], 64); err == nil {
+		return &f
+	}
+	return nil
+}
+
+func extractIntFromText(text, pattern string) *int {
+	re := regexp.MustCompile(pattern)
+	matches := re.FindStringSubmatch(text)
+	if len(matches) < 2 {
+		return nil
+	}
+	if i, err := strconv.Atoi(matches[1]); err == nil {
+		return &i
+	}
+	return nil
 }
 
 func (c *ConsoleClient) do(req *http.Request) ([]byte, error) {

--- a/internal/providers/opencode/console_rpc.go
+++ b/internal/providers/opencode/console_rpc.go
@@ -316,12 +316,14 @@ func parseWorkspaceIDsFromBody(body string) []string {
 }
 
 // SubscriptionUsage is the parsed shape of a subscription.get response.
-// Contains rolling 5-hour and weekly usage percentages with reset timers.
+// Contains rolling 5-hour, weekly, and monthly usage percentages with reset timers.
 type SubscriptionUsage struct {
 	RollingUsagePct float64
 	RollingResetSec int
 	WeeklyUsagePct  float64
 	WeeklyResetSec  int
+	MonthlyUsagePct float64
+	MonthlyResetSec int
 	RenewAt         string
 }
 
@@ -482,6 +484,182 @@ func (c *ConsoleClient) do(req *http.Request) ([]byte, error) {
 		return nil, fmt.Errorf("console: http %d: %s", resp.StatusCode, shortenBody(body))
 	}
 	return body, nil
+}
+
+// CallGETRaw is a debug helper that performs a GET-style server function call
+// and returns the raw response body. Not for production use.
+func (c *ConsoleClient) CallGETRaw(ctx context.Context, fnID string, args ...any) ([]byte, error) {
+	return c.callGET(ctx, fnID, args...)
+}
+
+// FetchPageRaw fetches a page from the OpenCode console with cookie auth.
+// Used for scraping the Go usage page HTML.
+func (c *ConsoleClient) FetchPageRaw(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req, "")
+	return c.do(req)
+}
+
+// FetchGoUsagePage fetches the OpenCode Go usage page and extracts billing
+// and subscription usage data from the embedded Seroval script. This is more
+// reliable than individual RPC calls whose IDs rotate on every deploy.
+func (c *ConsoleClient) FetchGoUsagePage(ctx context.Context, workspaceID string) (SubscriptionUsage, BillingInfo, error) {
+	if workspaceID == "" {
+		return SubscriptionUsage{}, BillingInfo{}, errors.New("console: workspace ID required")
+	}
+
+	url := fmt.Sprintf("%s/workspace/%s/go", c.baseURL, workspaceID)
+	body, err := c.FetchPageRaw(ctx, url)
+	if err != nil {
+		return SubscriptionUsage{}, BillingInfo{}, fmt.Errorf("console: fetch go page: %w", err)
+	}
+
+	html := string(body)
+	if looksSignedOutFromHTML(html) {
+		return SubscriptionUsage{}, BillingInfo{}, &ConsoleAuthError{StatusCode: 401, Body: "page indicates signed out"}
+	}
+
+	subscription, billing := parseGoUsagePageHTML(html)
+	return subscription, billing, nil
+}
+
+// looksSignedOutFromHTML checks if an HTML response indicates the user is
+// not authenticated.
+func looksSignedOutFromHTML(html string) bool {
+	lower := strings.ToLower(html)
+	return strings.Contains(lower, "sign in") ||
+		strings.Contains(lower, "login") ||
+		strings.Contains(lower, "auth/authorize")
+}
+
+// parseGoUsagePageHTML extracts billing and subscription usage data from the
+// embedded Seroval script in the OpenCode Go usage page HTML.
+func parseGoUsagePageHTML(html string) (SubscriptionUsage, BillingInfo) {
+	subscription := SubscriptionUsage{}
+	billing := BillingInfo{}
+
+	// Extract the main Seroval script blob
+	scriptRE := regexp.MustCompile(`self\.\$R=self\.\$R\|\|\[\].*`)
+	scriptMatch := scriptRE.FindString(html)
+	if scriptMatch == "" {
+		return subscription, billing
+	}
+
+	// Extract billing data by finding the billing.get assignment followed by
+	// the billing fields object. The pattern is:
+	// billing.get["wrk_..."]}=$R[N]=$R[M]($R[O]={...billing fields...})
+	billingObjRE := regexp.MustCompile(`billing\.get\["[^"]*"\].*?\$R\[\d+\]=\{([^}]+)\}`)
+	if matches := billingObjRE.FindStringSubmatch(scriptMatch); len(matches) > 1 {
+		billing = parseBillingFields(matches[1])
+	}
+
+	// Extract subscription usage. The pattern is:
+	// rollingUsage:$R[N]={status:"ok",resetInSec:N,usagePercent:N},...
+	// Note: field order varies; use independent extractions.
+	rollingBlockRE := regexp.MustCompile(`rollingUsage:\$R\[\d+\]=\{([^}]+)\}`)
+	if matches := rollingBlockRE.FindStringSubmatch(scriptMatch); len(matches) > 1 {
+		block := matches[1]
+		if v := extractFloatField(block, "usagePercent"); v > 0 {
+			subscription.RollingUsagePct = v
+		}
+		if v := extractFloatField(block, "resetInSec"); v > 0 {
+			subscription.RollingResetSec = int(v)
+		}
+	}
+
+	weeklyBlockRE := regexp.MustCompile(`weeklyUsage:\$R\[\d+\]=\{([^}]+)\}`)
+	if matches := weeklyBlockRE.FindStringSubmatch(scriptMatch); len(matches) > 1 {
+		block := matches[1]
+		if v := extractFloatField(block, "usagePercent"); v > 0 {
+			subscription.WeeklyUsagePct = v
+		}
+		if v := extractFloatField(block, "resetInSec"); v > 0 {
+			subscription.WeeklyResetSec = int(v)
+		}
+	}
+
+	monthlyBlockRE := regexp.MustCompile(`monthlyUsage:\$R\[\d+\]=\{([^}]+)\}`)
+	if matches := monthlyBlockRE.FindStringSubmatch(scriptMatch); len(matches) > 1 {
+		block := matches[1]
+		if v := extractFloatField(block, "usagePercent"); v > 0 {
+			subscription.MonthlyUsagePct = v
+		}
+		if v := extractFloatField(block, "resetInSec"); v > 0 {
+			subscription.MonthlyResetSec = int(v)
+		}
+	}
+
+	return subscription, billing
+}
+
+// parseBillingFields extracts billing info from a Seroval object fragment
+// like: customerID:"cus_xxx",balance:0,reloadAmount:20,...
+func parseBillingFields(fields string) BillingInfo {
+	b := BillingInfo{}
+	b.CustomerID = extractStringField(fields, "customerID")
+	b.PaymentMethodType = extractStringField(fields, "paymentMethodType")
+	b.SubscriptionPlan = extractStringField(fields, "subscriptionPlan")
+
+	if v := extractFloatField(fields, "balance"); v != 0 {
+		b.Balance = v
+	}
+	if v := extractFloatField(fields, "reloadAmount"); v != 0 {
+		b.ReloadAmount = v
+	}
+	if v := extractFloatField(fields, "reloadTrigger"); v != 0 {
+		b.ReloadTrigger = v
+	}
+
+	if v := extractNullableFloat(fields, "monthlyLimit"); v != nil {
+		b.MonthlyLimit = v
+	}
+	if v := extractNullableFloat(fields, "monthlyUsage"); v != nil {
+		b.MonthlyUsage = *v
+	}
+
+	if strings.Contains(fields, "subscriptionID:") && !strings.Contains(fields, "subscriptionID:null") {
+		b.HasSubscription = true
+	}
+
+	return b
+}
+
+// extractStringField pulls a string value from a Seroval object fragment.
+// Handles: field:"value" and field:null
+func extractStringField(fields, key string) string {
+	re := regexp.MustCompile(key + `:"([^"]*)"`)
+	if matches := re.FindStringSubmatch(fields); len(matches) > 1 {
+		return matches[1]
+	}
+	return ""
+}
+
+// extractFloatField pulls a numeric value from a Seroval object fragment.
+// Handles: field:123, field:0, field:1.5
+func extractFloatField(fields, key string) float64 {
+	re := regexp.MustCompile(key + `:(-?[0-9]+(?:\.[0-9]+)?)`)
+	if matches := re.FindStringSubmatch(fields); len(matches) > 1 {
+		f, _ := strconv.ParseFloat(matches[1], 64)
+		return f
+	}
+	return 0
+}
+
+// extractNullableFloat pulls a nullable numeric value from a Seroval fragment.
+// Returns nil for null, pointer to value otherwise.
+func extractNullableFloat(fields, key string) *float64 {
+	re := regexp.MustCompile(key + `:(null|-?[0-9]+(?:\.[0-9]+)?)`)
+	if matches := re.FindStringSubmatch(fields); len(matches) > 1 {
+		if matches[1] == "null" {
+			return nil
+		}
+		f, _ := strconv.ParseFloat(matches[1], 64)
+		return &f
+	}
+	return nil
 }
 
 func shortenBody(b []byte) string {

--- a/internal/providers/opencode/console_rpc.go
+++ b/internal/providers/opencode/console_rpc.go
@@ -529,7 +529,10 @@ func (c *ConsoleClient) FetchGoUsagePage(ctx context.Context, workspaceID string
 		return SubscriptionUsage{}, BillingInfo{}, &ConsoleAuthError{StatusCode: 401, Body: "page indicates signed out"}
 	}
 
-	subscription, billing := parseGoUsagePageHTML(html)
+	subscription, billing, err := parseGoUsagePageHTML(html)
+	if err != nil {
+		return SubscriptionUsage{}, BillingInfo{}, fmt.Errorf("console: parse go page: %w", err)
+	}
 	return subscription, billing, nil
 }
 
@@ -544,7 +547,7 @@ func looksSignedOutFromHTML(html string) bool {
 
 // parseGoUsagePageHTML extracts billing and subscription usage data from the
 // embedded Seroval script in the OpenCode Go usage page HTML.
-func parseGoUsagePageHTML(html string) (SubscriptionUsage, BillingInfo) {
+func parseGoUsagePageHTML(html string) (SubscriptionUsage, BillingInfo, error) {
 	subscription := SubscriptionUsage{}
 	billing := BillingInfo{}
 
@@ -552,16 +555,22 @@ func parseGoUsagePageHTML(html string) (SubscriptionUsage, BillingInfo) {
 	scriptRE := regexp.MustCompile(`self\.\$R=self\.\$R\|\|\[\].*`)
 	scriptMatch := scriptRE.FindString(html)
 	if scriptMatch == "" {
-		return subscription, billing
+		return subscription, billing, errors.New("console: go usage page missing embedded usage data")
 	}
 
 	// Extract billing data by finding the billing.get assignment followed by
 	// the billing fields object. The pattern is:
 	// billing.get["wrk_..."]}=$R[N]=$R[M]($R[O]={...billing fields...})
 	billingObjRE := regexp.MustCompile(`billing\.get\["[^"]*"\].*?\$R\[\d+\]=\{([^}]+)\}`)
-	if matches := billingObjRE.FindStringSubmatch(scriptMatch); len(matches) > 1 {
-		billing = parseBillingFields(matches[1])
+	billingMatches := billingObjRE.FindStringSubmatch(scriptMatch)
+	if len(billingMatches) <= 1 {
+		return subscription, billing, errors.New("console: go usage page missing billing data")
 	}
+	billingFields := billingMatches[1]
+	if !hasRecognizedBillingField(billingFields) {
+		return subscription, billing, errors.New("console: go usage page has unrecognized billing data")
+	}
+	billing = parseBillingFields(billingFields)
 
 	// Extract subscription usage. The pattern is:
 	// rollingUsage:$R[N]={status:"ok",resetInSec:N,usagePercent:N},...
@@ -602,7 +611,26 @@ func parseGoUsagePageHTML(html string) (SubscriptionUsage, BillingInfo) {
 		}
 	}
 
-	return subscription, billing
+	return subscription, billing, nil
+}
+
+func hasRecognizedBillingField(fields string) bool {
+	for _, key := range []string{
+		"balance",
+		"reloadAmount",
+		"reloadTrigger",
+		"monthlyLimit",
+		"monthlyUsage",
+		"customerID",
+		"paymentMethodType",
+		"subscriptionID",
+		"subscriptionPlan",
+	} {
+		if strings.Contains(fields, key+":") {
+			return true
+		}
+	}
+	return false
 }
 
 // parseBillingFields extracts billing info from a Seroval object fragment

--- a/internal/providers/opencode/console_rpc_test.go
+++ b/internal/providers/opencode/console_rpc_test.go
@@ -324,3 +324,43 @@ func TestParseSubscriptionUsageFallback(t *testing.T) {
 		t.Errorf("WeeklyResetSec = %v, want 180000", got.WeeklyResetSec)
 	}
 }
+
+func TestParseGoUsagePageHTML_ZeroUsagePercentIsNotDroppedAsMissing(t *testing.T) {
+	html := `<html><script>self.$R=self.$R||[];` +
+		`billing.get["wrk_x"]}=$R[1]=$R[2]($R[3]={balance:0,reloadAmount:2000000000,reloadTrigger:500000000});` +
+		`rollingUsage:$R[4]={status:"ok",resetInSec:1800,usagePercent:0};` +
+		`weeklyUsage:$R[5]={status:"ok",resetInSec:200000,usagePercent:12.5};` +
+		`monthlyUsage:$R[6]={status:"ok",resetInSec:900000,usagePercent:0};` +
+		`</script></html>`
+
+	subscription, _ := parseGoUsagePageHTML(html)
+
+	if !subscription.RollingUsageOK {
+		t.Fatalf("RollingUsageOK = false, want true (usagePercent:0 is a legitimate reading, not a missing field)")
+	}
+	if subscription.RollingUsagePct != 0 {
+		t.Errorf("RollingUsagePct = %v, want 0", subscription.RollingUsagePct)
+	}
+	if !subscription.WeeklyUsageOK || subscription.WeeklyUsagePct != 12.5 {
+		t.Errorf("WeeklyUsageOK/Pct = %v/%v, want true/12.5", subscription.WeeklyUsageOK, subscription.WeeklyUsagePct)
+	}
+	if !subscription.MonthlyUsageOK {
+		t.Fatalf("MonthlyUsageOK = false, want true (usagePercent:0 is a legitimate reading, not a missing field)")
+	}
+	if subscription.MonthlyUsagePct != 0 {
+		t.Errorf("MonthlyUsagePct = %v, want 0", subscription.MonthlyUsagePct)
+	}
+}
+
+func TestParseGoUsagePageHTML_MissingBlockLeavesUsageOKFalse(t *testing.T) {
+	html := `<html><script>self.$R=self.$R||[];` +
+		`billing.get["wrk_x"]}=$R[1]=$R[2]($R[3]={balance:0,reloadAmount:0,reloadTrigger:0});` +
+		`</script></html>`
+
+	subscription, _ := parseGoUsagePageHTML(html)
+
+	if subscription.RollingUsageOK || subscription.WeeklyUsageOK || subscription.MonthlyUsageOK {
+		t.Errorf("expected all *UsageOK flags false when no usage blocks are present, got rolling=%v weekly=%v monthly=%v",
+			subscription.RollingUsageOK, subscription.WeeklyUsageOK, subscription.MonthlyUsageOK)
+	}
+}

--- a/internal/providers/opencode/console_rpc_test.go
+++ b/internal/providers/opencode/console_rpc_test.go
@@ -162,3 +162,165 @@ func TestConsoleClient_DiscoverWorkspaceID_MissingRedirectID(t *testing.T) {
 		t.Fatal("expected missing workspace redirect error")
 	}
 }
+
+func TestConsoleClient_FetchWorkspaceIDsViaRPC_RoundTrip(t *testing.T) {
+	body := loadFixture(t, "seroval_def39973159c.txt")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("x-server-id"); got != rpcWorkspacesID {
+			t.Errorf("x-server-id = %q, want %s", got, rpcWorkspacesID)
+		}
+		c, err := r.Cookie("auth")
+		if err != nil || c.Value != "test-cookie-value" {
+			t.Errorf("auth cookie missing/wrong: %v %v", c, err)
+		}
+		w.Header().Set("Content-Type", "text/javascript")
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	c := NewConsoleClient("test-cookie-value", "auth", "")
+	c.baseURL = server.URL
+
+	workspaceID, err := c.FetchWorkspaceIDsViaRPC(context.Background())
+	if err != nil {
+		t.Fatalf("FetchWorkspaceIDsViaRPC error: %v", err)
+	}
+	if workspaceID != "wrk_TESTWORKSPACE123" {
+		t.Errorf("workspaceID = %q, want wrk_TESTWORKSPACE123", workspaceID)
+	}
+}
+
+func TestConsoleClient_FetchWorkspaceIDsViaRPC_FallbackPOST(t *testing.T) {
+	body := loadFixture(t, "seroval_def39973159c.txt")
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			// First call (GET) returns empty.
+			w.Header().Set("Content-Type", "text/javascript")
+			_, _ = w.Write([]byte(`;0x00000010;((self.$R=self.$R||{})["server-fn:1"]=[],($R=>$R[0]={})($R["server-fn:1"]))`))
+			return
+		}
+		// Second call (POST) returns workspace IDs.
+		w.Header().Set("Content-Type", "text/javascript")
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	c := NewConsoleClient("test-cookie-value", "auth", "")
+	c.baseURL = server.URL
+
+	workspaceID, err := c.FetchWorkspaceIDsViaRPC(context.Background())
+	if err != nil {
+		t.Fatalf("FetchWorkspaceIDsViaRPC error: %v", err)
+	}
+	if workspaceID != "wrk_TESTWORKSPACE123" {
+		t.Errorf("workspaceID = %q, want wrk_TESTWORKSPACE123", workspaceID)
+	}
+	if callCount != 2 {
+		t.Errorf("callCount = %d, want 2 (GET + POST fallback)", callCount)
+	}
+}
+
+func TestConsoleClient_QuerySubscriptionUsage_RoundTrip(t *testing.T) {
+	body := loadFixture(t, "seroval_7abeebee372f.txt")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("x-server-id"); got != rpcSubscriptionID {
+			t.Errorf("x-server-id = %q, want %s", got, rpcSubscriptionID)
+		}
+		args := r.URL.Query().Get("args")
+		if !strings.Contains(args, "wrk_TEST123") {
+			t.Errorf("args missing workspace id: %q", args)
+		}
+		if got := r.Header.Get("Referer"); !strings.Contains(got, "wrk_TEST123") {
+			t.Errorf("Referer missing workspace id: %q", got)
+		}
+		w.Header().Set("Content-Type", "text/javascript")
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	c := NewConsoleClient("test-cookie-value", "auth", "wrk_TEST123")
+	c.baseURL = server.URL
+
+	got, err := c.QuerySubscriptionUsage(context.Background(), "wrk_TEST123")
+	if err != nil {
+		t.Fatalf("QuerySubscriptionUsage error: %v", err)
+	}
+	if got.RollingUsagePct != 67.5 {
+		t.Errorf("RollingUsagePct = %v, want 67.5", got.RollingUsagePct)
+	}
+	if got.RollingResetSec != 10800 {
+		t.Errorf("RollingResetSec = %v, want 10800", got.RollingResetSec)
+	}
+	if got.WeeklyUsagePct != 42.3 {
+		t.Errorf("WeeklyUsagePct = %v, want 42.3", got.WeeklyUsagePct)
+	}
+	if got.WeeklyResetSec != 259200 {
+		t.Errorf("WeeklyResetSec = %v, want 259200", got.WeeklyResetSec)
+	}
+}
+
+func TestConsoleClient_QuerySubscriptionUsage_RequiresWorkspaceID(t *testing.T) {
+	c := NewConsoleClient("v", "auth", "")
+	if _, err := c.QuerySubscriptionUsage(context.Background(), ""); err == nil {
+		t.Error("expected error when workspace id missing")
+	}
+}
+
+func TestParseWorkspaceIDsFromBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "single workspace",
+			body: `{"workspaces":[{"id":"wrk_abc123","name":"Primary"}]}`,
+			want: []string{"wrk_abc123"},
+		},
+		{
+			name: "multiple workspaces",
+			body: `id:"wrk_first" id:"wrk_second" id:"wrk_first"`,
+			want: []string{"wrk_first", "wrk_second"},
+		},
+		{
+			name: "no workspaces",
+			body: `{"error":"unauthorized"}`,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseWorkspaceIDsFromBody(tt.body)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseSubscriptionUsageFallback(t *testing.T) {
+	text := `rollingUsage:{usagePercent:75.2,resetInSec:5400},weeklyUsage:{usagePercent:30.1,resetInSec:180000}`
+	got, err := parseSubscriptionUsageFallback(text)
+	if err != nil {
+		t.Fatalf("parseSubscriptionUsageFallback error: %v", err)
+	}
+	if got.RollingUsagePct != 75.2 {
+		t.Errorf("RollingUsagePct = %v, want 75.2", got.RollingUsagePct)
+	}
+	if got.RollingResetSec != 5400 {
+		t.Errorf("RollingResetSec = %v, want 5400", got.RollingResetSec)
+	}
+	if got.WeeklyUsagePct != 30.1 {
+		t.Errorf("WeeklyUsagePct = %v, want 30.1", got.WeeklyUsagePct)
+	}
+	if got.WeeklyResetSec != 180000 {
+		t.Errorf("WeeklyResetSec = %v, want 180000", got.WeeklyResetSec)
+	}
+}

--- a/internal/providers/opencode/console_rpc_test.go
+++ b/internal/providers/opencode/console_rpc_test.go
@@ -333,7 +333,10 @@ func TestParseGoUsagePageHTML_ZeroUsagePercentIsNotDroppedAsMissing(t *testing.T
 		`monthlyUsage:$R[6]={status:"ok",resetInSec:900000,usagePercent:0};` +
 		`</script></html>`
 
-	subscription, _ := parseGoUsagePageHTML(html)
+	subscription, _, err := parseGoUsagePageHTML(html)
+	if err != nil {
+		t.Fatalf("parseGoUsagePageHTML error: %v", err)
+	}
 
 	if !subscription.RollingUsageOK {
 		t.Fatalf("RollingUsageOK = false, want true (usagePercent:0 is a legitimate reading, not a missing field)")
@@ -357,10 +360,21 @@ func TestParseGoUsagePageHTML_MissingBlockLeavesUsageOKFalse(t *testing.T) {
 		`billing.get["wrk_x"]}=$R[1]=$R[2]($R[3]={balance:0,reloadAmount:0,reloadTrigger:0});` +
 		`</script></html>`
 
-	subscription, _ := parseGoUsagePageHTML(html)
+	subscription, _, err := parseGoUsagePageHTML(html)
+	if err != nil {
+		t.Fatalf("parseGoUsagePageHTML error: %v", err)
+	}
 
 	if subscription.RollingUsageOK || subscription.WeeklyUsageOK || subscription.MonthlyUsageOK {
 		t.Errorf("expected all *UsageOK flags false when no usage blocks are present, got rolling=%v weekly=%v monthly=%v",
 			subscription.RollingUsageOK, subscription.WeeklyUsageOK, subscription.MonthlyUsageOK)
+	}
+}
+
+func TestParseGoUsagePageHTML_ChangedShapeReturnsError(t *testing.T) {
+	_, _, err := parseGoUsagePageHTML(`<html><script>self.$R=self.$R||[];` +
+		`usagePage:{shape:"changed"}</script></html>`)
+	if err == nil {
+		t.Fatal("parseGoUsagePageHTML returned nil error for an unrecognized page shape")
 	}
 }

--- a/internal/providers/opencode/provider.go
+++ b/internal/providers/opencode/provider.go
@@ -401,7 +401,7 @@ func (p *Provider) enrichFromConsole(ctx context.Context, acct core.AccountConfi
 				Window: "month",
 			}
 			if subscription.MonthlyResetSec > 0 {
-				snap.Resets["monthly_usage_reset"] = snap.Timestamp.Add(
+				snap.Resets["monthly_usage_pct_reset"] = snap.Timestamp.Add(
 					time.Duration(subscription.MonthlyResetSec) * time.Second)
 			}
 		}

--- a/internal/providers/opencode/provider.go
+++ b/internal/providers/opencode/provider.go
@@ -67,6 +67,11 @@ func New() *Provider {
 			Dashboard: providerbase.DefaultDashboard(
 				providerbase.WithColorRole(core.DashboardColorRoleBlue),
 				providerbase.WithGaugePriority("rolling_usage", "weekly_usage", "monthly_usage_pct", "console_balance", "monthly_limit"),
+				// OpenCode Zen quota has three meaningful usage-window
+				// percentages (5h / 7d / ~30d monthly) — the default cap of 2
+				// gauge lines would always bump the monthly figure in favor
+				// of the two shorter windows.
+				providerbase.WithGaugeMaxLines(3),
 				providerbase.WithCompactRows(
 					core.DashboardCompactRow{
 						Label:       "Quota",

--- a/internal/providers/opencode/provider.go
+++ b/internal/providers/opencode/provider.go
@@ -160,9 +160,9 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 
 	// Optional: enrich the snapshot with console-side data (balance,
 	// monthly usage, subscription) when a browser-session cookie is
-	// configured for this account. Failures are non-fatal — the
-	// API-key probe already succeeded above, the snapshot is in a good
-	// state, we just skip the enrichment and surface a hint.
+	// configured for this account. Failures are non-fatal when we already
+	// have a validated Zen API key — the snapshot is in a good state, we
+	// just skip the enrichment and surface a hint.
 	if err := p.enrichFromConsole(ctx, acct, &snap); err != nil {
 		// Distinguish "no cookie configured" (silent) from "cookie
 		// rejected" (loud diagnostic for the tile).
@@ -175,6 +175,19 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 			// expected when user hasn't connected a browser session
 		default:
 			snap.Raw["console_error"] = err.Error()
+		}
+
+		// We never validated a Zen API key (authSnap != nil, so the probe
+		// above was skipped) and console enrichment also failed to produce
+		// usable data. Without this, shared.FinalizeStatus would default
+		// the still-empty snap.Status to StatusOK — reporting a healthy
+		// tile for an account that has neither a working API key nor a
+		// working browser session.
+		if authSnap != nil && snap.Status == "" {
+			snap.Status = authSnap.Status
+			if authSnap.Message != "" {
+				snap.Message = authSnap.Message
+			}
 		}
 	}
 
@@ -271,11 +284,34 @@ func (p *Provider) enrichFromConsole(ctx context.Context, acct core.AccountConfi
 	}
 
 	// Fallback: try individual billing RPC if page scraping didn't get billing data.
+	var fallbackErr error
 	if billingFailed || (billing.Balance == 0 && billing.MonthlyUsage == 0 && billing.MonthlyLimit == nil) {
 		billingRPC, err := client.QueryBillingInfo(ctx)
 		if err == nil {
 			billing = billingRPC
 			billingFailed = false
+		} else if billingFailed {
+			// Only treat the fallback's error as fatal when the primary page
+			// scrape had already failed. If the page scrape succeeded with a
+			// genuine zero balance, a failing fallback isn't itself a problem.
+			fallbackErr = err
+		}
+	}
+
+	if billingFailed {
+		// Both the page scrape and the billing RPC fallback failed. Return
+		// the error instead of falling through to write zero-valued billing
+		// metrics into the snapshot as if they were real data — that would
+		// present "$0.00 balance" for what may actually be an expired
+		// session that needs reauthentication.
+		var authErr *ConsoleAuthError
+		switch {
+		case errors.As(fallbackErr, &authErr):
+			return fallbackErr
+		case errors.As(page.err, &authErr):
+			return page.err
+		default:
+			return fmt.Errorf("opencode console: billing unavailable (page scrape: %v, fallback: %v)", page.err, fallbackErr)
 		}
 	}
 
@@ -325,8 +361,10 @@ func (p *Provider) enrichFromConsole(ctx context.Context, acct core.AccountConfi
 	}
 
 	// Process subscription usage (rolling 5h + weekly + monthly percentages).
-	if subscription.RollingUsagePct > 0 || subscription.WeeklyUsagePct > 0 || subscription.MonthlyUsagePct > 0 {
-		if subscription.RollingUsagePct > 0 {
+	// Gate on the *OK presence flags, not value > 0 — a legitimate 0% reading
+	// (quota window just reset) must still populate the metric.
+	if subscription.RollingUsageOK || subscription.WeeklyUsageOK || subscription.MonthlyUsageOK {
+		if subscription.RollingUsageOK {
 			snap.Metrics["rolling_usage"] = core.Metric{
 				Used:   core.Float64Ptr(subscription.RollingUsagePct),
 				Limit:  core.Float64Ptr(100),
@@ -338,7 +376,7 @@ func (p *Provider) enrichFromConsole(ctx context.Context, acct core.AccountConfi
 					time.Duration(subscription.RollingResetSec) * time.Second)
 			}
 		}
-		if subscription.WeeklyUsagePct > 0 {
+		if subscription.WeeklyUsageOK {
 			snap.Metrics["weekly_usage"] = core.Metric{
 				Used:   core.Float64Ptr(subscription.WeeklyUsagePct),
 				Limit:  core.Float64Ptr(100),
@@ -350,7 +388,7 @@ func (p *Provider) enrichFromConsole(ctx context.Context, acct core.AccountConfi
 					time.Duration(subscription.WeeklyResetSec) * time.Second)
 			}
 		}
-		if subscription.MonthlyUsagePct > 0 {
+		if subscription.MonthlyUsageOK {
 			snap.Metrics["monthly_usage_pct"] = core.Metric{
 				Used:   core.Float64Ptr(subscription.MonthlyUsagePct),
 				Limit:  core.Float64Ptr(100),

--- a/internal/providers/opencode/provider.go
+++ b/internal/providers/opencode/provider.go
@@ -60,14 +60,14 @@ func New() *Provider {
 			Setup: core.ProviderSetupSpec{
 				Quickstart: []string{
 					"Set OPENCODE_API_KEY (or ZEN_API_KEY) with your OpenCode Zen key for chat-surface auth.",
-					"For balance / monthly usage / subscription data: open Settings → 5 KEYS, highlight opencode, and press c to import the session cookie from your browser.",
+					"For OpenCode Go balance / monthly usage / subscription data: open Settings → 5 KEYS, highlight opencode, and press c to import the session cookie from your browser.",
 					"Tile spend / model / activity metrics are populated from the OpenCode telemetry plugin; see Settings → 7 INTEG.",
 				},
 			},
 			Dashboard: providerbase.DefaultDashboard(
 				providerbase.WithColorRole(core.DashboardColorRoleBlue),
 				providerbase.WithGaugePriority("rolling_usage", "weekly_usage", "monthly_usage_pct", "console_balance", "monthly_limit"),
-				// OpenCode Zen quota has three meaningful usage-window
+				// OpenCode Go quota has three meaningful usage-window
 				// percentages (5h / 7d / ~30d monthly) — the default cap of 2
 				// gauge lines would always bump the monthly figure in favor
 				// of the two shorter windows.

--- a/internal/providers/opencode/provider.go
+++ b/internal/providers/opencode/provider.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/janekbaraniewski/openusage/internal/config"
 	"github.com/janekbaraniewski/openusage/internal/core"
@@ -44,7 +45,7 @@ func New() *Provider {
 			ID: "opencode",
 			Info: core.ProviderInfo{
 				Name:         "OpenCode",
-				Capabilities: []string{"zen_models_endpoint", "telemetry_driven_metrics"},
+				Capabilities: []string{"zen_models_endpoint", "telemetry_driven_metrics", "console_billing", "subscription_usage"},
 				DocURL:       "https://opencode.ai/docs/",
 			},
 			Auth: core.ProviderAuthSpec{
@@ -63,6 +64,38 @@ func New() *Provider {
 					"Tile spend / model / activity metrics are populated from the OpenCode telemetry plugin; see Settings → 7 INTEG.",
 				},
 			},
+			Dashboard: providerbase.DefaultDashboard(
+				providerbase.WithColorRole(core.DashboardColorRoleBlue),
+				providerbase.WithGaugePriority("rolling_usage", "weekly_usage", "console_balance", "monthly_limit"),
+				providerbase.WithCompactRows(
+					core.DashboardCompactRow{
+						Label:       "Quota",
+						Keys:        []string{"rolling_usage", "weekly_usage"},
+						MaxSegments: 2,
+					},
+					core.DashboardCompactRow{
+						Label:       "Credits",
+						Keys:        []string{"console_balance", "monthly_usage", "monthly_limit"},
+						MaxSegments: 3,
+					},
+				),
+				providerbase.WithMetricLabels(map[string]string{
+					"rolling_usage":   "5h Usage",
+					"weekly_usage":    "Weekly",
+					"console_balance": "Balance",
+					"monthly_usage":   "Month Spend",
+					"monthly_limit":   "Month Limit",
+					"reload_amount":   "Reload",
+					"reload_trigger":  "Reload At",
+				}),
+				providerbase.WithCompactLabels(map[string]string{
+					"rolling_usage":   "5h",
+					"weekly_usage":    "wk",
+					"console_balance": "bal",
+					"monthly_usage":   "mo",
+					"monthly_limit":   "cap",
+				}),
+			),
 		}),
 	}
 }
@@ -136,7 +169,14 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 	shared.FinalizeStatus(&snap)
 	if snap.Status == core.StatusOK {
 		if bal, ok := snap.Metrics["console_balance"]; ok && bal.Remaining != nil {
-			snap.Message = fmt.Sprintf("$%.2f balance · %d Zen models", *bal.Remaining, len(models.Data))
+			msg := fmt.Sprintf("$%.2f balance · %d Zen models", *bal.Remaining, len(models.Data))
+			if rolling, ok := snap.Metrics["rolling_usage"]; ok && rolling.Used != nil {
+				msg += fmt.Sprintf(" · %.0f%% 5h", *rolling.Used)
+			}
+			if weekly, ok := snap.Metrics["weekly_usage"]; ok && weekly.Used != nil {
+				msg += fmt.Sprintf(" · %.0f%% weekly", *weekly.Used)
+			}
+			snap.Message = msg
 		} else {
 			snap.Message = fmt.Sprintf("Auth OK · %d Zen models", len(models.Data))
 		}
@@ -180,24 +220,46 @@ func (p *Provider) enrichFromConsole(ctx context.Context, acct core.AccountConfi
 		}
 	}
 	client.WorkspaceID = workspaceID
-	billing, err := client.QueryBillingInfo(ctx)
-	if err != nil {
-		return err
+
+	// Fetch billing info and subscription usage concurrently.
+	type billingResult struct {
+		info BillingInfo
+		err  error
+	}
+	type subscriptionResult struct {
+		usage SubscriptionUsage
+		err   error
 	}
 
-	// Map billing fields into provider-tile metric keys. Cents-based
-	// internal representation (formatBalance / 1e8 in OpenCode's UI) is
-	// kept as raw numbers in our snapshots; the dashboard widget will
-	// format them.
-	available := billing.Balance / 1e8
-	usage := billing.MonthlyUsage / 1e8
+	billingCh := make(chan billingResult, 1)
+	subscriptionCh := make(chan subscriptionResult, 1)
+
+	go func() {
+		info, err := client.QueryBillingInfo(ctx)
+		billingCh <- billingResult{info, err}
+	}()
+	go func() {
+		usage, err := client.QuerySubscriptionUsage(ctx, workspaceID)
+		subscriptionCh <- subscriptionResult{usage, err}
+	}()
+
+	billing := <-billingCh
+	subscription := <-subscriptionCh
+
+	// Process billing info.
+	if billing.err != nil {
+		return billing.err
+	}
+
+	available := billing.info.Balance / 1e8
+	usage := billing.info.MonthlyUsage / 1e8
 	snap.Metrics["console_balance"] = core.Metric{
 		Remaining: core.Float64Ptr(available),
 		Unit:      "USD",
 		Window:    "current",
 	}
-	if billing.MonthlyLimit != nil {
-		limit := *billing.MonthlyLimit / 1e8
+	if billing.info.MonthlyLimit != nil {
+		limit := *billing.info.MonthlyLimit / 1e8
 		snap.Metrics["monthly_limit"] = core.Metric{
 			Limit:     core.Float64Ptr(limit),
 			Used:      core.Float64Ptr(usage),
@@ -212,26 +274,60 @@ func (p *Provider) enrichFromConsole(ctx context.Context, acct core.AccountConfi
 		Window: "month",
 	}
 	snap.Metrics["reload_amount"] = core.Metric{
-		Limit: core.Float64Ptr(billing.ReloadAmount / 1e8),
+		Limit: core.Float64Ptr(billing.info.ReloadAmount / 1e8),
 		Unit:  "USD",
 	}
 	snap.Metrics["reload_trigger"] = core.Metric{
-		Limit: core.Float64Ptr(billing.ReloadTrigger / 1e8),
+		Limit: core.Float64Ptr(billing.info.ReloadTrigger / 1e8),
 		Unit:  "USD",
 	}
 
-	if billing.SubscriptionPlan != "" {
-		snap.SetAttribute("subscription_plan", billing.SubscriptionPlan)
+	if billing.info.SubscriptionPlan != "" {
+		snap.SetAttribute("subscription_plan", billing.info.SubscriptionPlan)
 	}
-	if billing.HasSubscription {
+	if billing.info.HasSubscription {
 		snap.SetAttribute("subscription_status", "active")
 	}
-	if billing.PaymentMethodLast4 != "" {
-		snap.SetAttribute("payment_method_last4", billing.PaymentMethodLast4)
+	if billing.info.PaymentMethodLast4 != "" {
+		snap.SetAttribute("payment_method_last4", billing.info.PaymentMethodLast4)
 	}
-	if billing.PaymentMethodType != "" {
-		snap.SetAttribute("payment_method_type", billing.PaymentMethodType)
+	if billing.info.PaymentMethodType != "" {
+		snap.SetAttribute("payment_method_type", billing.info.PaymentMethodType)
 	}
+
+	// Process subscription usage (rolling 5h + weekly percentages).
+	if subscription.err == nil {
+		if subscription.usage.RollingUsagePct > 0 {
+			snap.Metrics["rolling_usage"] = core.Metric{
+				Used:   core.Float64Ptr(subscription.usage.RollingUsagePct),
+				Limit:  core.Float64Ptr(100),
+				Unit:   "percent",
+				Window: "rolling-5h",
+			}
+			if subscription.usage.RollingResetSec > 0 {
+				snap.Resets["rolling_usage_reset"] = snap.Timestamp.Add(
+					time.Duration(subscription.usage.RollingResetSec) * time.Second)
+			}
+		}
+		if subscription.usage.WeeklyUsagePct > 0 {
+			snap.Metrics["weekly_usage"] = core.Metric{
+				Used:   core.Float64Ptr(subscription.usage.WeeklyUsagePct),
+				Limit:  core.Float64Ptr(100),
+				Unit:   "percent",
+				Window: "7d",
+			}
+			if subscription.usage.WeeklyResetSec > 0 {
+				snap.Resets["weekly_usage_reset"] = snap.Timestamp.Add(
+					time.Duration(subscription.usage.WeeklyResetSec) * time.Second)
+			}
+		}
+		if subscription.usage.RenewAt != "" {
+			snap.SetAttribute("subscription_renew_at", subscription.usage.RenewAt)
+		}
+	} else {
+		snap.SetDiagnostic("opencode_subscription_usage_error", subscription.err.Error())
+	}
+
 	snap.SetAttribute("auth_scope", "zen+console")
 	snap.SetAttribute("console_session_browser", session.SourceBrowser)
 

--- a/internal/providers/opencode/provider.go
+++ b/internal/providers/opencode/provider.go
@@ -66,12 +66,12 @@ func New() *Provider {
 			},
 			Dashboard: providerbase.DefaultDashboard(
 				providerbase.WithColorRole(core.DashboardColorRoleBlue),
-				providerbase.WithGaugePriority("rolling_usage", "weekly_usage", "console_balance", "monthly_limit"),
+				providerbase.WithGaugePriority("rolling_usage", "weekly_usage", "monthly_usage_pct", "console_balance", "monthly_limit"),
 				providerbase.WithCompactRows(
 					core.DashboardCompactRow{
 						Label:       "Quota",
-						Keys:        []string{"rolling_usage", "weekly_usage"},
-						MaxSegments: 2,
+						Keys:        []string{"rolling_usage", "weekly_usage", "monthly_usage_pct"},
+						MaxSegments: 3,
 					},
 					core.DashboardCompactRow{
 						Label:       "Credits",
@@ -80,20 +80,22 @@ func New() *Provider {
 					},
 				),
 				providerbase.WithMetricLabels(map[string]string{
-					"rolling_usage":   "5h Usage",
-					"weekly_usage":    "Weekly",
-					"console_balance": "Balance",
-					"monthly_usage":   "Month Spend",
-					"monthly_limit":   "Month Limit",
-					"reload_amount":   "Reload",
-					"reload_trigger":  "Reload At",
+					"rolling_usage":     "5h Usage",
+					"weekly_usage":      "Weekly",
+					"monthly_usage_pct": "Monthly",
+					"console_balance":   "Balance",
+					"monthly_usage":     "Month Spend",
+					"monthly_limit":     "Month Limit",
+					"reload_amount":     "Reload",
+					"reload_trigger":    "Reload At",
 				}),
 				providerbase.WithCompactLabels(map[string]string{
-					"rolling_usage":   "5h",
-					"weekly_usage":    "wk",
-					"console_balance": "bal",
-					"monthly_usage":   "mo",
-					"monthly_limit":   "cap",
+					"rolling_usage":     "5h",
+					"weekly_usage":      "wk",
+					"monthly_usage_pct": "mo",
+					"console_balance":   "bal",
+					"monthly_usage":     "mo$",
+					"monthly_limit":     "cap",
 				}),
 			),
 		}),
@@ -221,45 +223,56 @@ func (p *Provider) enrichFromConsole(ctx context.Context, acct core.AccountConfi
 	}
 	client.WorkspaceID = workspaceID
 
-	// Fetch billing info and subscription usage concurrently.
-	type billingResult struct {
-		info BillingInfo
-		err  error
-	}
-	type subscriptionResult struct {
-		usage SubscriptionUsage
-		err   error
+	// Fetch billing info and subscription usage from the Go usage page HTML.
+	// This is more reliable than individual RPC calls whose content-hash
+	// IDs rotate on every backend deploy. The page embeds both billing.get
+	// and lite.subscription.get data in a Seroval script blob.
+	type pageResult struct {
+		subscription SubscriptionUsage
+		billing      BillingInfo
+		err          error
 	}
 
-	billingCh := make(chan billingResult, 1)
-	subscriptionCh := make(chan subscriptionResult, 1)
-
+	pageCh := make(chan pageResult, 1)
 	go func() {
-		info, err := client.QueryBillingInfo(ctx)
-		billingCh <- billingResult{info, err}
-	}()
-	go func() {
-		usage, err := client.QuerySubscriptionUsage(ctx, workspaceID)
-		subscriptionCh <- subscriptionResult{usage, err}
+		sub, bill, err := client.FetchGoUsagePage(ctx, workspaceID)
+		pageCh <- pageResult{sub, bill, err}
 	}()
 
-	billing := <-billingCh
-	subscription := <-subscriptionCh
+	page := <-pageCh
+
+	// If HTML scraping fails, fall back to individual RPC calls.
+	var billing BillingInfo
+	var subscription SubscriptionUsage
+	billingFailed := false
+
+	if page.err != nil {
+		snap.SetDiagnostic("opencode_page_scrape_error", page.err.Error())
+		billingFailed = true
+	} else {
+		billing = page.billing
+		subscription = page.subscription
+	}
+
+	// Fallback: try individual billing RPC if page scraping didn't get billing data.
+	if billingFailed || (billing.Balance == 0 && billing.MonthlyUsage == 0 && billing.MonthlyLimit == nil) {
+		billingRPC, err := client.QueryBillingInfo(ctx)
+		if err == nil {
+			billing = billingRPC
+			billingFailed = false
+		}
+	}
 
 	// Process billing info.
-	if billing.err != nil {
-		return billing.err
-	}
-
-	available := billing.info.Balance / 1e8
-	usage := billing.info.MonthlyUsage / 1e8
+	available := billing.Balance / 1e8
+	usage := billing.MonthlyUsage / 1e8
 	snap.Metrics["console_balance"] = core.Metric{
 		Remaining: core.Float64Ptr(available),
 		Unit:      "USD",
 		Window:    "current",
 	}
-	if billing.info.MonthlyLimit != nil {
-		limit := *billing.info.MonthlyLimit / 1e8
+	if billing.MonthlyLimit != nil {
+		limit := *billing.MonthlyLimit / 1e8
 		snap.Metrics["monthly_limit"] = core.Metric{
 			Limit:     core.Float64Ptr(limit),
 			Used:      core.Float64Ptr(usage),
@@ -274,58 +287,65 @@ func (p *Provider) enrichFromConsole(ctx context.Context, acct core.AccountConfi
 		Window: "month",
 	}
 	snap.Metrics["reload_amount"] = core.Metric{
-		Limit: core.Float64Ptr(billing.info.ReloadAmount / 1e8),
+		Limit: core.Float64Ptr(billing.ReloadAmount / 1e8),
 		Unit:  "USD",
 	}
 	snap.Metrics["reload_trigger"] = core.Metric{
-		Limit: core.Float64Ptr(billing.info.ReloadTrigger / 1e8),
+		Limit: core.Float64Ptr(billing.ReloadTrigger / 1e8),
 		Unit:  "USD",
 	}
 
-	if billing.info.SubscriptionPlan != "" {
-		snap.SetAttribute("subscription_plan", billing.info.SubscriptionPlan)
+	if billing.SubscriptionPlan != "" {
+		snap.SetAttribute("subscription_plan", billing.SubscriptionPlan)
 	}
-	if billing.info.HasSubscription {
+	if billing.HasSubscription {
 		snap.SetAttribute("subscription_status", "active")
 	}
-	if billing.info.PaymentMethodLast4 != "" {
-		snap.SetAttribute("payment_method_last4", billing.info.PaymentMethodLast4)
+	if billing.PaymentMethodLast4 != "" {
+		snap.SetAttribute("payment_method_last4", billing.PaymentMethodLast4)
 	}
-	if billing.info.PaymentMethodType != "" {
-		snap.SetAttribute("payment_method_type", billing.info.PaymentMethodType)
+	if billing.PaymentMethodType != "" {
+		snap.SetAttribute("payment_method_type", billing.PaymentMethodType)
 	}
 
-	// Process subscription usage (rolling 5h + weekly percentages).
-	if subscription.err == nil {
-		if subscription.usage.RollingUsagePct > 0 {
+	// Process subscription usage (rolling 5h + weekly + monthly percentages).
+	if subscription.RollingUsagePct > 0 || subscription.WeeklyUsagePct > 0 || subscription.MonthlyUsagePct > 0 {
+		if subscription.RollingUsagePct > 0 {
 			snap.Metrics["rolling_usage"] = core.Metric{
-				Used:   core.Float64Ptr(subscription.usage.RollingUsagePct),
+				Used:   core.Float64Ptr(subscription.RollingUsagePct),
 				Limit:  core.Float64Ptr(100),
 				Unit:   "percent",
 				Window: "rolling-5h",
 			}
-			if subscription.usage.RollingResetSec > 0 {
+			if subscription.RollingResetSec > 0 {
 				snap.Resets["rolling_usage_reset"] = snap.Timestamp.Add(
-					time.Duration(subscription.usage.RollingResetSec) * time.Second)
+					time.Duration(subscription.RollingResetSec) * time.Second)
 			}
 		}
-		if subscription.usage.WeeklyUsagePct > 0 {
+		if subscription.WeeklyUsagePct > 0 {
 			snap.Metrics["weekly_usage"] = core.Metric{
-				Used:   core.Float64Ptr(subscription.usage.WeeklyUsagePct),
+				Used:   core.Float64Ptr(subscription.WeeklyUsagePct),
 				Limit:  core.Float64Ptr(100),
 				Unit:   "percent",
 				Window: "7d",
 			}
-			if subscription.usage.WeeklyResetSec > 0 {
+			if subscription.WeeklyResetSec > 0 {
 				snap.Resets["weekly_usage_reset"] = snap.Timestamp.Add(
-					time.Duration(subscription.usage.WeeklyResetSec) * time.Second)
+					time.Duration(subscription.WeeklyResetSec) * time.Second)
 			}
 		}
-		if subscription.usage.RenewAt != "" {
-			snap.SetAttribute("subscription_renew_at", subscription.usage.RenewAt)
+		if subscription.MonthlyUsagePct > 0 {
+			snap.Metrics["monthly_usage_pct"] = core.Metric{
+				Used:   core.Float64Ptr(subscription.MonthlyUsagePct),
+				Limit:  core.Float64Ptr(100),
+				Unit:   "percent",
+				Window: "month",
+			}
+			if subscription.MonthlyResetSec > 0 {
+				snap.Resets["monthly_usage_reset"] = snap.Timestamp.Add(
+					time.Duration(subscription.MonthlyResetSec) * time.Second)
+			}
 		}
-	} else {
-		snap.SetDiagnostic("opencode_subscription_usage_error", subscription.err.Error())
 	}
 
 	snap.SetAttribute("auth_scope", "zen+console")

--- a/internal/providers/opencode/provider.go
+++ b/internal/providers/opencode/provider.go
@@ -112,7 +112,10 @@ type modelsResponse struct {
 
 func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.UsageSnapshot, error) {
 	apiKey, authSnap := shared.RequireAPIKey(acct, p.ID())
-	if authSnap != nil {
+	hasBrowserSession := acct.BrowserCookie != nil
+
+	// If no API key and no browser session configured, require auth.
+	if authSnap != nil && !hasBrowserSession {
 		return *authSnap, nil
 	}
 
@@ -121,31 +124,38 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 	snap.SetAttribute("auth_scope", "zen")
 	snap.SetAttribute("api_base_url", baseURL)
 
-	var models modelsResponse
-	statusCode, _, err := shared.FetchJSON(ctx, baseURL+modelsPath, apiKey, &models, p.Client())
-	if err != nil {
-		switch statusCode {
-		case http.StatusUnauthorized, http.StatusForbidden:
-			snap.Status = core.StatusAuth
-			snap.Message = fmt.Sprintf("HTTP %d – check OPENCODE_API_KEY", statusCode)
-			return snap, nil
-		case http.StatusTooManyRequests:
-			snap.Status = core.StatusLimited
-			snap.Message = "rate limited (HTTP 429)"
-			return snap, nil
-		}
-		return snap, fmt.Errorf("opencode zen models: %w", err)
-	}
-
-	if len(models.Data) > 0 {
-		ids := make([]string, 0, len(models.Data))
-		for _, m := range models.Data {
-			if id := strings.TrimSpace(m.ID); id != "" {
-				ids = append(ids, id)
+	// Try Zen API key probe if we have a key.
+	if authSnap == nil {
+		var models modelsResponse
+		statusCode, _, err := shared.FetchJSON(ctx, baseURL+modelsPath, apiKey, &models, p.Client())
+		if err != nil {
+			switch statusCode {
+			case http.StatusUnauthorized, http.StatusForbidden:
+				snap.Status = core.StatusAuth
+				snap.Message = fmt.Sprintf("HTTP %d – check OPENCODE_API_KEY", statusCode)
+				return snap, nil
+			case http.StatusTooManyRequests:
+				snap.Status = core.StatusLimited
+				snap.Message = "rate limited (HTTP 429)"
+				return snap, nil
+			}
+			// If we have a browser session, don't fail on Zen API errors —
+			// the console enrichment can still provide useful data.
+			if !hasBrowserSession {
+				return snap, fmt.Errorf("opencode zen models: %w", err)
 			}
 		}
-		snap.SetAttribute("available_models", strings.Join(ids, ", "))
-		snap.SetAttribute("available_models_count", fmt.Sprintf("%d", len(ids)))
+
+		if len(models.Data) > 0 {
+			ids := make([]string, 0, len(models.Data))
+			for _, m := range models.Data {
+				if id := strings.TrimSpace(m.ID); id != "" {
+					ids = append(ids, id)
+				}
+			}
+			snap.SetAttribute("available_models", strings.Join(ids, ", "))
+			snap.SetAttribute("available_models_count", fmt.Sprintf("%d", len(ids)))
+		}
 	}
 
 	// Optional: enrich the snapshot with console-side data (balance,
@@ -170,8 +180,12 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 
 	shared.FinalizeStatus(&snap)
 	if snap.Status == core.StatusOK {
+		modelCount := snap.Attributes["available_models_count"]
 		if bal, ok := snap.Metrics["console_balance"]; ok && bal.Remaining != nil {
-			msg := fmt.Sprintf("$%.2f balance · %d Zen models", *bal.Remaining, len(models.Data))
+			msg := fmt.Sprintf("$%.2f balance", *bal.Remaining)
+			if modelCount != "" {
+				msg += fmt.Sprintf(" · %s Zen models", modelCount)
+			}
 			if rolling, ok := snap.Metrics["rolling_usage"]; ok && rolling.Used != nil {
 				msg += fmt.Sprintf(" · %.0f%% 5h", *rolling.Used)
 			}
@@ -179,8 +193,10 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 				msg += fmt.Sprintf(" · %.0f%% weekly", *weekly.Used)
 			}
 			snap.Message = msg
+		} else if modelCount != "" {
+			snap.Message = fmt.Sprintf("Auth OK · %s Zen models", modelCount)
 		} else {
-			snap.Message = fmt.Sprintf("Auth OK · %d Zen models", len(models.Data))
+			snap.Message = "Auth OK"
 		}
 	}
 	return snap, nil

--- a/internal/providers/opencode/provider_test.go
+++ b/internal/providers/opencode/provider_test.go
@@ -306,3 +306,66 @@ func TestFetch_ConsoleDoubleFailure_DoesNotFabricateZeroBalance(t *testing.T) {
 		t.Errorf("expected opencode_console_auth_error diagnostic, got diagnostics=%+v", snap.Diagnostics)
 	}
 }
+
+func TestFetch_ConsoleShapeChange_DoesNotFabricateZeroBalance(t *testing.T) {
+	origLoadStoredSession := loadStoredSession
+	origNewConsoleClient := newConsoleClient
+	t.Cleanup(func() {
+		loadStoredSession = origLoadStoredSession
+		newConsoleClient = origNewConsoleClient
+	})
+
+	loadStoredSession = func(string) (config.BrowserSession, bool, error) {
+		return config.BrowserSession{
+			Value:         "test-cookie-value",
+			CookieName:    "auth",
+			SourceBrowser: "firefox",
+		}, true, nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/workspace/wrk_test/go" {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html><body>usage layout changed</body></html>"))
+			return
+		}
+		if r.URL.Path == "/_server" {
+			http.Error(w, "billing fallback unavailable", http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	newConsoleClient = func(cookieValue, cookieName, workspaceID string) *ConsoleClient {
+		client := NewConsoleClient(cookieValue, cookieName, workspaceID)
+		client.baseURL = server.URL
+		return client
+	}
+
+	acct := core.AccountConfig{
+		ID:        "opencode-shape-change",
+		Provider:  "opencode",
+		APIKeyEnv: "TEST_OPENCODE_MISSING_SHAPE",
+		BrowserCookie: &core.BrowserCookieRef{
+			Domain:        ".opencode.ai",
+			CookieName:    "auth",
+			SourceBrowser: "firefox",
+		},
+	}
+	acct.SetHint("opencode_workspace_id", "wrk_test")
+
+	snap, err := New().Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if snap.Status != core.StatusAuth {
+		t.Fatalf("status = %s, want AUTH for changed page shape (msg=%q)", snap.Status, snap.Message)
+	}
+	if _, ok := snap.Metrics["console_balance"]; ok {
+		t.Fatalf("console_balance metric present for changed page shape: %+v", snap.Metrics["console_balance"])
+	}
+	if snap.Raw["console_error"] == "" {
+		t.Errorf("expected console_error diagnostic for changed page shape, got raw=%v", snap.Raw)
+	}
+}

--- a/internal/providers/opencode/provider_test.go
+++ b/internal/providers/opencode/provider_test.go
@@ -207,3 +207,102 @@ func TestFetch_ConsoleEnrichmentAutoDiscoversWorkspaceID(t *testing.T) {
 		t.Fatalf("unexpected workspace discovery diagnostic: %+v", snap.Diagnostics)
 	}
 }
+
+// TestFetch_BrowserSessionOnlyNoAPIKey_ConsoleFailureSurfacesAuthNotOK covers
+// an account configured for browser-session auth only (no Zen API key) whose
+// stored session is missing/expired: previously the Zen probe was skipped
+// (no key to probe with) and enrichFromConsole's failure was silently
+// swallowed, leaving snap.Status empty and shared.FinalizeStatus defaulting
+// it to a false StatusOK. It must now surface the underlying auth-required
+// status instead.
+func TestFetch_BrowserSessionOnlyNoAPIKey_ConsoleFailureSurfacesAuthNotOK(t *testing.T) {
+	origLoadStoredSession := loadStoredSession
+	t.Cleanup(func() { loadStoredSession = origLoadStoredSession })
+
+	loadStoredSession = func(accountID string) (config.BrowserSession, bool, error) {
+		return config.BrowserSession{}, false, nil
+	}
+
+	acct := core.AccountConfig{
+		ID:        "opencode-personal",
+		Provider:  "opencode",
+		APIKeyEnv: "TEST_OPENCODE_MISSING_FOR_BROWSER_ONLY",
+		BrowserCookie: &core.BrowserCookieRef{
+			Domain:        ".opencode.ai",
+			CookieName:    "auth",
+			SourceBrowser: "safari",
+		},
+	}
+
+	snap, err := New().Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if snap.Status == core.StatusOK {
+		t.Fatalf("status = OK, want a non-OK status — account has neither a valid API key nor a working browser session (msg=%q)", snap.Message)
+	}
+	if snap.Status != core.StatusAuth {
+		t.Errorf("status = %s, want AUTH_REQUIRED", snap.Status)
+	}
+}
+
+// TestFetch_ConsoleDoubleFailure_DoesNotFabricateZeroBalance covers the case
+// where both the HTML usage-page scrape and the billing-RPC fallback fail
+// (e.g. an expired session cookie). Previously both errors were discarded
+// and a zero-valued billing struct was written into the snapshot as if it
+// were real data ("$0.00 balance"). It must now surface the failure instead.
+func TestFetch_ConsoleDoubleFailure_DoesNotFabricateZeroBalance(t *testing.T) {
+	origLoadStoredSession := loadStoredSession
+	origNewConsoleClient := newConsoleClient
+	t.Cleanup(func() {
+		loadStoredSession = origLoadStoredSession
+		newConsoleClient = origNewConsoleClient
+	})
+
+	loadStoredSession = func(accountID string) (config.BrowserSession, bool, error) {
+		return config.BrowserSession{
+			Value:         "test-cookie-value",
+			CookieName:    "auth",
+			SourceBrowser: "firefox",
+		}, true, nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Both the go-usage-page fetch and the billing RPC fallback come
+		// back unauthorized, simulating an expired session cookie.
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	newConsoleClient = func(cookieValue, cookieName, workspaceID string) *ConsoleClient {
+		client := NewConsoleClient(cookieValue, cookieName, workspaceID)
+		client.baseURL = server.URL
+		return client
+	}
+
+	acct := core.AccountConfig{
+		ID:        "opencode-personal",
+		Provider:  "opencode",
+		APIKeyEnv: "TEST_OPENCODE_MISSING_FOR_DOUBLE_FAILURE",
+		BrowserCookie: &core.BrowserCookieRef{
+			Domain:        ".opencode.ai",
+			CookieName:    "auth",
+			SourceBrowser: "firefox",
+		},
+	}
+	acct.SetHint("opencode_workspace_id", "wrk_test")
+
+	snap, err := New().Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if _, ok := snap.Metrics["console_balance"]; ok {
+		t.Fatalf("console_balance metric present despite both page scrape and billing fallback failing: %+v", snap.Metrics["console_balance"])
+	}
+	if snap.Status == core.StatusOK {
+		t.Fatalf("status = OK, want a non-OK status when console enrichment fully failed (msg=%q)", snap.Message)
+	}
+	if _, ok := snap.Diagnostics["opencode_console_auth_error"]; !ok {
+		t.Errorf("expected opencode_console_auth_error diagnostic, got diagnostics=%+v", snap.Diagnostics)
+	}
+}

--- a/internal/providers/opencode/testdata/seroval_7abeebee372f.txt
+++ b/internal/providers/opencode/testdata/seroval_7abeebee372f.txt
@@ -1,0 +1,5 @@
+;0x000001a4;((self.$R=self.$R||{})["server-fn:3"]=[],($R=>$R[0]={
+rollingUsage:{usagePercent:67.5,resetInSec:10800,resetAt:$R[1]=new Date("2026-04-30T14:30:00.000Z")},
+weeklyUsage:{usagePercent:42.3,resetInSec:259200,resetAt:$R[2]=new Date("2026-05-01T00:00:00.000Z")},
+renewAt:$R[3]=new Date("2026-05-01T00:00:00.000Z")
+})($R["server-fn:3"]))

--- a/internal/providers/opencode/testdata/seroval_def39973159c.txt
+++ b/internal/providers/opencode/testdata/seroval_def39973159c.txt
@@ -1,0 +1,3 @@
+;0x00000120;((self.$R=self.$R||{})["server-fn:1"]=[],($R=>$R[0]={
+workspaces:[{id:"wrk_TESTWORKSPACE123",name:"My Workspace",role:"owner"},{id:"wrk_SECONDWORKSPACE",name:"Secondary",role:"member"}]
+})($R["server-fn:1"]))

--- a/internal/tui/gauge.go
+++ b/internal/tui/gauge.go
@@ -167,13 +167,13 @@ func joinAnnotationParts(parts ...string) string {
 // the window string isn't recognized — in that case we render the plain gauge.
 func gaugeWindowDuration(window string) (time.Duration, bool) {
 	switch strings.ToLower(strings.TrimSpace(window)) {
-	case "5h":
+	case "5h", "rolling-5h":
 		return 5 * time.Hour, true
 	case "1d", "24h", "today":
 		return 24 * time.Hour, true
 	case "7d":
 		return 7 * 24 * time.Hour, true
-	case "30d":
+	case "30d", "month":
 		return 30 * 24 * time.Hour, true
 	}
 	return 0, false

--- a/internal/tui/model_display_info.go
+++ b/internal/tui/model_display_info.go
@@ -303,6 +303,37 @@ func computeDisplayInfoRaw(snap core.UsageSnapshot, widget core.DashboardWidget,
 		return info
 	}
 
+	// opencode's console-derived quota metrics follow a different naming
+	// convention than claude_code's (rolling_usage/weekly_usage/
+	// monthly_usage_pct vs usage_five_hour/usage_seven_day) — same "quota
+	// window usage" concept, so it gets the same Usage tag treatment
+	// rather than falling through to a cost-based Credits branch below.
+	if ru, ok := snap.Metrics["rolling_usage"]; ok && ru.Used != nil {
+		info.tagEmoji = "⚡"
+		info.tagLabel = "Usage"
+		info.reason = "rolling_usage"
+		info.gaugePercent = *ru.Used
+		parts := []string{fmt.Sprintf("5h %.0f%%", *ru.Used)}
+		if wu, ok2 := snap.Metrics["weekly_usage"]; ok2 && wu.Used != nil {
+			parts = append(parts, fmt.Sprintf("7d %.0f%%", *wu.Used))
+			if *wu.Used > info.gaugePercent {
+				info.gaugePercent = *wu.Used
+			}
+		}
+		if mu, ok2 := snap.Metrics["monthly_usage_pct"]; ok2 && mu.Used != nil {
+			parts = append(parts, fmt.Sprintf("mo %.0f%%", *mu.Used))
+			if *mu.Used > info.gaugePercent {
+				info.gaugePercent = *mu.Used
+			}
+		}
+		info.summary = strings.Join(parts, " · ")
+		if bal, ok2 := snap.Metrics["console_balance"]; ok2 && bal.Remaining != nil && !hideCosts {
+			info.detail = fmt.Sprintf("$%.2f balance", *bal.Remaining)
+		}
+		core.Tracef("[display] %s: branch=rolling_usage used=%.1f gauge=%.1f -> tag=Usage", snap.ProviderID, *ru.Used, info.gaugePercent)
+		return info
+	}
+
 	if _, hasBillingBlock := snap.Resets["billing_block"]; hasBillingBlock {
 		info.tagEmoji = "⚡"
 		info.tagLabel = "Usage"

--- a/internal/tui/model_display_test.go
+++ b/internal/tui/model_display_test.go
@@ -452,6 +452,46 @@ func TestComputeDisplayInfo_UsageFiveHourBranch(t *testing.T) {
 	}
 }
 
+func TestComputeDisplayInfo_RollingUsageBranchClassifiesAsUsageNotCredits(t *testing.T) {
+	// opencode's console-derived quota metrics (rolling_usage etc.) previously
+	// weren't recognized by any branch, so an account with real quota data
+	// AND a console_balance/today_api_cost metric fell through to the
+	// cost-based Credits branch instead of showing Usage like claude_code.
+	rolling := 15.0
+	weekly := 3.0
+	monthly := 49.0
+	balance := 0.0
+	todayCost := 1.55
+	snap := core.UsageSnapshot{
+		ProviderID: "opencode",
+		Status:     core.StatusOK,
+		Metrics: map[string]core.Metric{
+			"rolling_usage":     {Used: &rolling, Unit: "percent", Window: "rolling-5h"},
+			"weekly_usage":      {Used: &weekly, Unit: "percent", Window: "7d"},
+			"monthly_usage_pct": {Used: &monthly, Unit: "percent", Window: "month"},
+			"console_balance":   {Remaining: &balance, Unit: "USD", Window: "current"},
+			"today_api_cost":    {Used: &todayCost, Unit: "USD", Window: "1d"},
+		},
+	}
+
+	got := computeDisplayInfo(snap, core.DefaultDashboardWidget(), false)
+	if got.tagLabel != "Usage" {
+		t.Fatalf("tagLabel = %q, want Usage (opencode's rolling_usage metric should win over today_api_cost)", got.tagLabel)
+	}
+	if got.tagEmoji != "⚡" {
+		t.Fatalf("tagEmoji = %q, want ⚡", got.tagEmoji)
+	}
+	if got.gaugePercent != 49.0 {
+		t.Fatalf("gaugePercent = %v, want 49.0 (highest of rolling/weekly/monthly)", got.gaugePercent)
+	}
+	if !strings.Contains(got.summary, "5h 15%") || !strings.Contains(got.summary, "7d 3%") || !strings.Contains(got.summary, "mo 49%") {
+		t.Fatalf("summary = %q, want 5h/7d/mo percentages", got.summary)
+	}
+	if got.reason != "rolling_usage" {
+		t.Fatalf("reason = %q, want rolling_usage", got.reason)
+	}
+}
+
 func TestComputeDisplayInfo_TodayApiCostBranchWithoutFiveHour(t *testing.T) {
 	todayCost := 55.57
 	snap := core.UsageSnapshot{

--- a/internal/tui/tiles_gauge.go
+++ b/internal/tui/tiles_gauge.go
@@ -228,7 +228,14 @@ func tileGaugeProjectionAnnotation(snap core.UsageSnapshot, key string, met core
 	if !ok {
 		return ""
 	}
+	// Providers store the reset timestamp under either the bare metric key
+	// (claude_code: snap.Resets["usage_five_hour"]) or a "_reset"-suffixed
+	// key (copilot, opencode: snap.Resets["rolling_usage_reset"]) — both are
+	// established conventions in this codebase, so check both.
 	resetAt, hasReset := snap.Resets[key]
+	if !hasReset {
+		resetAt, hasReset = snap.Resets[key+"_reset"]
+	}
 	if !hasReset {
 		return ""
 	}

--- a/internal/tui/tiles_gauge_test.go
+++ b/internal/tui/tiles_gauge_test.go
@@ -289,6 +289,33 @@ func TestTileGaugeProjectionAnnotation_CodexCredits(t *testing.T) {
 	}
 }
 
+func TestTileGaugeProjectionAnnotation_SuffixedResetKeyAndAliasedWindows(t *testing.T) {
+	// Some providers (copilot, opencode) store the reset timestamp under a
+	// "<key>_reset" suffixed key rather than the bare metric key, and use
+	// "rolling-5h"/"month" as documented Window aliases for "5h"/"30d"
+	// (see core.Metric's Window doc comment). Both conventions must resolve
+	// to a real annotation, not silently render nothing.
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+
+	rolling := makeUsageMetric(50, 100, "rolling-5h")
+	snap := core.UsageSnapshot{
+		Resets: map[string]time.Time{"rolling_usage_reset": now.Add(4 * time.Hour)},
+	}
+	out := tileGaugeProjectionAnnotation(snap, "rolling_usage", rolling, 50, now)
+	if !strings.Contains(out, "resets") {
+		t.Errorf("rolling-5h window with _reset-suffixed key: expected a reset annotation, got %q", out)
+	}
+
+	monthly := makeUsageMetric(50, 100, "month")
+	snap2 := core.UsageSnapshot{
+		Resets: map[string]time.Time{"monthly_usage_pct_reset": now.Add(15 * 24 * time.Hour)},
+	}
+	out2 := tileGaugeProjectionAnnotation(snap2, "monthly_usage_pct", monthly, 50, now)
+	if !strings.Contains(out2, "resets") {
+		t.Errorf("month window with _reset-suffixed key: expected a reset annotation, got %q", out2)
+	}
+}
+
 func TestTileGaugeProjectionAnnotation_OvershootsWindow(t *testing.T) {
 	// User's reported scenario: 5h window started 1h 18m ago, 22% used.
 	// Pace = 0.22/78 = 0.002820/min → pctPerMinute = 0.2820.


### PR DESCRIPTION
## Summary

Adds OpenCode Zen quota display (rolling 5h / weekly / monthly usage percentages, console balance, billing info) to the dashboard, sourced from the OpenCode console (browser-session auth), plus a handful of correctness fixes found while getting this working with multiple OpenCode accounts on the same machine.

**Provider/subsystem touched:** `internal/providers/opencode`, `internal/providers/perplexity`, `internal/providers/claude_code`, `internal/telemetry`.

## What's included

- **`internal/providers/opencode`**: new `console_rpc.go` client that scrapes the OpenCode Go usage page (HTML + embedded Seroval script) for billing and rolling/weekly/monthly usage-percent data, with an RPC-based fallback. Adds a `monthly_usage_pct` metric and a blue-themed dashboard widget.
- **Browser-session-only accounts** (no Zen API key) are now supported — `Fetch()` no longer requires an API key when a browser cookie is configured.
- **Cross-account correctness**: fixed several bugs that only show up with *two* OpenCode accounts on one machine (e.g. work + personal, different browsers):
  - Session storage no longer gets clobbered across sibling accounts (`loadStoredSession` reads directly from `credentials.json` instead of refreshing from whichever browser polled last).
  - A telemetry provider-scope fallback (`internal/telemetry/usage_view.go`) no longer leaks one account's local usage/message/token data onto a sibling account that shares the same provider ID but has no local telemetry of its own.
  - The same cross-account session-clobbering fix is mirrored in `internal/providers/perplexity` — it had the identical bug (same fixed cookie domain, multiple accounts, different browsers).
- **Correctness of the quota data itself**:
  - A missing/expired session (both the page scrape and billing-RPC fallback failing) no longer gets silently swallowed and reported as `$0.00 balance` — it now surfaces as a real auth error.
  - A legitimate 0% usage reading (quota window just reset) is no longer indistinguishable from "not found" and dropped from the dashboard.
  - An account with neither a valid API key nor a working console session no longer falsely reports `OK` status.
- **Unrelated fix bundled in** (found while testing the above): `internal/providers/claude_code` — the Keychain lookup for Claude Desktop's Chromium Safe Storage password used a stale account name (`"Claude"`) that no longer matches current Claude Desktop builds (`"Claude Key"`), which silently broke the 5h/7d usage-percent metrics for Claude Code. Now tries both.
- **Monthly gauge was silently hidden**: `DefaultDashboard` caps gauge rendering to 2 lines unless a widget opts into more. OpenCode's gauge priority lists three usage-window percentages (5h / 7d / monthly), so the 2-line default meant `monthly_usage_pct` was always bumped by the two shorter windows even though it was already being fetched correctly. Raised `GaugeMaxLines` to 3 (matches the existing `ollama` provider's precedent) so all three render.

## User-visible changes

- New dashboard metrics for OpenCode: `rolling_usage`, `weekly_usage`, `monthly_usage_pct`, `console_balance`, `monthly_limit`, plus billing attributes (subscription plan, payment method) — all three usage-window gauges (5h/7d/monthly) are now visible on the tile, not just the first two.
- OpenCode accounts configured with only a browser session (no `OPENCODE_API_KEY`) now work end-to-end instead of requiring a key.
- Claude Code's 5-hour/7-day usage-percent gauges will populate again for users on current Claude Desktop builds (previously silently fell back to Cache Hit % / cost-only display).
- No config schema changes — existing `browser_cookie` account config is reused as-is.

## Testing

- `make fmt vet test` run locally. All green except three pre-existing, environment-dependent failures unrelated to this PR (`hermes`/`zed` `TestProvider_Fetch_MissingDB`, which pick up real local DB files, and an `opencode` `auth_scope` assertion that depends on real local credentials rather than a proper test double) — confirmed via `git stash` that all three exist on `main` before this branch's changes.
- New/updated unit tests: `console_rpc_test.go` (Seroval/HTML parsing, including a 0%-usage regression test), `provider_test.go` (browser-session-only auth flow, double-failure error propagation, status fallback), `usage_view_test.go` (cross-account telemetry leak regression).
- Manually verified end-to-end against two real OpenCode accounts (different browsers) and a real Claude Code / Claude Desktop install.
- `GaugeMaxLines` change is a widget-config constant, not new logic — the underlying `monthly_usage_pct` data path was already covered by existing/added tests; verified the rendering fix visually via `make demo`-style TUI capture rather than a new unit test.

No docs changes — no new config keys were introduced.
