### PR TITLE
fix(config): recover a config left with stale trailing bytes

### DIFF
--- a/cmd/openusage/main.go
+++ b/cmd/openusage/main.go
@@ -19,18 +19,22 @@ func main() {
 		log.SetOutput(io.Discard)
 	}
 
-	cfg, err := config.Load()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
-		fmt.Fprintf(os.Stderr, "Config path: %s\n", config.ConfigPath())
-		os.Exit(1)
-	}
-
 	root := cobra.Command{
 		Use:     "openusage",
 		Short:   "OpenUsage is a terminal dashboard for monitoring AI coding tool usage and spend.",
 		Version: version.Version,
 		Run: func(_ *cobra.Command, _ []string) {
+			// Loaded here rather than in main so an unreadable config only fails
+			// the dashboard. Subcommands load their own config, and the ones that
+			// do not need it (version, help, daemon install/uninstall) keep
+			// working — including the ones you reach for to dig yourself out.
+			cfg, err := config.Load()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Config path: %s\n", config.ConfigPath())
+				fmt.Fprintf(os.Stderr, "Move that file aside to start from defaults.\n")
+				os.Exit(1)
+			}
 			runDashboard(cfg)
 		},
 	}

--- a/docs/site/docs/reference/paths.md
+++ b/docs/site/docs/reference/paths.md
@@ -12,6 +12,7 @@ OpenUsage follows the [XDG Base Directory Specification](https://specifications.
 | Path | Purpose | Override |
 |---|---|---|
 | `~/.config/openusage/settings.json` | Main config file. | — |
+| `~/.config/openusage/settings.json.corrupt` | Copy of a `settings.json` OpenUsage had to salvage, kept for inspection. Overwritten on each repair. See [common issues](../troubleshooting/common-issues.md). | — |
 | `~/.config/openusage/custom-pricing.json` | User pricing overrides. | `OPENUSAGE_CUSTOM_PRICING`, `XDG_CONFIG_HOME` |
 | `~/.config/openusage/themes/` | External themes directory (scanned for `*.json`). | `OPENUSAGE_THEME_DIR` (extra dirs only) |
 | `~/.config/openusage/hooks/` | Hook scripts installed by `openusage integrations`. | — |

--- a/docs/site/docs/troubleshooting/common-issues.md
+++ b/docs/site/docs/troubleshooting/common-issues.md
@@ -102,6 +102,41 @@ Checks:
 
 5. **Time window mismatch.** A `1d` window resets at local midnight. If you opened the dashboard at 23:59 and looked again at 00:01, the totals just rolled over. Cycle to `7d` or `30d` for context.
 
+## "Error loading config: parsing config ..."
+
+Symptoms: a command exits immediately with a parse error naming your
+`settings.json`, for example `invalid character 's' after top-level value`.
+
+The config file is not valid JSON. Only commands that read the config are
+affected — `openusage version`, `openusage --help`, and the daemon
+install/uninstall commands keep working, so you can still manage the daemon
+while the file is broken.
+
+One corruption shape heals itself: if the file holds a complete config object
+followed by leftover bytes (the signature of a write that did not truncate, so
+the tail of a longer previous version survives), OpenUsage recovers the config,
+rewrites the file cleanly, and keeps the original as
+`settings.json.corrupt` for inspection. You only see the parse error for damage
+that leaves no complete config to recover, such as a truncated file.
+
+To recover by hand, inspect the end of the file:
+
+```bash
+tail -20 ~/.config/openusage/settings.json
+python3 -m json.tool ~/.config/openusage/settings.json
+```
+
+If it cannot be salvaged, move it aside and OpenUsage starts from defaults and
+re-detects your tools:
+
+```bash
+mv ~/.config/openusage/settings.json ~/.config/openusage/settings.json.bad
+```
+
+Manually configured accounts and preferences (theme, widget layout) live in that
+file and have to be re-entered. Collected usage history does not — it lives in
+the telemetry database (see [paths](../reference/paths.md)).
+
 ## When to file an issue
 
 If none of the above helps, capture a debug log:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -265,22 +266,53 @@ func ConfigPath() string {
 }
 
 func Load() (Config, error) {
-	return LoadFrom(ConfigPath())
+	path := ConfigPath()
+
+	cfg, salvaged, err := loadFrom(path)
+	if err != nil || !salvaged {
+		return cfg, err
+	}
+
+	// Rewrite the salvaged config so the stale bytes are gone for good, keeping
+	// the corrupt original alongside it for inspection. Best effort: a repair we
+	// cannot write must not stop the caller from using what we just salvaged.
+	if err := repairCorruptFile(path, cfg); err != nil {
+		core.Tracef("config: repairing %s failed: %v", path, err)
+	}
+	return cfg, nil
 }
 
 func LoadFrom(path string) (Config, error) {
+	cfg, _, err := loadFrom(path)
+	return cfg, err
+}
+
+// loadFrom reads and normalizes the config at path. The salvaged return reports
+// that the file did not parse cleanly but a complete config was recovered from
+// it, so the caller may want to rewrite the file.
+func loadFrom(path string) (Config, bool, error) {
 	cfg := DefaultConfig()
 
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return cfg, nil
+			return cfg, false, nil
 		}
-		return cfg, fmt.Errorf("reading config: %w", err)
+		return cfg, false, fmt.Errorf("reading config: %w", err)
 	}
 
