### PR TITLE
feat(release): credit contributors in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,37 @@
+# Configures GitHub's auto-generated release notes.
+# release-please uses this when "changelog-type": "github" is set in
+# release-please-config.json: it calls the GitHub generate-notes API, which
+# credits each PR's author ("... by @user in #123") and adds a
+# "New Contributors" section. Categorization here is by PR *label*.
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    # Keep the release PR itself and CI bot noise out of the notes.
+    labels:
+      - "autorelease: pending"
+      - "autorelease: tagged"
+    authors:
+      - github-actions
+      - github-actions[bot]
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Performance
+      labels:
+        - performance
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    # Anything not matched above still shows up here, still credited.
+    - title: Other Changes
+      labels:
+        - "*"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "go",
       "package-name": "openusage",
+      "changelog-type": "github",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
## What

Makes release notes credit contributors by name:

- `release-please-config.json`: set `"changelog-type": "github"`, so release-please builds notes with GitHub's native generator.
- `.github/release.yml`: steer that generator — category grouping + keep release-PR / CI-bot noise out.

## Why

The current `default` changelog links the PR (`(#249)`) but never names the author, so community contributions aren't visibly credited. GitHub's note generator adds `... by @user in #NNN` on every line plus a **New Contributors** section.

## Preview

Generated notes for a hypothetical `v0.24.0` (via the generate-notes API) already show the credit:

```
* feat(claude_code): OAuth usage-API fallback … by @PavelCz in #249
* fix(docs): stop extending @docusaurus/tsconfig … by @janekbaraniewski in #261

## New Contributors
* @PavelCz made their first contribution in #249
```

(The live categories from `.github/release.yml` only take effect once this is merged to the default branch — GitHub reads that config from `main`.)

## Tradeoffs / notes

- **Categorization is by PR label**, not conventional-commit type. Dependabot PRs carry the `dependencies` label and group cleanly; feat/fix PRs need `enhancement` / `bug` labels or they fall under **Other Changes** (still credited). Happy to add a labeling action in a follow-up if you want tighter grouping.
- **Only merged PRs appear** — direct pushes to `main` are omitted (usually a plus).
- The existing `changelog-sections` block is now **inert** but left in place, so reverting to the default changelog is a one-line change.

## Docs

Repo-tooling change (release automation); no user-facing docs pages affected.