### PR TITLE
test: anchor time-dependent tests to a single instant

### DIFF
--- a/internal/core/time_window_test.go
+++ b/internal/core/time_window_test.go
@@ -139,17 +139,28 @@ func TestLargestWindowFitting(t *testing.T) {
 	}
 }
 
+// sameCalendarDay reports whether a and b fall on the same calendar date.
+func sameCalendarDay(a, b time.Time) bool {
+	return a.Year() == b.Year() && a.Month() == b.Month() && a.Day() == b.Day()
+}
+
 func TestLocalMidnight(t *testing.T) {
+	// LocalMidnight reads its own clock, so bracket the call rather than
+	// comparing against a separately captured time.Now(): if midnight lands
+	// between the two clock reads the dates legitimately differ. The result
+	// must match the day observed on one side of the call or the other.
+	before := time.Now()
 	m := LocalMidnight()
+	after := time.Now()
+
 	if m.Hour() != 0 || m.Minute() != 0 || m.Second() != 0 || m.Nanosecond() != 0 {
 		t.Errorf("LocalMidnight() = %v, want 00:00:00.000000000", m)
 	}
-	now := time.Now()
-	if m.Year() != now.Year() || m.Month() != now.Month() || m.Day() != now.Day() {
-		t.Errorf("LocalMidnight() date = %v, want %v", m.Format("2006-01-02"), now.Format("2006-01-02"))
+	if !sameCalendarDay(m, before) && !sameCalendarDay(m, after) {
+		t.Errorf("LocalMidnight() date = %v, want %v or %v", m.Format("2006-01-02"), before.Format("2006-01-02"), after.Format("2006-01-02"))
 	}
-	if m.Location() != now.Location() {
-		t.Errorf("LocalMidnight() location = %v, want %v", m.Location(), now.Location())
+	if m.Location() != after.Location() {
+		t.Errorf("LocalMidnight() location = %v, want %v", m.Location(), after.Location())
 	}
 }
 
@@ -162,12 +173,14 @@ func TestTimeWindowSince(t *testing.T) {
 		t.Errorf("TimeWindowAll.Since() = %v, want zero", allSince)
 	}
 
-	// "1d" returns local midnight (calendar day boundary).
+	// "1d" returns local midnight (calendar day boundary). Bracketed for the
+	// same reason as TestLocalMidnight: Since() reads the clock itself.
 	oneDaySince := TimeWindow1d.Since()
+	afterOneDay := time.Now()
 	if oneDaySince.Hour() != 0 || oneDaySince.Minute() != 0 || oneDaySince.Second() != 0 {
 		t.Errorf("TimeWindow1d.Since() = %v, want midnight", oneDaySince)
 	}
-	if oneDaySince.Year() != now.Year() || oneDaySince.Month() != now.Month() || oneDaySince.Day() != now.Day() {
+	if !sameCalendarDay(oneDaySince, now) && !sameCalendarDay(oneDaySince, afterOneDay) {
 		t.Errorf("TimeWindow1d.Since() date = %v, want today", oneDaySince.Format("2006-01-02"))
 	}
 

--- a/internal/providers/codex/codex_test.go
+++ b/internal/providers/codex/codex_test.go
@@ -771,17 +771,24 @@ func TestClassifyClient_NormalizesCodexWrapperSources(t *testing.T) {
 func TestFetchExtractsToolLanguageAndCodeStats(t *testing.T) {
 	tmpDir := t.TempDir()
 	sessionsRoot := filepath.Join(tmpDir, "sessions")
+	// The provider buckets events by the day encoded in their timestamp and
+	// compares that against time.Now().UTC() for requests_today, so the
+	// fixture must live on the real current UTC day. Anchor the day directory
+	// and every event timestamp to the start of that day: derived from a
+	// single instant they can never straddle midnight the way now-relative
+	// offsets did.
 	now := time.Now().UTC()
-	dayDir := filepath.Join(sessionsRoot, now.Format("2006"), now.Format("01"), now.Format("02"))
+	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	dayDir := filepath.Join(sessionsRoot, dayStart.Format("2006"), dayStart.Format("01"), dayStart.Format("02"))
 	if err := os.MkdirAll(dayDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	sessionFile := filepath.Join(dayDir, "rollout-rich.jsonl")
-	ts1 := now.Add(-2 * time.Minute).Format(time.RFC3339)
-	ts2 := now.Add(-90 * time.Second).Format(time.RFC3339)
-	ts3 := now.Add(-60 * time.Second).Format(time.RFC3339)
-	ts4 := now.Add(-30 * time.Second).Format(time.RFC3339)
+	ts1 := dayStart.Add(1 * time.Second).Format(time.RFC3339)
+	ts2 := dayStart.Add(2 * time.Second).Format(time.RFC3339)
+	ts3 := dayStart.Add(3 * time.Second).Format(time.RFC3339)
+	ts4 := dayStart.Add(4 * time.Second).Format(time.RFC3339)
 	sessionContent := fmt.Sprintf(`{"timestamp":"%s","type":"session_meta","payload":{"id":"sess-rich","source":"cli","originator":"codex_cli_rs"}}
 {"timestamp":"%s","type":"turn_context","payload":{"model":"gpt-5-codex"}}
 {"timestamp":"%s","type":"event_msg","payload":{"type":"user_message","text":"first"}}

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -98,11 +98,13 @@ func TestFetch_Success(t *testing.T) {
 	}
 
 	now := time.Now().In(time.Local)
+	// Date and clock come from the same instant: an offset clock (now-1m)
+	// paired with today's date stamps a line dated today but timed yesterday
+	// whenever the test runs just after midnight.
 	today := now.Format("2006/01/02")
-	t0 := now.Add(-1 * time.Minute).Format("15:04:05")
-	t1 := now.Format("15:04:05")
+	t0 := now.Format("15:04:05")
 	logData := fmt.Sprintf(`[GIN] %s - %s | 200 | 1.2s | 127.0.0.1 | POST     "/api/chat"`+"\n", today, t0) +
-		fmt.Sprintf(`[GIN] %s - %s | 200 | 850ms | 127.0.0.1 | POST     "/v1/chat/completions"`+"\n", today, t1)
+		fmt.Sprintf(`[GIN] %s - %s | 200 | 850ms | 127.0.0.1 | POST     "/v1/chat/completions"`+"\n", today, t0)
 	if err := os.WriteFile(filepath.Join(logDir, "server.log"), []byte(logData), 0o644); err != nil {
 		t.Fatalf("write server log: %v", err)
 	}
@@ -381,8 +383,10 @@ func TestFetch_NoSyntheticUsageWithoutCloudWindows(t *testing.T) {
 	}
 
 	now := time.Now().In(time.Local)
+	// Date and clock come from the same instant, so the fixture cannot land on
+	// today's date with yesterday's wall-clock time just after midnight.
 	today := now.Format("2006/01/02")
-	t0 := now.Add(-2 * time.Minute).Format("15:04:05")
+	t0 := now.Format("15:04:05")
 	logData := fmt.Sprintf(`[GIN] %s - %s | 200 | 1.2s | 127.0.0.1 | POST     "/api/chat"`+"\n", today, t0)
 	if err := os.WriteFile(filepath.Join(logDir, "server.log"), []byte(logData), 0o644); err != nil {
 		t.Fatalf("write server log: %v", err)
@@ -528,8 +532,10 @@ func TestFetchServerLogs_CountsAnthropicMessagesPath(t *testing.T) {
 	}
 
 	now := time.Now().In(time.Local)
+	// Date and clock come from the same instant, so the fixture cannot land on
+	// today's date with yesterday's wall-clock time just after midnight.
 	today := now.Format("2006/01/02")
-	t0 := now.Add(-1 * time.Minute).Format("15:04:05")
+	t0 := now.Format("15:04:05")
 	logData := fmt.Sprintf(`[GIN] %s - %s | 200 | 640ms | 127.0.0.1 | POST     "/v1/messages"`+"\n", today, t0)
 	if err := os.WriteFile(filepath.Join(logDir, "server.log"), []byte(logData), 0o644); err != nil {
 		t.Fatalf("write server log: %v", err)

--- a/internal/providers/zai/zai_test.go
+++ b/internal/providers/zai/zai_test.go
@@ -218,8 +218,11 @@ func TestFetch_QuotaLimit_LimitedByBusinessCode(t *testing.T) {
 }
 
 func TestFetch_ParsesModelAndToolUsage(t *testing.T) {
-	today := time.Now().UTC().Format("2006-01-02")
-	yesterday := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02")
+	// Both day keys come from one instant; two separate time.Now() calls can
+	// straddle midnight and collapse yesterday onto today.
+	now := time.Now().UTC()
+	today := now.Format("2006-01-02")
+	yesterday := now.Add(-24 * time.Hour).Format("2006-01-02")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/telemetry/usage_view_test.go
+++ b/internal/telemetry/usage_view_test.go
@@ -661,7 +661,13 @@ func TestApplyCanonicalUsageView_ProviderFallbackUsesProviderIDWhenUpstreamMissi
 func TestApplyCanonicalUsageView_IncludesErroredToolCallsAndMCPBreakdown(t *testing.T) {
 	dbPath, store := openUsageViewTestStore(t)
 
-	occurredAt := time.Now().UTC().Add(-2 * time.Minute)
+	// The daily series groups by date(occurred_at), so the two events must land
+	// on the same UTC day for usage_mcp_gopls to be a single point. Anchoring to
+	// the start of the current UTC day keeps them together; a now-relative
+	// offset put them on either side of midnight whenever the test ran in the
+	// first couple of minutes of a day.
+	now := time.Now().UTC()
+	occurredAt := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	if _, err := store.Ingest(context.Background(), IngestRequest{
 		SourceSystem:  SourceSystem("codex"),
 		SourceChannel: SourceChannelJSONL,
@@ -959,11 +965,17 @@ func TestApplyCanonicalUsageView_UsesClientFromPayloadBeforeWorkspace(t *testing
 func TestApplyCanonicalUsageView_EmitsProjectMetricsFromWorkspace(t *testing.T) {
 	dbPath, store := openUsageViewTestStore(t)
 
-	now := time.Now().UTC()
+	// Every event and the day key asserted below derive from this one instant,
+	// anchored to the start of the current UTC day (the read model buckets on
+	// date(occurred_at), which is UTC). With now-relative offsets a run within
+	// a couple of seconds of midnight scattered the events across two days and
+	// the per-day series lookup missed them.
+	nowUTC := time.Now().UTC()
+	dayStart := time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), 0, 0, 0, 0, time.UTC)
 	if _, err := store.Ingest(context.Background(), IngestRequest{
 		SourceSystem:  SourceSystem("codex"),
 		SourceChannel: SourceChannelJSONL,
-		OccurredAt:    now,
+		OccurredAt:    dayStart,
 		ProviderID:    "codex",
 		AccountID:     "codex-cli",
 		WorkspaceID:   "openusage",
@@ -987,7 +999,7 @@ func TestApplyCanonicalUsageView_EmitsProjectMetricsFromWorkspace(t *testing.T) 
 	if _, err := store.Ingest(context.Background(), IngestRequest{
 		SourceSystem:  SourceSystem("codex"),
 		SourceChannel: SourceChannelJSONL,
-		OccurredAt:    now.Add(1 * time.Second),
+		OccurredAt:    dayStart.Add(1 * time.Second),
 		ProviderID:    "codex",
 		AccountID:     "codex-cli",
 		WorkspaceID:   "garage-tracker",
@@ -1011,7 +1023,7 @@ func TestApplyCanonicalUsageView_EmitsProjectMetricsFromWorkspace(t *testing.T) 
 	if _, err := store.Ingest(context.Background(), IngestRequest{
 		SourceSystem:  SourceSystem("codex"),
 		SourceChannel: SourceChannelJSONL,
-		OccurredAt:    now.Add(2 * time.Second),
+		OccurredAt:    dayStart.Add(2 * time.Second),
 		ProviderID:    "codex",
 		AccountID:     "codex-cli",
 		AgentName:     "codex",
@@ -1055,7 +1067,7 @@ func TestApplyCanonicalUsageView_EmitsProjectMetricsFromWorkspace(t *testing.T) 
 		t.Fatalf("unexpected unknown project bucket emitted: %+v", snap.Metrics["project_unknown_requests"])
 	}
 
-	day := now.Format("2006-01-02")
+	day := dayStart.Format("2006-01-02")
 	if got := seriesValueByDate(snap.DailySeries["usage_project_openusage"], day); got != 1 {
 		t.Fatalf("usage_project_openusage[%s] = %v, want 1", day, got)
 	}


### PR DESCRIPTION
## Problem

Several tests derived a date/day label and their event timestamps from **different clock reads**. A run that straddles UTC midnight puts the fixture and the assertion on different days, and the test fails.

This is not hypothetical — it is currently breaking CI on unrelated PRs:

- **#285** and **#269** both failed `Test (windows-latest)` on `TestFetchExtractsToolLanguageAndCodeStats`, at **00:01:06** and **00:01:07 UTC**.
- #285 only touches `internal/core/model_identity.go`. It does not go near the codex provider.
- `main` passed the same test at 09:39–09:55 UTC, and it passes locally at 00:05 UTC.

Two contributors were staring at a red X that had nothing to do with their changes.

## Fixes

**`internal/providers/codex`** — the session fixture was written into *today's* day-directory but stamped up to 2 minutes in the past, so just after midnight those events landed on the previous day.

A fixed past date does **not** work here: `readSessionUsageBreakdowns` compares against `time.Now().UTC()` for `requests_today`, and the test asserts `requests_today == 2`. Anchoring to `now.Add(-10*time.Minute)` fails the same way — self-consistent, but on yesterday. The fixture is therefore anchored to the **start of the current UTC day**, so events are always on the provider's "today" and never in the future. This matches the idiom already used in `internal/providers/cursor/cursor_test.go`.

**`internal/telemetry`** — events ingested at `now`/`+1s`/`+2s` were asserted against a per-day series keyed off a separate `now`.

The production windowing was checked **first**: day buckets come from `date(occurred_at)` and "today" from `date('now')`, both UTC, so the frames already agree. Only the test was wrong. No production change.

**`internal/core/time_window`** — `LocalMidnight()` and `TimeWindow1d.Since()` read their own clock, which the tests compared against a separately captured `time.Now()`. Neither takes an injectable clock, so the calls are bracketed with before/after reads via a `sameCalendarDay` helper rather than pretending to control time.

**`internal/providers/{ollama,zai}`** — same class, latent rather than actively failing. `ollama` wrote lines dated today but timed ~24h in the future just after midnight; `zai` derived `today`/`yesterday` from two separate `time.Now()` calls, which collapse if midnight falls between them.

## Scope

Test-only. **No production behaviour changes.**

The rest of the repo was swept for the same class — daemon, tui, tmux, cmd, report, pricing, parsers, config, detect, and the remaining providers — and the sites there are single-anchor or duration-based, so they are safe.

## Verification

- `go test ./... -count=1` — green, zero failures
- `go test -race` on all touched packages — green
- Previously-failing tests re-run `-count=20` and `-count=10` — green
- `gofmt -l` and `go vet` — clean

## Docs

No docs update: this is a test-only change with no user-facing behaviour.

## Noted separately, not fixed here

`internal/providers/ollama/desktop_db.go` mixes time frames — today-counters use `date('now','localtime')` while the rolling windows use `datetime('now')` (UTC), against `created_at` values stored as local wall-clock. On a machine offset from UTC the 5h/24h counts skew by that offset. No test covers those metrics and CI runs UTC, so it is invisible in CI. Real production bug, out of scope for a test-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)