+	salvaged := false
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return DefaultConfig(), fmt.Errorf("parsing config %s: %w", path, err)
+		// A failed Unmarshal leaves cfg partially populated, so salvage into a
+		// fresh value rather than the half-written one.
+		cfg = DefaultConfig()
+		trailing, rerr := decodeLeadingValue(data, &cfg)
+		if rerr != nil {
+			return DefaultConfig(), false, fmt.Errorf("parsing config %s: %w", path, err)
+		}
+		core.Tracef("config: %s holds a complete config followed by %d stale bytes "+
+			"(left by a write that did not truncate); recovering it and discarding the tail", path, trailing)
+		salvaged = true
 	}
 
 	cfg.UI = normalizeUIConfig(cfg.UI)
@@ -297,7 +329,52 @@ func LoadFrom(path string) (Config, error) {
 	cfg.Dashboard.WidgetSections = normalizeDashboardWidgetSections(cfg.Dashboard.WidgetSections)
 	cfg.Dashboard.DetailSections = normalizeDetailWidgetSections(cfg.Dashboard.DetailSections)
 
-	return cfg, nil
+	return cfg, salvaged, nil
+}
+
+// decodeLeadingValue decodes the first complete JSON value in data into out and
+// returns the number of bytes left over after it.
+//
+// This is the recovery path for a config file whose writer did not truncate: a
+// shorter document written over a longer one from offset 0 leaves a valid config
+// object followed by the tail of the previous version, which json.Unmarshal
+// rejects wholesale ("invalid character 's' after top-level value"). Everything
+// the config owns is in that leading object, so it is fully recoverable. A file
+// that is truncated or structurally broken instead has no complete leading
+// value, and decoding it fails here as it should.
+func decodeLeadingValue(data []byte, out *Config) (int, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(out); err != nil {
+		return 0, err
+	}
+	return len(data) - int(dec.InputOffset()), nil
+}
+
+// corruptBackupSuffix names the copy repairCorruptFile keeps of a config file it
+// had to salvage.
+const corruptBackupSuffix = ".corrupt"
+
+// repairCorruptFile backs up the unparseable config at path and rewrites it from
+// the config salvaged out of it. The backup is overwritten on each repair: it is
+// a debugging aid for the corruption just seen, not a version history.
+func repairCorruptFile(path string, cfg Config) error {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading corrupt config: %w", err)
+	}
+	// Re-check under the lock: another writer may have replaced the file with a
+	// good one between the salvaging read and this repair, and overwriting that
+	// with our salvaged copy would throw away their write.
+	if json.Valid(data) {
+		return nil
+	}
+	if err := os.WriteFile(path+corruptBackupSuffix, data, 0o600); err != nil {
+		return fmt.Errorf("backing up corrupt config: %w", err)
+	}
+	return saveLocked(path, cfg)
 }
 
 func normalizeUIConfig(in UIConfig) UIConfig {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -127,6 +128,92 @@ func TestLoadFrom_InvalidJSON(t *testing.T) {
 	}
 	if cfg.Theme != "Gruvbox" {
 		t.Errorf("expected default theme on error, got %q", cfg.Theme)
+	}
+}
+
+// staleTailConfig is what a writer that does not truncate leaves behind: a
+// shorter document written over a longer one from offset 0, so a complete config
+// object is followed by the tail of the previous version.
+const staleTailConfig = `{
+  "theme": "Nord",
+  "tmux": {
+    "format": "{tool:icon}"
+  }
+}
+_cost:money}/today}",
+    "alerts": {}
+  }
+}
+`
+
+func TestLoadFrom_RecoversConfigFollowedByStaleBytes(t *testing.T) {
+	cfg, err := LoadFrom(writeSettingsJSON(t, staleTailConfig))
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v, want the leading config recovered", err)
+	}
+	if cfg.Theme != "Nord" {
+		t.Errorf("theme = %q, want Nord", cfg.Theme)
+	}
+	if cfg.Tmux.Format != "{tool:icon}" {
+		t.Errorf("tmux format = %q, want {tool:icon}", cfg.Tmux.Format)
+	}
+	if cfg.UI.RefreshIntervalSeconds != DefaultConfig().UI.RefreshIntervalSeconds {
+		t.Errorf("recovered config skipped normalization: refresh = %d", cfg.UI.RefreshIntervalSeconds)
+	}
+}
+
+func TestLoadFrom_TruncatedJSONStillFails(t *testing.T) {
+	// No complete leading value, so there is nothing to salvage.
+	cfg, err := LoadFrom(writeSettingsJSON(t, `{"theme":"Nord","ui":{`))
+	if err == nil {
+		t.Fatal("expected error for truncated JSON")
+	}
+	if cfg.Theme != DefaultConfig().Theme {
+		t.Errorf("expected default theme on error, got %q", cfg.Theme)
+	}
+}
+
+func TestLoad_RepairsConfigWithStaleBytesInPlace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("config dir is resolved from APPDATA on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".config", "openusage", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(staleTailConfig), 0o644); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Theme != "Nord" {
+		t.Errorf("theme = %q, want Nord", cfg.Theme)
+	}
+
+	// The file itself must now be clean, so the next reader needs no salvaging.
+	repaired, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read repaired config: %v", err)
+	}
+	var probe Config
+	if err := json.Unmarshal(repaired, &probe); err != nil {
+		t.Fatalf("repaired config does not parse: %v\n%s", err, repaired)
+	}
+	if probe.Theme != "Nord" {
+		t.Errorf("repaired theme = %q, want Nord", probe.Theme)
+	}
+
+	backup, err := os.ReadFile(path + corruptBackupSuffix)
+	if err != nil {
+		t.Fatalf("read corrupt backup: %v", err)
+	}
+	if string(backup) != staleTailConfig {
+		t.Errorf("backup does not hold the original bytes:\n%s", backup)
 	}
 }
 

