### PR TITLE
fix(config): follow symlink chain when saving config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -508,7 +508,20 @@ func SaveTo(path string, cfg Config) error {
 
 // saveLocked is the actual write path; callers MUST hold saveMu.
 func saveLocked(path string, cfg Config) error {
-	dir := filepath.Dir(path)
+	target := path
+	if _, err := os.Lstat(path); err == nil {
+		// Resolve the full symlink chain so the write lands on the real file
+		// instead of replacing the symlink itself.
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return fmt.Errorf("resolving config path %s: %w", path, err)
+		}
+		target = resolved
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat config: %w", err)
+	}
+
+	dir := filepath.Dir(target)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
@@ -519,12 +532,12 @@ func saveLocked(path string, cfg Config) error {
 	}
 	data = append(data, '\n')
 
-	tmpPath := path + ".tmp"
+	tmpPath := target + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		return fmt.Errorf("writing config tmp file: %w", err)
 	}
 	defer os.Remove(tmpPath) // no-op if rename succeeded; cleans up on rename failure
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := os.Rename(tmpPath, target); err != nil {
 		return fmt.Errorf("renaming config tmp file: %w", err)
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -210,6 +211,147 @@ func TestSaveTo_CreatesFileAndDir(t *testing.T) {
 	}
 	if !loaded.Experimental.Analytics {
 		t.Error("expected analytics=true after round-trip")
+	}
+}
+
+func TestSaveTo_FollowsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privilege on Windows")
+	}
+
+	realDir := t.TempDir()
+	realPath := filepath.Join(realDir, "settings.json")
+
+	linkDir := t.TempDir()
+	linkPath := filepath.Join(linkDir, "settings.json")
+
+	cfg := DefaultConfig()
+	cfg.Theme = "Dracula"
+	if err := SaveTo(realPath, cfg); err != nil {
+		t.Fatalf("seeding real file: %v", err)
+	}
+	if err := os.Symlink(realPath, linkPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	cfg.Theme = "Synthwave '84"
+	if err := SaveTo(linkPath, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected settings.json to remain a symlink")
+	}
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if target != realPath {
+		t.Errorf("symlink target changed: got %q, want %q", target, realPath)
+	}
+
+	loaded, err := LoadFrom(realPath)
+	if err != nil {
+		t.Fatalf("loading real file: %v", err)
+	}
+	if loaded.Theme != "Synthwave '84" {
+		t.Errorf("expected real file to reflect write through symlink, got theme %q", loaded.Theme)
+	}
+
+	if _, err := os.Stat(linkPath + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("expected no leftover tmp file next to symlink")
+	}
+	if _, err := os.Stat(realPath + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("expected no leftover tmp file next to real target")
+	}
+}
+
+func TestSaveTo_FollowsSymlinkChain(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privilege on Windows")
+	}
+
+	realDir := t.TempDir()
+	realPath := filepath.Join(realDir, "settings.json")
+
+	midDir := t.TempDir()
+	midPath := filepath.Join(midDir, "settings.json")
+
+	linkDir := t.TempDir()
+	linkPath := filepath.Join(linkDir, "settings.json")
+
+	cfg := DefaultConfig()
+	if err := SaveTo(realPath, cfg); err != nil {
+		t.Fatalf("seeding real file: %v", err)
+	}
+	if err := os.Symlink(realPath, midPath); err != nil {
+		t.Fatalf("creating mid symlink: %v", err)
+	}
+	if err := os.Symlink(midPath, linkPath); err != nil {
+		t.Fatalf("creating outer symlink: %v", err)
+	}
+
+	cfg.Theme = "Dracula"
+	if err := SaveTo(linkPath, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, l := range []struct{ path, wantTarget string }{
+		{linkPath, midPath},
+		{midPath, realPath},
+	} {
+		info, err := os.Lstat(l.path)
+		if err != nil {
+			t.Fatalf("lstat %s: %v", l.path, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("expected %s to remain a symlink", l.path)
+		}
+		target, err := os.Readlink(l.path)
+		if err != nil {
+			t.Fatalf("readlink %s: %v", l.path, err)
+		}
+		if target != l.wantTarget {
+			t.Errorf("symlink %s target changed: got %q, want %q", l.path, target, l.wantTarget)
+		}
+	}
+
+	loaded, err := LoadFrom(realPath)
+	if err != nil {
+		t.Fatalf("loading real file: %v", err)
+	}
+	if loaded.Theme != "Dracula" {
+		t.Errorf("expected real file to reflect write through symlink chain, got theme %q", loaded.Theme)
+	}
+}
+
+func TestSaveTo_BrokenSymlinkErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privilege on Windows")
+	}
+
+	linkDir := t.TempDir()
+	linkPath := filepath.Join(linkDir, "settings.json")
+	missingTarget := filepath.Join(t.TempDir(), "gone.json")
+
+	if err := os.Symlink(missingTarget, linkPath); err != nil {
+		t.Fatalf("creating broken symlink: %v", err)
+	}
+
+	if err := SaveTo(linkPath, DefaultConfig()); err == nil {
+		t.Fatal("expected error saving through a broken symlink")
+	}
+
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected broken symlink to remain untouched, but it was replaced")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `saveLocked` wrote the config via a temp-file + `os.Rename`, which replaces whatever sits at the destination path. If `settings.json` was a symlink, the rename unlinked the symlink and dropped a regular file in its place, leaving the real target stale.
- Resolve the symlink chain with `filepath.EvalSymlinks` before writing so the rename lands on the real file and the symlink (or chain of symlinks) stays intact. A broken symlink now returns a clear error instead of silently clobbering it.

## Test plan
- [x] `TestSaveTo_FollowsSymlink` — save through a symlink, assert the symlink survives and the real file gets the update
- [x] `TestSaveTo_FollowsSymlinkChain` — two-hop symlink chain, same assertions
- [x] `TestSaveTo_BrokenSymlinkErrors` — symlink to a nonexistent target errors and is left untouched
- [x] `go build`, `go vet`, `gofmt`, and full `internal/config` suite (78 tests) pass

No user-facing docs change needed — this is an internal bug fix to config persistence with no change in behavior for non-symlinked configs.