### PR TITLE
fix(docs): stop extending @docusaurus/tsconfig so typecheck works on typescript 7

### DIFF
--- a/docs/site/tsconfig.json
+++ b/docs/site/tsconfig.json
@@ -1,11 +1,26 @@
 // This file is not used by "docusaurus start/build" commands.
 // It is here to improve your IDE experience (type-checking, autocompletion...),
 // and can also run the package.json "typecheck" script manually.
+//
+// We inline the options from "@docusaurus/tsconfig" instead of extending it:
+// that shared config still sets the "baseUrl" compiler option, which
+// TypeScript 7 removed, so extending it fails typecheck with TS5102. Under
+// TS 7 the "paths" below resolve relative to this file's directory, so the
+// "@site/*" alias keeps working without "baseUrl".
 {
-  "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "noEmit": true,
+    "paths": {
+      "@site/*": ["./*"]
+    },
+    "skipLibCheck": true,
     "strict": true
   },
   "exclude": [".docusaurus", "build"]


### PR DESCRIPTION
## What

Stops `docs/site/tsconfig.json` from extending `@docusaurus/tsconfig`, inlining that base config's compiler options **minus the removed `baseUrl`**. TypeScript stays on the latest `7.0.2` — no downgrade.

## Why

The **Docs Preview** `typecheck` step (`tsc`) fails with:

```
tsconfig.json error TS5102: Option 'baseUrl' has been removed.
```

TypeScript 7 removed the `baseUrl` compiler option. `@docusaurus/tsconfig` (3.10.2) still sets `baseUrl`, and an inherited compiler option can't be un-set from a child config — so simply *extending* it can never pass under TS 7. This went red on `main` after #255 bumped TypeScript `6.0.3 → 7.0.2` (that dependabot PR merged despite its own Docs Preview check failing), and every open PR inherits the failure (e.g. #249).

Inlining the base options and dropping `baseUrl` fixes it. Under TS 7, `paths` resolve relative to the tsconfig's own directory, so the `@site/*` alias keeps working without `baseUrl` (this is exactly the migration TS5102's own message suggests). A comment in the file explains why we inline rather than extend.

## Verification

Reproduced the exact CI step locally with Node 24 / npm 11 on the real TS 7.0.2 pinned by `main`'s lockfile:

```
$ npm ci && npm run typecheck   # typescript@7.0.2
> tsc
# exit 0
```

## Docs

Build-tooling-only change (the docs site's own tsconfig); no user-facing docs pages affected.