### PR TITLE
fix(tui): surface browser-session keybindings in the Keys tab footer

### DIFF
--- a/internal/tui/settings_modal_layout.go
+++ b/internal/tui/settings_modal_layout.go
@@ -155,7 +155,7 @@ func (m Model) settingsModalHint() string {
 		if m.settings.apiKeyEditing {
 			return "Type API key  ·  Enter: validate & save  ·  Esc: cancel"
 		}
-		if m.hasBrowserSessionRows(m.apiKeysTabIDs()) {
+		if m.selectedAPIKeyRowSupportsBrowserSession() {
 			return "Up/Down: select  ·  Enter: edit key  ·  c: read browser cookie  ·  b: open site  ·  x: disconnect browser  ·  d: delete key  ·  Left/Right: switch tab  ·  Esc: close"
 		}
 		return "Up/Down: select  ·  Enter: edit key  ·  d: delete key  ·  Left/Right: switch tab  ·  Esc: close"

--- a/internal/tui/settings_modal_layout.go
+++ b/internal/tui/settings_modal_layout.go
@@ -155,6 +155,9 @@ func (m Model) settingsModalHint() string {
 		if m.settings.apiKeyEditing {
 			return "Type API key  ·  Enter: validate & save  ·  Esc: cancel"
 		}
+		if m.hasBrowserSessionRows(m.apiKeysTabIDs()) {
+			return "Up/Down: select  ·  Enter: edit key  ·  c: read browser cookie  ·  b: open site  ·  x: disconnect browser  ·  d: delete key  ·  Left/Right: switch tab  ·  Esc: close"
+		}
 		return "Up/Down: select  ·  Enter: edit key  ·  d: delete key  ·  Left/Right: switch tab  ·  Esc: close"
 	case settingsTabView:
 		return "Up/Down: select view  ·  Space/Enter: apply  ·  v/Shift+V: cycle outside settings  ·  Esc: close"

--- a/internal/tui/settings_modal_preferences.go
+++ b/internal/tui/settings_modal_preferences.go
@@ -100,17 +100,17 @@ func (m Model) apiKeysTabIDs() []string {
 	return ids
 }
 
-// hasBrowserSessionRows reports whether the Keys tab has at least one
-// browser-session-capable provider — controls whether the c/b/x
-// keybindings (read cookie / open site / disconnect) are relevant, since
-// they only apply to browser-session rows.
-func (m Model) hasBrowserSessionRows(ids []string) bool {
-	for _, id := range ids {
-		if supportsBrowserSessionProvider(providerForAccountID(id, m.accountProviders)) {
-			return true
-		}
+// selectedAPIKeyRowSupportsBrowserSession reports whether the Keys tab row
+// currently under the cursor supports browser-session auth — controls
+// whether the c/b/x keybindings (read cookie / open site / disconnect) are
+// shown in the footer, since they only do something on that specific row.
+func (m Model) selectedAPIKeyRowSupportsBrowserSession() bool {
+	ids := m.apiKeysTabIDs()
+	if len(ids) == 0 {
+		return false
 	}
-	return false
+	cursor := clamp(m.settings.cursor, 0, len(ids)-1)
+	return supportsBrowserSessionProvider(providerForAccountID(ids[cursor], m.accountProviders))
 }
 
 func providerForAccountID(accountID string, accountProviders map[string]string) string {

--- a/internal/tui/settings_modal_preferences.go
+++ b/internal/tui/settings_modal_preferences.go
@@ -100,6 +100,19 @@ func (m Model) apiKeysTabIDs() []string {
 	return ids
 }
 
+// hasBrowserSessionRows reports whether the Keys tab has at least one
+// browser-session-capable provider — controls whether the c/b/x
+// keybindings (read cookie / open site / disconnect) are relevant, since
+// they only apply to browser-session rows.
+func (m Model) hasBrowserSessionRows(ids []string) bool {
+	for _, id := range ids {
+		if supportsBrowserSessionProvider(providerForAccountID(id, m.accountProviders)) {
+			return true
+		}
+	}
+	return false
+}
+
 func providerForAccountID(accountID string, accountProviders map[string]string) string {
 	if providerID := strings.TrimSpace(accountProviders[accountID]); providerID != "" {
 		return providerID
@@ -224,18 +237,6 @@ func (m Model) renderSettingsAPIKeysBody(w, h int) string {
 	}
 	if m.settings.apiKeyStatus != "" && !m.settings.apiKeyEditing {
 		lines = append(lines, "", dimStyle.Render("  "+m.settings.apiKeyStatus))
-	}
-	// Help line that explains the new keybindings only when at least one
-	// browser-session row is in view.
-	hasBrowserRows := false
-	for _, id := range ids {
-		if supportsBrowserSessionProvider(providerForAccountID(id, m.accountProviders)) {
-			hasBrowserRows = true
-			break
-		}
-	}
-	if hasBrowserRows {
-		lines = append(lines, "", dimStyle.Render("  Enter: configure primary auth · c: read browser cookie · b: open site · x: disconnect browser session · d: delete API key"))
 	}
 	return padToSize(strings.Join(lines, "\n"), w, h)
 }


### PR DESCRIPTION
## Summary

The Settings → Keys tab keybindings for browser-session providers (`c`: read cookie, `b`: open site, `x`: disconnect) were only documented in a hint line appended to the end of the tab's scrollable provider list. With enough providers in the catalog to fill the available modal height — which is the common case, there are 15+ built-in providers — that line gets silently cropped by `padToSize` and never reaches the screen. The persistent footer (always visible regardless of scroll) never mentioned these keybindings at all, so they were effectively undiscoverable for anyone with a reasonably full provider list.

**Provider/subsystem touched:** `internal/tui` (Settings modal only — no provider changes).

## What changed

- Removed the truncation-prone inline hint line from `renderSettingsAPIKeysBody` (`internal/tui/settings_modal_preferences.go`).
- Added a small `hasBrowserSessionRows` helper (dedupes logic that previously lived inline).
- `settingsModalHint()` (`internal/tui/settings_modal_layout.go`) now includes the `c`/`b`/`x` keybindings in the persistent footer whenever the Keys tab has at least one browser-session-capable provider — which is always true today, since OpenCode and Perplexity are both browser-session providers in the default catalog.

## User-visible changes

- The Keys tab footer now reads `Up/Down: select · Enter: edit key · c: read browser cookie · b: open site · x: disconnect browser · d: delete key · Left/Right: switch tab · Esc: close` instead of omitting the browser-session bindings.
- No behavior change to the keybindings themselves — only their discoverability.
- No config schema changes.

## Testing

- `go build ./...` and `go test ./internal/tui/...` pass.
- Manually verified: opened Settings (`,`), navigated to the Keys tab (5 providers deep in the list, well past the truncation point), confirmed the footer now shows the full keybinding list where it previously showed only `Up/Down: select · Enter: edit key · d: delete key · Left/Right: switch tab · Esc: close`.

No docs changes — this is a UI-string fix, no new config keys or behavior.