--- a/internal/providers/opencode/provider_test.go
+++ b/internal/providers/opencode/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -11,6 +12,19 @@ import (
 	"github.com/janekbaraniewski/openusage/internal/config"
 	"github.com/janekbaraniewski/openusage/internal/core"
 )
+
+// TestMain neutralizes the browser-session lookup for the whole package. Left at
+// its default, Fetch reads the developer's real browser cookie store, and on
+// macOS that blocks in a Keychain prompt no test binary can answer — the test
+// hangs until the 10m timeout. It only passes in CI because there is no browser
+// profile there. Tests that exercise console enrichment override this seam with
+// a session of their own.
+func TestMain(m *testing.M) {
+	loadBrowserSession = func(context.Context, core.AccountConfig, browsercookies.Reader) (config.BrowserSession, bool, error) {
+		return config.BrowserSession{}, false, nil
+	}
+	os.Exit(m.Run())
+}
 
 func zenModelsBody() string {
 	return `{

--- a/internal/providers/perplexity/perplexity.go
+++ b/internal/providers/perplexity/perplexity.go
@@ -27,6 +27,11 @@ import (
 	"github.com/janekbaraniewski/openusage/internal/providers/shared"
 )
 
+// loadBrowserSession is a seam so tests can supply a session instead of reading
+// the developer's real browser cookie store, which on macOS blocks in a Keychain
+// prompt no test binary can answer.
+var loadBrowserSession = shared.LoadOrRefreshBrowserSession
+
 const (
 	consoleBaseURL = "https://console.perplexity.ai"
 
@@ -77,7 +82,7 @@ func New() *Provider {
 func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.UsageSnapshot, error) {
 	snap := core.NewUsageSnapshot(p.ID(), acct.ID)
 
-	session, ok, err := shared.LoadOrRefreshBrowserSession(ctx, acct, nil)
+	session, ok, err := loadBrowserSession(ctx, acct, nil)
 	if err != nil || !ok || session.Value == "" {
 		snap.Status = core.StatusAuth
 		snap.Message = "browser session not configured — Settings → 5 KEYS → perplexity → Enter"

--- a/internal/providers/perplexity/perplexity_test.go
+++ b/internal/providers/perplexity/perplexity_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/janekbaraniewski/openusage/internal/browsercookies"
 	"github.com/janekbaraniewski/openusage/internal/config"
 	"github.com/janekbaraniewski/openusage/internal/core"
 )
@@ -29,6 +30,18 @@ func isolateConfigDir(t *testing.T) {
 		t.Setenv("USERPROFILE", tmp)
 		t.Setenv("APPDATA", filepath.Join(tmp, "AppData", "Roaming"))
 		t.Setenv("LOCALAPPDATA", filepath.Join(tmp, "AppData", "Local"))
+	}
+}
+
+// stubNoBrowserSession makes the browser-session lookup report "none configured"
+// without touching the developer's real browsers or Keychain.
+func stubNoBrowserSession(t *testing.T) {
+	t.Helper()
+
+	orig := loadBrowserSession
+	t.Cleanup(func() { loadBrowserSession = orig })
+	loadBrowserSession = func(context.Context, core.AccountConfig, browsercookies.Reader) (config.BrowserSession, bool, error) {
+		return config.BrowserSession{}, false, nil
 	}
 }
 
@@ -128,6 +141,11 @@ func TestFetch_CookieConfigured_PopulatesAllFields(t *testing.T) {
 // No cookie → AUTH state with helpful message pointing at the connect flow.
 func TestFetch_NoCookie_AuthMessage(t *testing.T) {
 	isolateConfigDir(t)
+	// With no stored session, the real lookup falls through to scanning the
+	// developer's browsers, and decrypting a Chrome cookie for perplexity.ai
+	// blocks in a macOS Keychain prompt no test binary can answer. Stub the
+	// no-session answer this test is actually about.
+	stubNoBrowserSession(t)
 
 	snap, err := New().Fetch(context.Background(), core.AccountConfig{
 		ID:       "perplexity",


### PR DESCRIPTION
## Why

`openusage` refused to start:

```
Error loading config: parsing config ~/.config/openusage/settings.json: invalid character 's' after top-level value
```

The config file held a complete config object followed by 56 leftover bytes:

```
237	}                                    ← valid JSON ends here
238	st: {today_cost:money}/today}",      ← tail of an older, longer version
```

That is the signature of a write that did not truncate: shorter content written
over a longer file from offset 0, so the previous version's tail survives.
`json.Unmarshal` rejects the whole document, and every byte the config actually
owns is sitting right there in the leading object, fully readable.

Every current save path is atomic (tmp + rename, since f0ca25f), so the writer
was external or a pre-f0ca25f binary. This makes the corruption survivable
rather than chasing that writer.

## What changed

**Recovery.** `loadFrom` falls back to a `json.Decoder` that reads the first
complete value, logs how many bytes it discarded, and — in `Load` — rewrites the
file cleanly with the original preserved as `settings.json.corrupt`. Truncated or
structurally broken files still fail loudly, since they leave no complete value
to salvage. The repair re-reads under `saveMu` and skips if the file is valid
again, so it cannot clobber a good config another process wrote in between.

**Blast radius.** `main()` loaded the config before cobra parsed args and exited
on failure, so one bad byte took down *every* subcommand — including `version`,
`--help`, and `telemetry daemon install/uninstall`, none of which use that
config and all of which you reach for to dig yourself out. The load moved into
the root command's `Run`, where the dashboard needs it; every other subcommand
already loads its own.

## An unrelated bug this surfaced

Verifying the fix, `go test -race ./...` turned out to be **timing out at 600s**
in `internal/providers/opencode`, on `main`, independent of this change:

```
panic: test timed out after 10m0s
	running tests:
		TestFetch_Success_AuthOKExposesModels (10m0s)

