### PR TITLE
fix(docs): pin typescript to 6.0.2 so docs typecheck passes

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -25,7 +25,7 @@
         "@docusaurus/tsconfig": "3.10.1",
         "@docusaurus/types": "3.10.1",
         "@types/react": "^19.2.17",
-        "typescript": "~6.0.2"
+        "typescript": "6.0.2"
       },
       "engines": {
         "node": ">=20.0"
@@ -18602,9 +18602,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -34,7 +34,7 @@
     "@docusaurus/tsconfig": "3.10.1",
     "@docusaurus/types": "3.10.1",
     "@types/react": "^19.2.17",
-    "typescript": "~6.0.2"
+    "typescript": "6.0.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## What

Pins `typescript` to exactly `6.0.2` in `docs/site` (and locks it).

## Why

The **Docs Preview** workflow's `typecheck` step (`tsc`) currently fails on every open PR with:

```
tsconfig.json error TS5102: Option 'baseUrl' has been removed.
```

Root cause: TypeScript **6.0.3** *removed* the `baseUrl` compiler option (it was only deprecated in 6.0.2). But `@docusaurus/tsconfig@3.10.1`, which `docs/site/tsconfig.json` extends, still sets `baseUrl` — and an inherited option can't be un-set from the child config. `docs/site/package.json` declared `~6.0.2`, which allowed the `6.0.3` patch to be locked, so the check went red as soon as that version was published. (This is unrelated to any feature work — it's why community PRs like #249 are blocked.)

Pinning to `6.0.2` — the last release that still accepts `baseUrl`, whose deprecation warning the existing `ignoreDeprecations: "6.0"` already silences — restores the check without touching Docusaurus's shipped config or editing our tsconfig.

## Verification

Reproduced the exact CI step locally with Node 24 / npm 11:

```
$ npm ci && npm run typecheck
> tsc
# exit 0
```

## Docs

Build-tooling-only change (docs site's TypeScript pin); no user-facing docs pages affected.