### PR TITLE
Preserve full Claude model lineage in canonical identifiers

### DIFF
--- a/internal/core/model_identity.go
+++ b/internal/core/model_identity.go
@@ -103,7 +103,7 @@ func normalizeCanonicalModel(providerID, rawModelID string, cfg ModelNormalizati
 		identity.LineageID = identity.Vendor + "/" + claude.lineage
 		identity.Confidence = claude.confidence
 		identity.Reason = claude.reason
-		identity.Canonical = "anthropic/claude-" + FirstNonEmpty(claude.variant, "unknown")
+		identity.Canonical = identity.Vendor + "/" + claude.lineage
 	case "gpt":
 		gpt := canonicalizeGPT(tokens)
 		identity.Vendor = FirstNonEmpty(identity.Vendor, "openai")

--- a/internal/core/model_identity_test.go
+++ b/internal/core/model_identity_test.go
@@ -9,6 +9,9 @@ func TestNormalizeCanonicalModel_ClaudeLineage(t *testing.T) {
 	if got.LineageID != "anthropic/claude-opus-4.6" {
 		t.Fatalf("lineage = %q, want anthropic/claude-opus-4.6", got.LineageID)
 	}
+	if got.Canonical != "anthropic/claude-opus-4.6" {
+		t.Fatalf("canonical = %q, want anthropic/claude-opus-4.6", got.Canonical)
+	}
 	if got.Confidence < 0.9 {
 		t.Fatalf("confidence = %.2f, want >= 0.9", got.Confidence)
 	}


### PR DESCRIPTION
## Summary

Claude model identifiers such as `claude-4.6-opus-high-thinking` were being normalized to:

`anthropic/claude-opus`

This loses the model version and causes different Claude releases to be grouped together.

This change preserves the full lineage:

`anthropic/claude-opus-4.6`

## Changes

- Use the computed Claude lineage for `Canonical`
- Add regression coverage for heuristic normalization
- Keep existing override behavior unchanged

## Testing

- `CGO_ENABLED=1 go test ./...`
- `go vet ./internal/core`
- `gofmt` clean