goroutine 58 [syscall]:
github.com/keybase/go-keychain._Cfunc_SecItemCopyMatching(...)
	.../kooky/internal/chrome.(*CookieStore).getKeyringPassword(...)
	.../openusage/internal/providers/opencode.(*Provider).enrichFromConsole(...)
```

The test stands up an `httptest` server, then `Fetch` reaches straight past it
into the developer's **real Chrome cookie store** and blocks in a macOS Keychain
prompt no test binary can answer. The package already had a `loadBrowserSession`
seam — one later test in the same file stubs it — but the four `Fetch` tests did
not. It passes in CI only because CI has no browser profile and no Keychain, so
this has been hanging local runs invisibly while CI stayed green.

- `opencode`: `TestMain` neutralizes the seam package-wide, so no future test in
  the package can reach the real Keychain either. 600s → 1.5s.
- `perplexity`: same hole, one cookie away from biting. `Fetch` called
  `shared.LoadOrRefreshBrowserSession` directly with no seam, and
  `TestFetch_NoCookie_AuthMessage` deliberately runs with no stored session, so
  it falls through to scanning real browsers — green today only because there is
  no `perplexity.ai` cookie in Chrome to decrypt. Added the seam (matching the
  `opencode` pattern) and stubbed it in that one test; the two tests covering the
  real stored-session path still exercise it.

## Tests

Three new tests in `internal/config`:

- `TestLoadFrom_RecoversConfigFollowedByStaleBytes` — the corruption above is
  recovered, values preserved, normalization still applied
- `TestLoadFrom_TruncatedJSONStillFails` — no complete leading value, still an error
- `TestLoad_RepairsConfigWithStaleBytesInPlace` — the file on disk ends up clean
  and the `.corrupt` backup holds the original bytes

Verified end to end against a planted corrupt config: `telemetry daemon
uninstall` succeeds where it previously died, and the first config-reading
command silently repairs the file.

`go test -race ./...`: 55 packages ok, no failures, no data races.
`gofmt`, `go vet`, `golangci-lint` (0 issues) clean.

## Docs

- `troubleshooting/common-issues.md` — new section on the parse error: which
  commands keep working, which corruption heals itself, how to recover by hand,
  and what is lost if you move the file aside (config yes, usage history no)
- `reference/paths.md` — documents `settings.json.corrupt`

`DOCS_PREVIEW=1 npm run build` → `[SUCCESS]`, no broken-link warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJrjw1zLbDSNpxxpbaxCu6