### PR TITLE
refactor(claude_code): unify usage-API auth sources behind a closure list

### DIFF
--- a/internal/providers/claude_code/claude_code.go
+++ b/internal/providers/claude_code/claude_code.go
@@ -3,6 +3,7 @@ package claude_code
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,8 +18,9 @@ import (
 
 type Provider struct {
 	providerbase.Base
-	mu            sync.Mutex
-	usageAPICache *usageResponse // last successful Usage API response
+	mu                  sync.Mutex
+	usageAPICache       *usageResponse // last successful Usage API response
+	lastUsageAuthSource string         // name of the usageAuthSource that last succeeded; empty until a first success
 
 	jsonlCacheMu sync.Mutex
 	jsonlCache   map[string]*jsonlCacheEntry // keyed by file path
@@ -433,42 +435,156 @@ func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.Usa
 	return snap, nil
 }
 
+// usageAuthSource is one way of authenticating against the usage API.
+// prepare resolves credentials and, on success, returns the URL to call and
+// a closure that applies auth headers to the request; it errs without
+// making a request if the credential it needs (cookies, an OAuth token)
+// isn't available.
+type usageAuthSource struct {
+	name    string
+	prepare func() (url string, setAuth func(*http.Request), err error)
+}
+
+// usageAuthSources lists the auth sources in priority order: cookie/org
+// (macOS desktop app) first, then the CLI's own OAuth token as the fallback
+// used everywhere the desktop app's session cookies aren't available.
+func (p *Provider) usageAuthSources(orgUUID string) []usageAuthSource {
+	return []usageAuthSource{
+		{
+			name: "cookie",
+			prepare: func() (string, func(*http.Request), error) {
+				cookies, err := getClaudeSessionCookies()
+				if err != nil {
+					return "", nil, err
+				}
+				url := fmt.Sprintf("https://claude.ai/api/organizations/%s/usage", orgUUID)
+				return url, cookieAuthHeaders(cookies), nil
+			},
+		},
+		{
+			name: "oauth",
+			prepare: func() (string, func(*http.Request), error) {
+				token, err := readClaudeCodeOAuthToken()
+				if err != nil {
+					return "", nil, err
+				}
+				return oauthUsageURL, oauthAuthHeaders(token), nil
+			},
+		},
+	}
+}
+
+// cookieAuthHeaders builds the auth closure for the cookie/org usage source:
+// the desktop app's session cookies plus the browser-shaped headers the
+// claude.ai endpoint expects. Kept separate from getClaudeSessionCookies so
+// the header scheme can be tested without macOS keychain/cookie access.
+func cookieAuthHeaders(cookies map[string]string) func(*http.Request) {
+	return func(req *http.Request) {
+		var cookieParts []string
+		for name, value := range cookies {
+			cookieParts = append(cookieParts, fmt.Sprintf("%s=%s", name, value))
+		}
+		req.Header.Set("Cookie", strings.Join(cookieParts, "; "))
+		req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+		req.Header.Set("Referer", "https://claude.ai/settings/usage")
+		req.Header.Set("anthropic-client-platform", "web_claude_ai")
+	}
+}
+
+// oauthAuthHeaders builds the auth closure for the OAuth usage source: the
+// Claude Code CLI's own bearer token. Kept separate from
+// readClaudeCodeOAuthToken so the header scheme can be tested without a
+// credentials file on disk.
+func oauthAuthHeaders(token string) func(*http.Request) {
+	return func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("anthropic-beta", "oauth-2025-04-20")
+	}
+}
+
+// readUsageAPI resolves usage data through one of usageAuthSources. Once a
+// source has succeeded, it's pinned (p.lastUsageAuthSource) and later calls
+// go straight to it instead of re-probing every source on every poll; if the
+// pinned source stops working, the pin is cleared so the next call re-scans
+// all sources from scratch.
 func (p *Provider) readUsageAPI(ctx context.Context, orgUUID string, snap *core.UsageSnapshot) error {
-	cookies, err := getClaudeSessionCookies()
-	if err != nil {
-		usage, oauthErr := fetchUsageAPIOAuth(ctx)
-		if oauthErr == nil {
-			p.setCachedUsage(usage)
-			applyUsageResponse(usage, snap, time.Now())
-			cacheFiveHourFromSnapshot(snap)
-			snap.Raw["usage_api_ok"] = "true"
-			snap.Raw["usage_api_source"] = "oauth"
+	sources := p.usageAuthSources(orgUUID)
+
+	if pinned := p.getLastUsageAuthSource(); pinned != "" {
+		src, ok := findUsageAuthSource(sources, pinned)
+		if ok {
+			if err := p.tryUsageAuthSource(ctx, src, snap); err == nil {
+				return nil
+			}
+			p.setLastUsageAuthSource("")
+		}
+		if p.applyCachedUsage(snap) {
 			return nil
 		}
-		if cached := p.getCachedUsage(); cached != nil {
-			applyUsageResponse(cached, snap, time.Now())
-			snap.Raw["usage_api_cached"] = "true"
-			return nil
-		}
-		return fmt.Errorf("cookie extraction: %v; oauth fallback: %w", err, oauthErr)
+		return fmt.Errorf("%s auth source (previously successful) failed and no cached usage available", pinned)
 	}
 
-	usage, err := fetchUsageAPI(ctx, orgUUID, cookies)
-	if err != nil {
-		if cached := p.getCachedUsage(); cached != nil {
-			applyUsageResponse(cached, snap, time.Now())
-			snap.Raw["usage_api_cached"] = "true"
+	var errs []string
+	for _, src := range sources {
+		if err := p.tryUsageAuthSource(ctx, src, snap); err == nil {
 			return nil
+		} else {
+			errs = append(errs, fmt.Sprintf("%s: %v", src.name, err))
 		}
-		return fmt.Errorf("API fetch: %w", err)
 	}
 
+	if p.applyCachedUsage(snap) {
+		return nil
+	}
+	return fmt.Errorf("all usage API sources failed: %s", strings.Join(errs, "; "))
+}
+
+func findUsageAuthSource(sources []usageAuthSource, name string) (usageAuthSource, bool) {
+	for _, src := range sources {
+		if src.name == name {
+			return src, true
+		}
+	}
+	return usageAuthSource{}, false
+}
+
+// tryUsageAuthSource attempts a single auth source. On success it applies
+// the fetched usage to snap and pins the source for subsequent calls.
+func (p *Provider) tryUsageAuthSource(ctx context.Context, src usageAuthSource, snap *core.UsageSnapshot) error {
+	url, setAuth, err := src.prepare()
+	if err != nil {
+		return err
+	}
+	usage, err := fetchUsageAPIWithAuth(ctx, url, setAuth)
+	if err != nil {
+		return err
+	}
+	p.applyFetchedUsage(usage, snap, src.name)
+	p.setLastUsageAuthSource(src.name)
+	return nil
+}
+
+// applyFetchedUsage records a freshly fetched usage response as the shared
+// cache and applies it to snap. source names which auth source produced it
+// (e.g. "cookie", "oauth").
+func (p *Provider) applyFetchedUsage(usage *usageResponse, snap *core.UsageSnapshot, source string) {
 	p.setCachedUsage(usage)
 	applyUsageResponse(usage, snap, time.Now())
 	cacheFiveHourFromSnapshot(snap)
-
 	snap.Raw["usage_api_ok"] = "true"
-	return nil
+	snap.Raw["usage_api_source"] = source
+}
+
+// applyCachedUsage applies the last cached usage response to snap, if any,
+// reporting whether a cached value was available.
+func (p *Provider) applyCachedUsage(snap *core.UsageSnapshot) bool {
+	cached := p.getCachedUsage()
+	if cached == nil {
+		return false
+	}
+	applyUsageResponse(cached, snap, time.Now())
+	snap.Raw["usage_api_cached"] = "true"
+	return true
 }
 
 // cacheFiveHourFromSnapshot persists the freshly-resolved 5h usage % to the
@@ -495,4 +611,16 @@ func (p *Provider) setCachedUsage(u *usageResponse) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.usageAPICache = u
+}
+
+func (p *Provider) getLastUsageAuthSource() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastUsageAuthSource
+}
+
+func (p *Provider) setLastUsageAuthSource(name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastUsageAuthSource = name
 }

--- a/internal/providers/claude_code/usage_api.go
+++ b/internal/providers/claude_code/usage_api.go
@@ -181,24 +181,18 @@ func decryptChromiumCookie(encrypted []byte, key []byte) (string, error) {
 	return string(plaintext), nil
 }
 
-func fetchUsageAPI(ctx context.Context, orgUUID string, cookies map[string]string) (*usageResponse, error) {
-	url := fmt.Sprintf("https://claude.ai/api/organizations/%s/usage", orgUUID)
-
+// fetchUsageAPIWithAuth performs the GET/parse round trip shared by every
+// usage-API source (cookie-authenticated org endpoint, OAuth-authenticated
+// account endpoint): only how the request is authenticated differs between
+// them, so callers supply that as a closure over an already-resolved
+// credential rather than duplicating the request/response plumbing.
+func fetchUsageAPIWithAuth(ctx context.Context, url string, setAuth func(*http.Request)) (*usageResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-
-	var cookieParts []string
-	for name, value := range cookies {
-		cookieParts = append(cookieParts, fmt.Sprintf("%s=%s", name, value))
-	}
-	req.Header.Set("Cookie", strings.Join(cookieParts, "; "))
-
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+	setAuth(req)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Referer", "https://claude.ai/settings/usage")
-	req.Header.Set("anthropic-client-platform", "web_claude_ai")
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
@@ -262,49 +256,4 @@ func readClaudeCodeOAuthToken() (string, error) {
 		return "", fmt.Errorf("Claude Code OAuth token expired (refreshed on next Claude Code use)")
 	}
 	return token, nil
-}
-
-// fetchUsageAPIOAuth queries Anthropic's OAuth usage endpoint with the Claude
-// Code CLI's own access token. This is the fallback where desktop-app cookie
-// extraction is unavailable (anywhere but macOS), and it needs no org UUID:
-// the token is scoped to the account. The endpoint returns the same
-// five_hour/seven_day utilization shape as the claude.ai usage API, so the
-// response decodes into the same struct.
-func fetchUsageAPIOAuth(ctx context.Context) (*usageResponse, error) {
-	token, err := readClaudeCodeOAuthToken()
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", oauthUsageURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
-	req.Header.Set("Content-Type", "application/json")
-
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("API request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	var usage usageResponse
-	if err := json.Unmarshal(body, &usage); err != nil {
-		return nil, fmt.Errorf("parsing response: %w", err)
-	}
-
-	return &usage, nil
 }

--- a/internal/providers/claude_code/usage_api_oauth_test.go
+++ b/internal/providers/claude_code/usage_api_oauth_test.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
 )
 
 // setTempHome points os.UserHomeDir at a fresh temp dir. HOME covers
@@ -99,7 +102,7 @@ func TestReadClaudeCodeOAuthToken_MissingFile(t *testing.T) {
 	}
 }
 
-func TestFetchUsageAPIOAuth(t *testing.T) {
+func TestFetchUsageAPIWithAuth_OAuth(t *testing.T) {
 	var gotAuth, gotBeta string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
@@ -109,14 +112,7 @@ func TestFetchUsageAPIOAuth(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := oauthUsageURL
-	oauthUsageURL = srv.URL
-	defer func() { oauthUsageURL = old }()
-
-	futureMs := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
-	writeCredentials(t, `{"claudeAiOauth":{"accessToken":"tok-xyz","expiresAt":`+futureMs+`}}`)
-
-	usage, err := fetchUsageAPIOAuth(context.Background())
+	usage, err := fetchUsageAPIWithAuth(context.Background(), srv.URL, oauthAuthHeaders("tok-xyz"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,10 +130,157 @@ func TestFetchUsageAPIOAuth(t *testing.T) {
 	}
 }
 
-func TestFetchUsageAPIOAuth_NonOKStatus(t *testing.T) {
+func TestFetchUsageAPIWithAuth_NonOKStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"error":"invalid token"}`))
+	}))
+	defer srv.Close()
+
+	if _, err := fetchUsageAPIWithAuth(context.Background(), srv.URL, oauthAuthHeaders("tok")); err == nil {
+		t.Fatal("expected error on 401 response")
+	}
+}
+
+// TestCookieAuthHeaders verifies the cookie/org source's scheme: session
+// cookies plus browser-shaped headers, and specifically that it never sets
+// the OAuth scheme's Authorization header — the two auth schemes must stay
+// distinct since fetchUsageAPIWithAuth applies exactly one of them per call.
+func TestCookieAuthHeaders(t *testing.T) {
+	cookies := map[string]string{
+		"sessionKey":    "sess-abc",
+		"lastActiveOrg": "org-123",
+	}
+	req := httptest.NewRequest(http.MethodGet, "https://claude.ai/api/organizations/org-123/usage", nil)
+	cookieAuthHeaders(cookies)(req)
+
+	cookieHeader := req.Header.Get("Cookie")
+	for name, value := range cookies {
+		want := name + "=" + value
+		if !strings.Contains(cookieHeader, want) {
+			t.Errorf("Cookie header %q missing %q", cookieHeader, want)
+		}
+	}
+	if got := req.Header.Get("Referer"); got != "https://claude.ai/settings/usage" {
+		t.Errorf("Referer = %q, want %q", got, "https://claude.ai/settings/usage")
+	}
+	if got := req.Header.Get("anthropic-client-platform"); got != "web_claude_ai" {
+		t.Errorf("anthropic-client-platform = %q, want %q", got, "web_claude_ai")
+	}
+	if req.Header.Get("User-Agent") == "" {
+		t.Error("User-Agent not set")
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization header should not be set on the cookie scheme, got %q", got)
+	}
+	if got := req.Header.Get("anthropic-beta"); got != "" {
+		t.Errorf("anthropic-beta header should not be set on the cookie scheme, got %q", got)
+	}
+}
+
+// TestOAuthAuthHeaders verifies the OAuth source's scheme: a bearer token
+// plus the oauth-beta header, and that it never sets the cookie scheme's
+// Cookie/Referer/platform headers.
+func TestOAuthAuthHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://api.anthropic.com/api/oauth/usage", nil)
+	oauthAuthHeaders("tok-xyz")(req)
+
+	if got := req.Header.Get("Authorization"); got != "Bearer tok-xyz" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer tok-xyz")
+	}
+	if got := req.Header.Get("anthropic-beta"); got != "oauth-2025-04-20" {
+		t.Errorf("anthropic-beta = %q, want %q", got, "oauth-2025-04-20")
+	}
+	if got := req.Header.Get("Cookie"); got != "" {
+		t.Errorf("Cookie header should not be set on the oauth scheme, got %q", got)
+	}
+	if got := req.Header.Get("Referer"); got != "" {
+		t.Errorf("Referer header should not be set on the oauth scheme, got %q", got)
+	}
+	if got := req.Header.Get("anthropic-client-platform"); got != "" {
+		t.Errorf("anthropic-client-platform header should not be set on the oauth scheme, got %q", got)
+	}
+}
+
+// TestUsageAuthSources_NamesAndOrder pins down the fixture list itself:
+// cookie/org is tried before oauth, matching the macOS-first, CLI-fallback
+// priority documented on usageAuthSources.
+func TestUsageAuthSources_NamesAndOrder(t *testing.T) {
+	p := &Provider{}
+	sources := p.usageAuthSources("org-uuid")
+	if len(sources) != 2 {
+		t.Fatalf("len(sources) = %d, want 2", len(sources))
+	}
+	if sources[0].name != "cookie" {
+		t.Errorf("sources[0].name = %q, want %q", sources[0].name, "cookie")
+	}
+	if sources[1].name != "oauth" {
+		t.Errorf("sources[1].name = %q, want %q", sources[1].name, "oauth")
+	}
+}
+
+// TestUsageAuthSources_OAuthPrepare_UsesOAuthSchemeAndURL exercises the real
+// "oauth" fixture's prepare() end to end: it should resolve to oauthUsageURL
+// and a setAuth closure using the bearer scheme, never the cookie scheme.
+func TestUsageAuthSources_OAuthPrepare_UsesOAuthSchemeAndURL(t *testing.T) {
+	futureMs := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
+	writeCredentials(t, `{"claudeAiOauth":{"accessToken":"tok-fixture","expiresAt":`+futureMs+`}}`)
+
+	p := &Provider{}
+	sources := p.usageAuthSources("org-uuid")
+	src, ok := findUsageAuthSource(sources, "oauth")
+	if !ok {
+		t.Fatal(`findUsageAuthSource(sources, "oauth") = false`)
+	}
+
+	url, setAuth, err := src.prepare()
+	if err != nil {
+		t.Fatalf("prepare: unexpected error: %v", err)
+	}
+	if url != oauthUsageURL {
+		t.Errorf("url = %q, want oauthUsageURL %q", url, oauthUsageURL)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	setAuth(req)
+	if got := req.Header.Get("Authorization"); got != "Bearer tok-fixture" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer tok-fixture")
+	}
+	if got := req.Header.Get("Cookie"); got != "" {
+		t.Errorf("Cookie header should not be set by the oauth fixture, got %q", got)
+	}
+}
+
+// TestFindUsageAuthSource covers the pin-lookup helper readUsageAPI relies on
+// to resume the previously successful source.
+func TestFindUsageAuthSource(t *testing.T) {
+	p := &Provider{}
+	sources := p.usageAuthSources("org-uuid")
+
+	if _, ok := findUsageAuthSource(sources, "oauth"); !ok {
+		t.Error(`findUsageAuthSource(sources, "oauth") = false, want true`)
+	}
+	if _, ok := findUsageAuthSource(sources, "cookie"); !ok {
+		t.Error(`findUsageAuthSource(sources, "cookie") = false, want true`)
+	}
+	if _, ok := findUsageAuthSource(sources, "does-not-exist"); ok {
+		t.Error(`findUsageAuthSource(sources, "does-not-exist") = true, want false`)
+	}
+}
+
+// TestReadUsageAPI_PinsSuccessfulAuthSource covers the second-call fast path:
+// once an auth source has succeeded it's pinned, so later calls go straight
+// to it; when the pinned source stops working, the pin clears and the call
+// falls back to the last cached usage rather than erroring.
+//
+// Cookie extraction always fails on this (non-macOS) test runner, so oauth
+// is the only source that can succeed here; that's enough to exercise pin
+// set/reuse/clear without needing to fake a working cookie source too.
+func TestReadUsageAPI_PinsSuccessfulAuthSource(t *testing.T) {
+	var oauthCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		oauthCalls++
+		_, _ = w.Write([]byte(`{"five_hour":{"utilization":10,"resets_at":"2999-01-01T00:00:00Z"}}`))
 	}))
 	defer srv.Close()
 
@@ -148,7 +291,45 @@ func TestFetchUsageAPIOAuth_NonOKStatus(t *testing.T) {
 	futureMs := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
 	writeCredentials(t, `{"claudeAiOauth":{"accessToken":"tok","expiresAt":`+futureMs+`}}`)
 
-	if _, err := fetchUsageAPIOAuth(context.Background()); err == nil {
-		t.Fatal("expected error on 401 response")
+	p := &Provider{}
+
+	snap := core.NewUsageSnapshot("claude_code", "acct")
+	if err := p.readUsageAPI(context.Background(), "org-uuid", &snap); err != nil {
+		t.Fatalf("first call: unexpected error: %v", err)
+	}
+	if got := p.getLastUsageAuthSource(); got != "oauth" {
+		t.Fatalf("pinned source after first success = %q, want %q", got, "oauth")
+	}
+	if oauthCalls != 1 {
+		t.Fatalf("oauth server calls after first call = %d, want 1", oauthCalls)
+	}
+
+	snap2 := core.NewUsageSnapshot("claude_code", "acct")
+	if err := p.readUsageAPI(context.Background(), "org-uuid", &snap2); err != nil {
+		t.Fatalf("second call: unexpected error: %v", err)
+	}
+	if got := p.getLastUsageAuthSource(); got != "oauth" {
+		t.Fatalf("pinned source after second success = %q, want %q", got, "oauth")
+	}
+	if oauthCalls != 2 {
+		t.Fatalf("oauth server calls after second call = %d, want 2", oauthCalls)
+	}
+
+	// Break the pinned source: point the home dir somewhere with no
+	// credentials file, so readClaudeCodeOAuthToken fails before any HTTP call.
+	setTempHome(t)
+
+	snap3 := core.NewUsageSnapshot("claude_code", "acct")
+	if err := p.readUsageAPI(context.Background(), "org-uuid", &snap3); err != nil {
+		t.Fatalf("third call: expected cache fallback, got error: %v", err)
+	}
+	if snap3.Raw["usage_api_cached"] != "true" {
+		t.Fatalf("third call: expected cached fallback, got Raw=%v", snap3.Raw)
+	}
+	if got := p.getLastUsageAuthSource(); got != "" {
+		t.Fatalf("pin should clear once the pinned source fails, got %q", got)
+	}
+	if oauthCalls != 2 {
+		t.Fatalf("oauth server calls after credential removal = %d, want still 2 (prepare should fail before any request)", oauthCalls)
 	}
 }


### PR DESCRIPTION
## Summary

Builds on #249 by @PavelCz, which adds an OAuth CLI-token fallback so the
Claude Code 5h/7d utilization gauge works off macOS (where the existing
cookie/keychain path is a dead end). This PR keeps that fix and refactors
the auth handling underneath it:

- Collapses `fetchUsageAPI` (cookie/org) and `fetchUsageAPIOAuth` (CLI
  token) into one `fetchUsageAPIWithAuth`, since they were near-duplicate
  HTTP/parse boilerplate differing only in how the request is authenticated.
- `readUsageAPI` now walks an ordered `[]usageAuthSource` (cookie/org first,
  OAuth token as the off-macOS fallback) instead of two hand-written
  branches, so adding a future auth source is a one-line list entry.
- Each source's header-setting closure (`cookieAuthHeaders`,
  `oauthAuthHeaders`) is extracted so the auth scheme itself is testable
  without macOS keychain access or a `~/.claude/.credentials.json` file.
- Once a source succeeds it's pinned on the `Provider`, so subsequent polls
  go straight to it instead of re-probing every source each cycle; the pin
  clears and the next call re-scans from scratch if that source stops
  working.

## Tests

- New coverage for the auth-source fixtures: header-scheme isolation
  (cookie vs OAuth headers never leak into each other), fixture
  ordering/lookup, and pin set/reuse/clear across consecutive
  `readUsageAPI` calls.
- `go build ./...`, `go vet ./...`, and `go test -race
  ./internal/providers/claude_code/...` all pass.

## Docs

No user-facing behavior changes beyond what #249 already documented in
`docs/site/docs/providers/claude-code.md`; no further docs changes needed.