### PR TITLE
perf(daemon): gate on-demand read-model refresh on new data

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -37,7 +37,8 @@ type Service struct {
 	logThrottle *core.LogThrottle
 
 	rmCache       *readModelCache
-	dataIngested  atomic.Bool // set when new data is ingested; read model loop skips refresh when clean
+	dataIngested  atomic.Bool  // set when new data is ingested; read model loop skips refresh when clean
+	lastIngestAt  atomic.Int64 // UnixNano of the most recent ingest; lets readers refresh only when data changed
 	pollScheduler *PollScheduler
 
 	pollStateMu sync.Mutex
@@ -58,6 +59,22 @@ func (s *Service) now() time.Time {
 		return s.clock.Now()
 	}
 	return time.Now()
+}
+
+// markDataIngested records that new data landed. It arms the flag the
+// background read-model refresh loop consumes and stamps the ingest time so
+// on-demand readers can tell whether their cached view is stale relative to
+// real data (rather than merely old in wall-clock terms).
+func (s *Service) markDataIngested() {
+	s.dataIngested.Store(true)
+	s.lastIngestAt.Store(time.Now().UnixNano())
+}
+
+// ingestedSince reports whether any data was ingested after t. A zero
+// lastIngestAt (nothing ingested yet) reports false.
+func (s *Service) ingestedSince(t time.Time) bool {
+	last := s.lastIngestAt.Load()
+	return last > 0 && last > t.UnixNano()
 }
 
 func RunServer(cfg Config) error {

--- a/internal/daemon/server_collect.go
+++ b/internal/daemon/server_collect.go
@@ -105,11 +105,11 @@ func (s *Service) collectAndFlush(ctx context.Context) int {
 	// into usage_rollup_daily and then pruned (see pruneOldData).
 	direct, retries := s.ingestBatch(ctx, allReqs)
 	if direct.ingested > 0 {
-		s.dataIngested.Store(true)
+		s.markDataIngested()
 	}
 	flush, enqueued, flushWarnings := s.flushBacklog(ctx, retries, backlogFlushLimit)
 	if flush.Ingested > 0 {
-		s.dataIngested.Store(true)
+		s.markDataIngested()
 	}
 	warnings = append(warnings, flushWarnings...)
 

--- a/internal/daemon/server_http.go
+++ b/internal/daemon/server_http.go
@@ -125,7 +125,12 @@ func (s *Service) handleReadModel(w http.ResponseWriter, r *http.Request) {
 			core.Tracef("[read_model]   %s: %d metrics", id, len(snap.Metrics))
 		}
 		writeJSON(w, http.StatusOK, ReadModelResponse{Snapshots: cached})
-		if time.Since(cachedAt) > 2*time.Second {
+		// Refresh opportunistically only when new data has actually been
+		// ingested since this entry was built. Without the data gate, every
+		// connected client's poll (~5s) forced a full recompute purely because
+		// the entry aged past the staleness floor — pinning daemon CPU even
+		// when nothing changed. The staleness floor still debounces bursts.
+		if time.Since(cachedAt) > 2*time.Second && s.ingestedSince(cachedAt) {
 			s.refreshReadModelCacheAsync(s.serviceContext(r.Context()), cacheKey, req, 60*time.Second)
 		}
 		return
@@ -148,7 +153,7 @@ func (s *Service) handleReadModel(w http.ResponseWriter, r *http.Request) {
 	// again instead of sticking on stale empty templates. Without this,
 	// a single failed compute can leave the read-model cache permanently
 	// empty until the next ingest event.
-	s.dataIngested.Store(true)
+	s.markDataIngested()
 	s.refreshReadModelCacheAsync(s.serviceContext(r.Context()), cacheKey, req, 60*time.Second)
 	snapshots = ReadModelTemplatesFromRequest(req, DisabledAccountsFromConfig())
 	writeJSON(w, http.StatusOK, ReadModelResponse{Snapshots: snapshots})

--- a/internal/daemon/server_ingest_signal_test.go
+++ b/internal/daemon/server_ingest_signal_test.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIngestedSinceReportsFreshDataOnly(t *testing.T) {
+	s := &Service{}
+
+	// Nothing ingested yet: no cached entry can be considered stale.
+	if s.ingestedSince(time.Now().Add(-time.Hour)) {
+		t.Fatal("ingestedSince = true before any ingest, want false")
+	}
+
+	before := time.Now().Add(-time.Second)
+	s.markDataIngested()
+	after := time.Now().Add(time.Second)
+
+	if !s.dataIngested.Load() {
+		t.Fatal("markDataIngested did not arm the background-refresh flag")
+	}
+	// A cache entry built before the ingest is stale and should refresh.
+	if !s.ingestedSince(before) {
+		t.Fatal("ingestedSince(before ingest) = false, want true")
+	}
+	// A cache entry built after the ingest is current and must not refresh.
+	if s.ingestedSince(after) {
+		t.Fatal("ingestedSince(after ingest) = true, want false")
+	}
+}
+
+func TestIngestedSinceRequiresStrictlyNewerData(t *testing.T) {
+	s := &Service{}
+	s.lastIngestAt.Store(time.Unix(0, 1_000).UnixNano())
+
+	at := time.Unix(0, 1_000)
+	// Equal timestamps mean the cached entry already reflects that ingest.
+	if s.ingestedSince(at) {
+		t.Fatal("ingestedSince(equal timestamp) = true, want false")
+	}
+	if !s.ingestedSince(at.Add(-time.Nanosecond)) {
+		t.Fatal("ingestedSince(older timestamp) = false, want true")
+	}
+}

--- a/internal/daemon/server_poll.go
+++ b/internal/daemon/server_poll.go
@@ -163,7 +163,7 @@ func (s *Service) pollProviders(ctx context.Context) {
 		s.warnf("poll_ingest_warning", "error=%v", ingestErr)
 	}
 	if ingestErr == nil && len(snapshots) > 0 {
-		s.dataIngested.Store(true)
+		s.markDataIngested()
 	}
 
 	durationMs := time.Since(started).Milliseconds()

--- a/internal/daemon/server_read_model.go
+++ b/internal/daemon/server_read_model.go
@@ -72,7 +72,7 @@ func (s *Service) runReadModelCacheLoop(ctx context.Context) {
 	interval := readModelCacheInterval(s.cfg.PollInterval)
 
 	s.infof("read_model_cache_loop_start", "interval=%s", interval)
-	s.dataIngested.Store(true) // ensure first boot always computes
+	s.markDataIngested() // ensure first boot always computes
 	s.refreshReadModelCacheFromConfig(ctx)
 
 	ticker := time.NewTicker(interval)

--- a/internal/daemon/server_spool.go
+++ b/internal/daemon/server_spool.go
@@ -44,7 +44,7 @@ func (s *Service) flushSpoolBacklog(ctx context.Context, maxTotal int) {
 
 	flush, warnings := FlushInBatches(ctx, s.pipeline, maxTotal)
 	if flush.Ingested > 0 {
-		s.dataIngested.Store(true)
+		s.markDataIngested()
 	}
 	if flush.Processed > 0 || len(warnings) > 0 {
 		s.infof(
@@ -182,7 +182,7 @@ func (s *Service) processHookSpool(ctx context.Context, dir string) {
 
 		tally, _ := s.ingestBatch(ctx, parsed.Requests)
 		if tally.ingested > 0 {
-			s.dataIngested.Store(true)
+			s.markDataIngested()
 		}
 		_ = os.Remove(path)
 		processed++

--- a/internal/daemon/server_watch.go
+++ b/internal/daemon/server_watch.go
@@ -69,7 +69,7 @@ func (s *Service) runWatchLoop(ctx context.Context) {
 			}
 			eventName, eventOp := event.Name, event.Op
 			debounceTimer = time.AfterFunc(debounceInterval, func() {
-				s.dataIngested.Store(true) // trigger read model refresh
+				s.markDataIngested() // trigger read model refresh
 				core.Tracef("[watch] change detected: %s op=%s", eventName, eventOp)
 			})
 


### PR DESCRIPTION
## Problem

The telemetry daemon burns a lot of CPU, and it gets noticeably worse whenever a second `openusage` process connects to it.

Root cause is in `handleReadModel`: on a cache hit, it fires a full read-model recompute (`refreshReadModelCacheAsync` → `computeReadModel`) whenever the cached entry is older than **2s** — regardless of whether any data actually changed.

A connected dashboard polls the read-model endpoint every ~5s (the client broadcaster interval is `refreshInterval/3`, clamped to 1–5s). Every poll therefore finds an entry aged past the 2s floor and forces a fresh SQLite `materialize` + ~15 aggregate-query pass, per provider. So simply having a dashboard open pins the daemon at a full recompute every 5s even when the workstation is idle.

The background refresh loop (`runReadModelCacheLoop`) already does the right thing — it only recomputes when `dataIngested` was set — but the HTTP path bypassed that gate entirely.

## Fix

Track the timestamp of the most recent ingest (`lastIngestAt`) alongside the existing `dataIngested` flag, and refresh opportunistically **only when data has actually been ingested since the cached entry was built**. This mirrors the data-gating the background loop applies. The 2s staleness floor is kept to debounce bursts.

- Added `Service.markDataIngested()` / `Service.ingestedSince()` helpers.
- Routed all ingest sites through `markDataIngested()` so `lastIngestAt` stays current.
- Gated the `handleReadModel` opportunistic refresh on `s.ingestedSince(cachedAt)`.

Net effect: an idle-but-connected dashboard no longer drives continuous recomputes; recomputes now track real data arrival.

## Follow-up (not in this PR)

This addresses the *unconditional* recompute amplification. The per-recompute cost itself — Claude Code's provider `Fetch` re-sorting and re-aggregating the entire all-time conversation history on every poll — is a separate, larger baseline cost tracked in #266.

## Testing

- New unit tests for the ingest-signal gating (`server_ingest_signal_test.go`).
- `make build`, `make vet`, and `go test -race ./internal/daemon/...` all pass.

## Docs

No user-facing docs change: this is internal daemon behavior with no new flags, config keys, or commands.
