### PR TITLE
feat(providers): add Makora billing/usage provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ If the question is whether this is the right fit versus a simpler local limits t
 ## Features
 
 - **Cross-provider tracking** — compare coding agents, API platforms, and local runtimes in one local dashboard
-- **35 providers** — coding agents and CLIs (Claude Code, Codex, Cursor, Copilot, Gemini CLI, OpenCode, Amp, Goose, Roo Code, Kilo Code, Kiro, Zed, and more), API platforms (OpenAI, Anthropic, OpenRouter, Groq, Mistral, DeepSeek, Moonshot, Perplexity, xAI, Z.AI, and more), and local runtimes (Ollama)
+- **36 providers** — coding agents and CLIs (Claude Code, Codex, Cursor, Copilot, Gemini CLI, OpenCode, Amp, Goose, Roo Code, Kilo Code, Kiro, Zed, and more), API platforms (OpenAI, Anthropic, OpenRouter, Groq, Mistral, DeepSeek, Moonshot, Perplexity, xAI, Z.AI, and more), and local runtimes (Ollama)
 - **Zero config** — auto-detects your AI tools and API keys, just run it
 - **Live dashboard** — see spend, quotas, rate limits, tokens, burn rate, and per-model usage at a glance
 - **tmux integration** — show the active tool's usage in your tmux status bar, with provider icons, presets, and active-tool detection
@@ -173,7 +173,7 @@ If the question is whether this is the right fit versus a simpler local limits t
 
 ## Supported providers
 
-35 provider integrations covering coding agents, CLIs, IDE tools, API platforms, and local runtimes. See [docs/providers.md](docs/providers.md) for all providers with detailed descriptions and screenshots.
+36 provider integrations covering coding agents, CLIs, IDE tools, API platforms, and local runtimes. See [docs/providers.md](docs/providers.md) for all providers with detailed descriptions and screenshots.
 
 ### Claude Code
 
@@ -215,6 +215,7 @@ Tracks credits, activity, generation stats, and per-model breakdown across multi
 | **OpenRouter** | `OPENROUTER_API_KEY` | Credits, activity, per-model breakdown |
 | **Groq** | `GROQ_API_KEY` | Rate limits, daily usage windows |
 | **Mistral AI** | `MISTRAL_API_KEY` | Subscription, usage endpoints |
+| **Makora** | `MAKORA_SESSION_TOKEN` / `MAKORA_EMAIL` + `MAKORA_PASSWORD` / token cache | Credits balance, monthly spend limit, per-model cost & tokens, daily spend series |
 | **DeepSeek** | `DEEPSEEK_API_KEY` | Rate limits, account balance |
 | **Moonshot (Kimi)** | `MOONSHOT_API_KEY` | Balance breakdown (cash + voucher), org limits, tier; supports api.moonshot.ai (default) and api.moonshot.cn |
 | **Perplexity** | Browser session at console.perplexity.ai | Tier, balance, lifetime spend, auto-reload, 30d usage analytics |

--- a/docs/site/docs/providers/makora.md
+++ b/docs/site/docs/providers/makora.md
@@ -1,0 +1,132 @@
+---
+title: Makora
+description: Track Makora credits balance, monthly spend, and per-model usage in OpenUsage.
+sidebar_label: Makora
+keywords: [makora usage tracker, makora billing, makora cost tracking, makora credits, track makora spend locally]
+---
+
+# Makora
+
+Full billing and usage visibility for [Makora](https://app.makora.com) inference. Shows the live credits balance, the monthly spend limit, and per-model token/cost breakdowns with a daily spend series.
+
+## At a glance
+
+- **Provider ID** — `makora`
+- **Detection** — `MAKORA_SESSION_TOKEN`, `~/.config/makora-usage/state.json`, `MAKORA_EMAIL` + `MAKORA_PASSWORD`, or the `makora-usage` binary on `$PATH`
+- **Auth** — Dashboard session JWT (see below)
+- **Type** — API platform (full billing data)
+- **Tracks**:
+  - Live credits balance
+  - Monthly spend limit (reference for the balance gauge)
+  - Month-to-date spend (last 30 days, computed from usage + rate card)
+  - Per-model tokens / cached tokens / requests / cost
+  - Daily cost + token series (analytics + daily views)
+
+## Setup
+
+### Auto-detection
+
+OpenUsage detects a Makora account when any credential signal is present:
+
+| Signal | What it provides |
+|---|---|
+| `MAKORA_SESSION_TOKEN` env var | A dashboard session JWT (pasted manually) |
+| `~/.config/makora-usage/state.json` | Shared token cache (read-only) — reused from the makora-usage helper |
+| `MAKORA_EMAIL` + `MAKORA_PASSWORD` env vars | Password login path |
+| `makora-usage` binary on `$PATH` | Presence signal (account registered) |
+
+### Manual configuration
+
+```json
+{
+  "accounts": [
+    {
+      "id": "makora",
+      "provider": "makora"
+    }
+  ]
+}
+```
+
+## Auth model — the important gotcha
+
+Makora's **main API key** (`MAKORA_API_KEY`) is Inference+Optimize scoped and returns `HTTP 403` on all credits/usage endpoints. The billing endpoints require a **dashboard session JWT** (24&nbsp;h, HS256, `aud: "a2labs:auth"`).
+
+The provider resolves the JWT in precedence order:
+
+1. `MAKORA_SESSION_TOKEN` env var — a manually pasted JWT.
+2. `~/.config/makora-usage/state.json` token cache — read-only; the shared sibling cache written by the makora-usage helper.
+3. `MAKORA_EMAIL` + `MAKORA_PASSWORD` env vars — password login to `POST https://be.prod.makora.com/api/v1/login/access-token`.
+
+On an `HTTP 401` during a fetch, the provider re-authenticates **once** (preferring the refresh token, falling back to password login) and retries. The token file is read-only unless this flow itself performs the login, in which case it may rewrite `state.json` with `0600` permissions.
+
+## Data sources & how each metric is computed
+
+Each poll makes up to four calls. Data endpoints sit under `https://app.makora.com` with `Authorization: Bearer <jwt>`.
+
+| Call | Endpoint | What it provides |
+|---|---|---|
+| 1 | `GET /api/v1/credits/status` | Live balance, currency, payment method |
+| 2 | `GET /api/v1/credits/user` | Monthly spend limit + auto-recharge config |
+| 3 | `GET /api/v1/credits/default-rates` | **Public** per-1M-token price card (no auth) |
+| 4 | `GET /api/v1/usage/my-usage/between/{start}/{end}?paygo=true` | Per-model daily usage for the last 30 days |
+
+### `credit_balance`
+
+- Source: `balance` field of `GET /api/v1/credits/status`; `currency` is `"Credits"`.
+- Transform: stored as `Remaining`. When the monthly spend limit is present it is wired in as the gauge `Limit`, so the tile shows remaining credits against the monthly budget.
+
+### `spend_limit` / `monthly_spend`
+
+- `spend_limit` — the monthly cap from `GET /api/v1/credits/user` (`monthly_prepaid_notification.amount`, e.g. 400).
+- `monthly_spend` — total cost across the last 30 days of usage, computed with the rate card. Used = spent, so the gauge renders spend vs. limit.
+
+### Per-model cost — cached tokens are a SUBSET of input tokens
+
+The rate card is public and used for cost computation instead of hardcoding:
+
+```text
+cost = (input − cached) × prompt + completion × completion + cached × cache_read
+```
+
+where each rate is USD per 1M tokens. **`cached_tokens` is a subset of `input_tokens`** — non-cached input is `input − cached`. The provider never adds `cached` on top of `input` (that would double-count). Verified: token-cost with the rate card reconciles to the Makora billing ledger within ~4%.
+
+### Per-model table & daily series
+
+- `ModelUsage` rows: input / output / cached / total tokens, requests, and cost per model.
+- `DailySeries["cost"]` and `DailySeries["tokens"]`: per-day points powering the analytics and daily views.
+- Today aggregates (`today_input_tokens`, `today_output_tokens`, `today_cached_tokens`, `today_tokens`, `today_requests`) derive from the most recent day in the window.
+
+### Auth status
+
+- Missing credential → snapshot `auth` with a clear setup message.
+- `HTTP 401`/`403` that persists after the one-shot re-auth → `auth`.
+- `balance ≤ 0` → `limited` ("balance exhausted"), otherwise `ok`.
+
+## What's NOT tracked
+
+- **Exact ledger spend.** Month-to-date spend is computed from usage × rate card, which reconciles within ~4% of the billing ledger but may not match the ledger to the cent.
+- **Notification preferences.** The spend-warning threshold (`spending_warning_notification.amount`) is not surfaced as a meter — only the monthly cap is used as the gauge reference.
+
+## API endpoints used
+
+- `GET https://app.makora.com/api/v1/credits/status`
+- `GET https://app.makora.com/api/v1/credits/user`
+- `GET https://app.makora.com/api/v1/credits/default-rates`
+- `GET https://app.makora.com/api/v1/usage/my-usage/between/{start}/{end}?paygo=true`
+- `POST https://be.prod.makora.com/api/v1/login/access-token?device_name=openusage`
+- `POST https://be.prod.makora.com/api/v1/login/refresh` (refresh token)
+
+## Caveats
+
+:::warning
+Set `MAKORA_SESSION_TOKEN` (or `MAKORA_EMAIL` + `MAKORA_PASSWORD`), **not** `MAKORA_API_KEY`. The API key returns `HTTP 403` on the billing endpoints.
+:::
+
+- The session JWT expires after ~24&nbsp;h; the provider refreshes automatically when a refresh token or login credentials are available.
+- Balance is in `Credits`; per-model cost is reported in USD (from the rate card).
+
+## Troubleshooting
+
+- **`Authentication failed`** — no usable credential path; set `MAKORA_SESSION_TOKEN`, add email+password, or make sure `~/.config/makora-usage/state.json` exists with a valid token.
+- **Wrong error on data endpoints** — confirm you're not using `MAKORA_API_KEY` for the billing endpoints.

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -77,6 +77,7 @@ const sidebars: SidebarsConfig = {
             'providers/openrouter',
             'providers/groq',
             'providers/mistral',
+            'providers/makora',
             'providers/deepseek',
             'providers/moonshot',
             'providers/perplexity',

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -64,6 +64,7 @@ func AutoDetect() Result {
 	detectOpenClaw(&result)
 	detectPi(&result)
 	detectQwenCLI(&result)
+	detectMakora(&result)
 
 	// Phase 2: process env vars. Most authoritative; runs before any
 	// file-based credential adoption so a freshly-set env var always

--- a/internal/detect/makora.go
+++ b/internal/detect/makora.go
@@ -1,0 +1,68 @@
+package detect
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// makoraStatePath returns the shared makora-usage token cache path.
+func makoraStatePath() string {
+	home := homeDir()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "makora-usage", "state.json")
+}
+
+// detectMakora registers a Makora account when a session credential is
+// present via any of its supported signals:
+//   - MAKORA_SESSION_TOKEN env var (dashboard session JWT)
+//   - the makora-usage token cache (~/.config/makora-usage/state.json)
+//   - MAKORA_EMAIL + MAKORA_PASSWORD env vars (password login)
+//   - the `makora-usage` helper binary on PATH
+//
+// The provider resolves the actual token at fetch time; detection only
+// records that a credential path exists. The account id is "makora".
+func detectMakora(result *Result) {
+	bin := findBinary("makora-usage")
+	state := makoraStatePath()
+	hasState := state != "" && fileExists(state)
+	hasSessionToken := os.Getenv("MAKORA_SESSION_TOKEN") != ""
+	hasLogin := os.Getenv("MAKORA_EMAIL") != "" && os.Getenv("MAKORA_PASSWORD") != ""
+
+	if !hasSessionToken && !hasState && !hasLogin && bin == "" {
+		return
+	}
+
+	if bin != "" {
+		log.Printf("[detect] Found makora-usage at %s", bin)
+		result.Tools = append(result.Tools, DetectedTool{
+			Name:       "makora-usage",
+			BinaryPath: bin,
+			ConfigDir:  filepath.Dir(state),
+			Type:       "cli",
+		})
+	}
+
+	acct := core.AccountConfig{
+		ID:       "makora",
+		Provider: "makora",
+		Auth:     "token",
+	}
+	if hasState {
+		acct.SetPath("state_file", state)
+		acct.SetHint("state_file", state)
+		log.Printf("[detect] Makora token cache at %s", state)
+	}
+	if hasSessionToken {
+		acct.SetHint("auth_source", "env_session")
+	}
+	if hasLogin {
+		acct.SetHint("auth_source", "password")
+	}
+
+	addAccount(result, acct)
+}

--- a/internal/detect/makora_test.go
+++ b/internal/detect/makora_test.go
@@ -1,0 +1,130 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+func TestDetectMakora_None(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", t.TempDir())
+	t.Setenv("MAKORA_SESSION_TOKEN", "")
+	t.Setenv("MAKORA_EMAIL", "")
+	t.Setenv("MAKORA_PASSWORD", "")
+
+	var result Result
+	detectMakora(&result)
+
+	for _, a := range result.Accounts {
+		if a.ID == "makora" {
+			t.Errorf("expected no makora account; got %+v", a)
+		}
+	}
+}
+
+func TestDetectMakora_FromSessionTokenEnv(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", t.TempDir())
+	t.Setenv("MAKORA_SESSION_TOKEN", "jwt-abc")
+	t.Setenv("MAKORA_EMAIL", "")
+	t.Setenv("MAKORA_PASSWORD", "")
+
+	var result Result
+	detectMakora(&result)
+
+	acct := findMakoraAccount(t, result)
+	if v := acct.Hint("auth_source", ""); v != "env_session" {
+		t.Errorf("auth_source = %q, want env_session", v)
+	}
+}
+
+func TestDetectMakora_FromStateFile(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", t.TempDir())
+	t.Setenv("MAKORA_SESSION_TOKEN", "")
+	t.Setenv("MAKORA_EMAIL", "")
+	t.Setenv("MAKORA_PASSWORD", "")
+
+	dir := filepath.Join(home, ".config", "makora-usage")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	state := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(state, []byte(`{"access_token":"x","refresh_token":"y"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var result Result
+	detectMakora(&result)
+
+	acct := findMakoraAccount(t, result)
+	if got := acct.Path("state_file", ""); got != state {
+		t.Errorf("state_file = %q, want %q", got, state)
+	}
+}
+
+func TestDetectMakora_FromPasswordEnv(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", t.TempDir())
+	t.Setenv("MAKORA_SESSION_TOKEN", "")
+	t.Setenv("MAKORA_EMAIL", "user@example.com")
+	t.Setenv("MAKORA_PASSWORD", "sekret")
+
+	var result Result
+	detectMakora(&result)
+
+	acct := findMakoraAccount(t, result)
+	if v := acct.Hint("auth_source", ""); v != "password" {
+		t.Errorf("auth_source = %q, want password", v)
+	}
+}
+
+func TestDetectMakora_FromBinary(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	t.Setenv("MAKORA_SESSION_TOKEN", "")
+	t.Setenv("MAKORA_EMAIL", "")
+	t.Setenv("MAKORA_PASSWORD", "")
+
+	binDir := t.TempDir()
+	writeFakeBinary(t, binDir, "makora-usage")
+	t.Setenv("PATH", binDir)
+	t.Setenv("OPENUSAGE_DETECT_BIN_DIRS", binDir)
+
+	var result Result
+	detectMakora(&result)
+
+	findMakoraAccount(t, result)
+
+	var toolFound bool
+	for _, tool := range result.Tools {
+		if tool.Name == "makora-usage" {
+			toolFound = true
+		}
+	}
+	if !toolFound {
+		t.Errorf("expected makora-usage tool entry; tools=%+v", result.Tools)
+	}
+}
+
+func findMakoraAccount(t *testing.T, result Result) core.AccountConfig {
+	t.Helper()
+	for _, a := range result.Accounts {
+		if a.ID == "makora" && a.Provider == "makora" {
+			return a
+		}
+	}
+	t.Fatalf("expected makora account; accounts=%+v", result.Accounts)
+	return core.AccountConfig{}
+}

--- a/internal/providers/makora/fetch.go
+++ b/internal/providers/makora/fetch.go
@@ -1,0 +1,423 @@
+package makora
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/janekbaraniewski/openusage/internal/providers/shared"
+)
+
+// errAuthFailed signals that authentication genuinely failed after any
+// available retry path (401/403 with no working refresh or one that also
+// failed). Callers promote the snapshot to StatusAuth.
+var errAuthFailed = errors.New("authentication failed")
+
+// session holds the bearer access token plus an optional refresh token.
+// The refresh token is only populated when a password login or the shared
+// token cache supplied one.
+type session struct {
+	accessToken  string
+	refreshToken string
+}
+
+func (p *Provider) Fetch(ctx context.Context, acct core.AccountConfig) (core.UsageSnapshot, error) {
+	baseURL := shared.ResolveBaseURL(acct, defaultBaseURL)
+	snap := core.NewUsageSnapshot(p.ID(), acct.ID)
+
+	st, err := p.resolveSession(ctx, acct, &snap)
+	if err != nil {
+		return snap, err
+	}
+	if st.accessToken == "" {
+		// resolveSession already set a StatusAuth snapshot.
+		return snap, nil
+	}
+
+	if err := p.fetchStatus(ctx, baseURL, st, acct, &snap); err != nil {
+		if errors.Is(err, errAuthFailed) {
+			snap.Status = core.StatusAuth
+			snap.Message = "Makora authentication failed (check MAKORA_SESSION_TOKEN, MAKORA_EMAIL+MAKORA_PASSWORD, or the ~/.config/makora-usage/state.json cache)"
+			return snap, nil
+		}
+		snap.Raw["balance_error"] = err.Error()
+	}
+
+	if err := p.fetchUser(ctx, baseURL, st, acct, &snap); err != nil {
+		snap.Raw["user_error"] = err.Error()
+	}
+
+	rc, err := p.fetchRates(ctx, baseURL, &snap)
+	if err != nil {
+		snap.Raw["rates_error"] = err.Error()
+	}
+
+	// Month-to-date usage window: the last 30 days, inclusive of today.
+	end := time.Now().UTC().Format(time.RFC3339)
+	start := time.Now().AddDate(0, 0, -30).UTC().Format(time.RFC3339)
+	if err := p.fetchUsage(ctx, baseURL, st, acct, start, end, rc, &snap); err != nil {
+		snap.Raw["usage_error"] = err.Error()
+	}
+
+	finalizeStatus(&snap)
+	return snap, nil
+}
+
+// resolveSession establishes the bearer token in precedence order:
+//  1. MAKORA_SESSION_TOKEN env var
+//  2. ~/.config/makora-usage/state.json token cache (read-only)
+//  3. MAKORA_EMAIL + MAKORA_PASSWORD env vars → password login
+//
+// On a successful password login the cache file is written (0600), since this
+// flow itself performed the login. If no credential is available it returns an
+// empty session after setting a StatusAuth snapshot.
+func (p *Provider) resolveSession(ctx context.Context, acct core.AccountConfig, snap *core.UsageSnapshot) (*session, error) {
+	if tok := os.Getenv("MAKORA_SESSION_TOKEN"); tok != "" {
+		snap.SetAttribute("auth_type", "env_session")
+		return &session{accessToken: tok}, nil
+	}
+
+	if st, ok := p.loadStateFile(acct); ok {
+		snap.SetAttribute("auth_type", "token_cache")
+		return st, nil
+	}
+
+	email := os.Getenv("MAKORA_EMAIL")
+	password := os.Getenv("MAKORA_PASSWORD")
+	if email != "" && password != "" {
+		st, err := p.passwordLogin(ctx, acct, email, password)
+		if err != nil {
+			snap.SetAttribute("auth_type", "password")
+			snap.Status = core.StatusAuth
+			snap.Message = fmt.Sprintf("Makora password login failed: %v", err)
+			return &session{}, nil
+		}
+		snap.SetAttribute("auth_type", "password")
+		p.writeStateFile(acct, *st)
+		return st, nil
+	}
+
+	snap.Status = core.StatusAuth
+	snap.Message = "no Makora session token (set MAKORA_SESSION_TOKEN, MAKORA_EMAIL+MAKORA_PASSWORD, or a ~/.config/makora-usage/state.json cache)"
+	return &session{}, nil
+}
+
+func (p *Provider) fetchStatus(ctx context.Context, baseURL string, st *session, acct core.AccountConfig, snap *core.UsageSnapshot) error {
+	body, err := p.authedGET(ctx, baseURL+statusPath, st, acct)
+	if err != nil {
+		return err
+	}
+	resp, err := parseCreditsStatus(body)
+	if err != nil {
+		return err
+	}
+	currency := resp.Currency
+	if currency == "" {
+		currency = "Credits"
+	}
+	snap.SetAttribute("currency", currency)
+	if resp.HasPaymentMethod {
+		snap.SetAttribute("has_payment_method", "true")
+	}
+	snap.Metrics["credit_balance"] = core.Metric{
+		Remaining: core.Float64Ptr(resp.Balance),
+		Unit:      currency,
+		Window:    "current",
+	}
+	return nil
+}
+
+func (p *Provider) fetchUser(ctx context.Context, baseURL string, st *session, acct core.AccountConfig, snap *core.UsageSnapshot) error {
+	body, err := p.authedGET(ctx, baseURL+userPath, st, acct)
+	if err != nil {
+		if errors.Is(err, errAuthFailed) {
+			return err
+		}
+		return err
+	}
+	resp, err := parseUserCredits(body)
+	if err != nil {
+		return err
+	}
+	if resp.PayAsYouGoEnabled {
+		snap.SetAttribute("pay_as_you_go_enabled", "true")
+	}
+	if resp.MonthlyPrepaid.Amount > 0 {
+		limit := resp.MonthlyPrepaid.Amount
+		snap.Metrics["spend_limit"] = core.Metric{
+			Limit:  core.Float64Ptr(limit),
+			Unit:   "Credits",
+			Window: "month",
+		}
+		snap.SetAttribute("spend_limit", fmt.Sprintf("%.0f", limit))
+	}
+	return nil
+}
+
+// fetchRates loads the public per-1M-token price card. It requires NO auth —
+// a plain GET — and is cached in memory for the run via the returned card.
+// On failure an empty card is returned so usage parsing still produces rows
+// (with conservative zero cost) rather than aborting the whole fetch.
+func (p *Provider) fetchRates(ctx context.Context, baseURL string, snap *core.UsageSnapshot) (rateCard, error) {
+	rc := rateCard{prices: make(map[string]pricing)}
+	status, body, err := p.doGET(ctx, baseURL+ratesPath, "")
+	if err != nil {
+		return rc, err
+	}
+	if status != http.StatusOK {
+		return rc, fmt.Errorf("rate card HTTP %d", status)
+	}
+	parsed, err := parseRateCard(body)
+	if err != nil {
+		return rc, err
+	}
+	if !parsed.UpdatedAt.IsZero() {
+		snap.SetAttribute("rate_card_updated_at", parsed.UpdatedAt.Format(time.RFC3339))
+	}
+	snap.SetAttribute("models_priced", fmt.Sprintf("%d", len(parsed.prices)))
+	return parsed, nil
+}
+
+func (p *Provider) fetchUsage(ctx context.Context, baseURL string, st *session, acct core.AccountConfig, start, end string, rc rateCard, snap *core.UsageSnapshot) error {
+	body, err := p.authedGET(ctx, baseURL+usagePrefix+start+"/"+end+"?paygo=true", st, acct)
+	if err != nil {
+		return err
+	}
+	snap.SetAttribute("usage_range", start[:10]+" → "+end[:10])
+	return parseUsage(snap, body, "", rc)
+}
+
+// authedGET performs an authenticated GET with a one-shot 401/403 → re-auth
+// retry. If re-auth succeeds the request is retried once; if auth still fails
+// it returns errAuthFailed so callers can surface StatusAuth.
+func (p *Provider) authedGET(ctx context.Context, url string, st *session, acct core.AccountConfig) ([]byte, error) {
+	for attempt := 0; attempt < 2; attempt++ {
+		status, body, err := p.doGET(ctx, url, st.accessToken)
+		if err != nil {
+			return nil, err
+		}
+		if status == http.StatusOK {
+			return body, nil
+		}
+		if (status == http.StatusUnauthorized || status == http.StatusForbidden) && attempt == 0 {
+			if p.reAuth(ctx, st, acct) {
+				continue
+			}
+		}
+		if status == http.StatusUnauthorized || status == http.StatusForbidden {
+			return nil, errAuthFailed
+		}
+		return nil, fmt.Errorf("HTTP %d", status)
+	}
+	return nil, errAuthFailed
+}
+
+// reAuth refreshes the session: prefer the refresh token, else fall back to a
+// password login. On success it updates st in place and refreshes the shared
+// token cache (this flow performed the login). Returns false when no
+// credential path is available or every path fails.
+func (p *Provider) reAuth(ctx context.Context, st *session, acct core.AccountConfig) bool {
+	if st.refreshToken != "" {
+		next, err := p.refreshLogin(ctx, acct, st.refreshToken)
+		if err == nil && next.accessToken != "" {
+			*st = *next
+			p.writeStateFile(acct, *st)
+			return true
+		}
+		return false
+	}
+	email := os.Getenv("MAKORA_EMAIL")
+	password := os.Getenv("MAKORA_PASSWORD")
+	if email != "" && password != "" {
+		next, err := p.passwordLogin(ctx, acct, email, password)
+		if err == nil && next.accessToken != "" {
+			*st = *next
+			p.writeStateFile(acct, *st)
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Provider) passwordLogin(ctx context.Context, acct core.AccountConfig, email, password string) (*session, error) {
+	form := url.Values{}
+	form.Set("username", email)
+	form.Set("password", password)
+	var resp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := p.postForm(ctx, loginBaseURL(acct)+loginPath+"?device_name="+url.QueryEscape(deviceName), form, &resp); err != nil {
+		return nil, err
+	}
+	if resp.AccessToken == "" {
+		return nil, fmt.Errorf("login response missing access_token")
+	}
+	return &session{accessToken: resp.AccessToken, refreshToken: resp.RefreshToken}, nil
+}
+
+func (p *Provider) refreshLogin(ctx context.Context, acct core.AccountConfig, refreshToken string) (*session, error) {
+	form := url.Values{}
+	form.Set("refresh_token", refreshToken)
+	var resp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := p.postForm(ctx, loginBaseURL(acct)+refreshPath+"?device_name="+url.QueryEscape(deviceName), form, &resp); err != nil {
+		return nil, err
+	}
+	if resp.AccessToken == "" {
+		return nil, fmt.Errorf("refresh response missing access_token")
+	}
+	return &session{accessToken: resp.AccessToken, refreshToken: resp.RefreshToken}, nil
+}
+
+func (p *Provider) postForm(ctx context.Context, url string, form url.Values, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := p.Client().Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("auth HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if out != nil && len(body) > 0 {
+		if err := json.Unmarshal(body, out); err != nil {
+			return fmt.Errorf("parsing auth response: %w", err)
+		}
+	}
+	return nil
+}
+
+func (p *Provider) doGET(ctx context.Context, url, token string) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, nil, fmt.Errorf("creating request: %w", err)
+	}
+	if token != "" {
+		// The Authorization header is never logged; the token stays in-memory.
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := p.Client().Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("reading body: %w", err)
+	}
+	return resp.StatusCode, body, nil
+}
+
+// --- token cache (shared, read-only except when this flow logs in) ---
+
+// loginBaseURL resolves the auth (login/refresh) host. Defaults to the
+// dedicated be.prod.makora.com backend, but tests and self-hosted setups can
+// override it via the account's "login_base_url" hint/path.
+func loginBaseURL(acct core.AccountConfig) string {
+	if v := acct.Path("login_base_url", ""); v != "" {
+		return v
+	}
+	return baseLoginURL
+}
+
+func statePath(acct core.AccountConfig) string {
+	if p := acct.Path("state_file", ""); p != "" {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "makora-usage", "state.json")
+}
+
+func (p *Provider) loadStateFile(acct core.AccountConfig) (*session, bool) {
+	path := statePath(acct)
+	if path == "" {
+		return nil, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	var s struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, false
+	}
+	if s.AccessToken == "" {
+		return nil, false
+	}
+	return &session{accessToken: s.AccessToken, refreshToken: s.RefreshToken}, true
+}
+
+func (p *Provider) writeStateFile(acct core.AccountConfig, st session) {
+	path := statePath(acct)
+	if path == "" {
+		return
+	}
+	payload := map[string]any{
+		"access_token":  st.accessToken,
+		"refresh_token": st.refreshToken,
+		"exp":           time.Now().Add(24 * time.Hour).Unix(),
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o600)
+}
+
+// finalizeStatus combines the spend-limit reference into the balance gauge
+// and derives the final snapshot Status/Message. Existing terminal statuses
+// (auth, limited, error) are preserved.
+func finalizeStatus(snap *core.UsageSnapshot) {
+	bal, balOK := snap.Metrics["credit_balance"]
+	if lim, ok := snap.Metrics["spend_limit"]; ok && lim.Limit != nil && balOK && bal.Remaining != nil {
+		bal.Limit = lim.Limit
+		snap.Metrics["credit_balance"] = bal
+	}
+
+	if snap.Status != "" && snap.Status != core.StatusOK {
+		return
+	}
+
+	currency := snap.Attributes["currency"]
+	if currency == "" {
+		currency = "Credits"
+	}
+	if balOK && bal.Remaining != nil {
+		if *bal.Remaining <= 0 {
+			snap.Status = core.StatusLimited
+			snap.Message = "balance exhausted"
+			return
+		}
+		snap.Status = core.StatusOK
+		snap.Message = fmt.Sprintf("Balance: %.2f %s", *bal.Remaining, currency)
+		return
+	}
+	snap.Status = core.StatusOK
+	snap.Message = "OK"
+}

--- a/internal/providers/makora/parse.go
+++ b/internal/providers/makora/parse.go
@@ -1,0 +1,312 @@
+package makora
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// creditsStatusResponse mirrors GET /api/v1/credits/status.
+type creditsStatusResponse struct {
+	Balance          float64 `json:"balance"`
+	Currency         string  `json:"currency"`
+	HasPaymentMethod bool    `json:"has_payment_method"`
+}
+
+// userCreditsResponse mirrors GET /api/v1/credits/user. The monthly budget is
+// reported as the amount on the monthly prepaid notification; the spend
+// warning threshold is separate.
+type userCreditsResponse struct {
+	PayAsYouGoEnabled bool `json:"pay_as_you_go_enabled"`
+	SpendingWarning   struct {
+		Enabled bool    `json:"is_enabled"`
+		Amount  float64 `json:"amount"`
+	} `json:"spending_warning_notification"`
+	MonthlyPrepaid struct {
+		Enabled bool    `json:"is_enabled"`
+		Amount  float64 `json:"amount"`
+	} `json:"monthly_prepaid_notification"`
+}
+
+// rateCardResponse mirrors the public GET /api/v1/credits/default-rates.
+// Pricing strings are USD per 1M tokens.
+type rateCardResponse struct {
+	UpdatedAt string      `json:"updated_at"`
+	Models    []modelRate `json:"models"`
+}
+
+type modelRate struct {
+	Model   string  `json:"model"`
+	Pricing pricing `json:"pricing"`
+}
+
+type pricing struct {
+	Prompt         string `json:"prompt"`
+	Completion     string `json:"completion"`
+	InputCacheRead string `json:"input_cache_read"`
+}
+
+// usageResponse mirrors GET /api/v1/usage/my-usage/between/{start}/{end}.
+type usageResponse struct {
+	Interval string     `json:"interval"`
+	Usage    []usageRow `json:"usage"`
+}
+
+type usageRow struct {
+	RequestTime      time.Time `json:"request_time"`
+	Model            string    `json:"model"`
+	RequestCount     int       `json:"request_count"`
+	InputTokens      int       `json:"input_tokens"`
+	CompletionTokens int       `json:"completion_tokens"`
+	TotalTokens      int       `json:"total_tokens"`
+	// CachedTokens is a SUBSET of InputTokens — non-cached input is
+	// InputTokens − CachedTokens. Never add it on top of input.
+	CachedTokens int `json:"cached_tokens"`
+}
+
+// rateCard is the parsed per-model price table (USD per 1M tokens).
+type rateCard struct {
+	UpdatedAt time.Time
+	prices    map[string]pricing
+}
+
+func parseCreditsStatus(body []byte) (creditsStatusResponse, error) {
+	var resp creditsStatusResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return resp, fmt.Errorf("parsing credits status: %w", err)
+	}
+	return resp, nil
+}
+
+func parseUserCredits(body []byte) (userCreditsResponse, error) {
+	var resp userCreditsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return resp, fmt.Errorf("parsing user credits: %w", err)
+	}
+	return resp, nil
+}
+
+func parseRateCard(body []byte) (rateCard, error) {
+	var resp rateCardResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return rateCard{}, fmt.Errorf("parsing rate card: %w", err)
+	}
+	rc := rateCard{prices: make(map[string]pricing, len(resp.Models))}
+	if t, err := time.Parse(time.RFC3339, resp.UpdatedAt); err == nil {
+		rc.UpdatedAt = t
+	}
+	for _, m := range resp.Models {
+		if m.Model == "" {
+			continue
+		}
+		rc.prices[m.Model] = m.Pricing
+	}
+	return rc, nil
+}
+
+// rate returns the per-1M-token prices for a model, defaulting to zeros when
+// the model is not on the rate card so cost stays defined but conservative.
+func (rc rateCard) rate(model string) (prompt, completion, cacheRead float64) {
+	p, ok := rc.prices[model]
+	if !ok {
+		return 0, 0, 0
+	}
+	prompt = parsePrice(p.Prompt)
+	completion = parsePrice(p.Completion)
+	cacheRead = parsePrice(p.InputCacheRead)
+	return
+}
+
+func parsePrice(s string) float64 {
+	v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil || v < 0 {
+		return 0
+	}
+	return v
+}
+
+// parseUsage consumes the my-usage payload, computes per-model cost from the
+// rate card (cached treated as a subset of input), and fills the snapshot's
+// ModelUsage rows, DailySeries (cost + tokens), and aggregate spend metrics.
+// Returns the total cost (USD) and total request count across the window.
+func parseUsage(snap *core.UsageSnapshot, body []byte, interval string, rc rateCard) error {
+	var resp usageResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return fmt.Errorf("parsing usage: %w", err)
+	}
+	if interval != "" {
+		resp.Interval = interval
+	}
+
+	type modelAgg struct {
+		input  int
+		output int
+		cached int
+		total  int
+		reqs   int
+		cost   float64
+	}
+	modelAggs := make(map[string]*modelAgg)
+	dailyCost := make(map[string]float64)
+	dailyTokens := make(map[string]float64)
+
+	var totalCost float64
+	var totalReqs int
+
+	for i := range resp.Usage {
+		row := resp.Usage[i]
+		if row.Model == "" {
+			continue
+		}
+		prompt, completion, cacheRead := rc.rate(row.Model)
+		nonCached := row.InputTokens - row.CachedTokens
+		if nonCached < 0 {
+			nonCached = 0
+		}
+		cost := (float64(nonCached)/1e6)*prompt +
+			(float64(row.CompletionTokens)/1e6)*completion +
+			(float64(row.CachedTokens)/1e6)*cacheRead
+
+		totalCost += cost
+		totalReqs += row.RequestCount
+
+		a := modelAggs[row.Model]
+		if a == nil {
+			a = &modelAgg{}
+			modelAggs[row.Model] = a
+		}
+		a.input += row.InputTokens
+		a.output += row.CompletionTokens
+		a.cached += row.CachedTokens
+		a.total += row.TotalTokens
+		a.reqs += row.RequestCount
+		a.cost += cost
+
+		day := row.RequestTime.Format("2006-01-02")
+		dailyCost[day] += cost
+		dailyTokens[day] += float64(row.TotalTokens)
+	}
+
+	// Per-model rows for the detail panel.
+	for model, a := range modelAggs {
+		snap.AppendModelUsage(core.ModelUsageRecord{
+			RawModelID:   model,
+			RawSource:    "api",
+			Window:       "30d",
+			InputTokens:  core.Float64Ptr(float64(a.input)),
+			OutputTokens: core.Float64Ptr(float64(a.output)),
+			CachedTokens: core.Float64Ptr(float64(a.cached)),
+			TotalTokens:  core.Float64Ptr(float64(a.total)),
+			CostUSD:      core.Float64Ptr(a.cost),
+			Requests:     core.Float64Ptr(float64(a.reqs)),
+		})
+	}
+
+	// Daily series for the analytics/daily views.
+	snap.DailySeries = make(map[string][]core.TimePoint, 2)
+	snap.DailySeries["cost"] = dailyPoints(dailyCost)
+	snap.DailySeries["tokens"] = dailyPoints(dailyTokens)
+
+	snap.SetAttribute("usage_interval", resp.Interval)
+	snap.SetAttribute("request_count_total", strconv.Itoa(totalReqs))
+	snap.SetAttribute("30d_requests", strconv.Itoa(totalReqs))
+	snap.SetAttribute("30d_models", strconv.Itoa(len(modelAggs)))
+
+	snap.Metrics["monthly_spend"] = core.Metric{
+		Used:   core.Float64Ptr(totalCost),
+		Unit:   "USD",
+		Window: "month",
+	}
+	snap.Metrics["30d_cost"] = core.Metric{
+		Used:   core.Float64Ptr(totalCost),
+		Unit:   "USD",
+		Window: "30d",
+	}
+
+	setTodayTotals(snap, resp.Usage)
+
+	return nil
+}
+
+// setTodayTotals records today's aggregate tokens/requests derived from the
+// most recent date present in the usage window.
+func setTodayTotals(snap *core.UsageSnapshot, rows []usageRow) {
+	today := ""
+	for _, r := range rows {
+		if r.RequestTime.Format("2006-01-02") > today {
+			today = r.RequestTime.Format("2006-01-02")
+		}
+	}
+	if today == "" {
+		return
+	}
+	var input, output, cached, total, reqs int
+	for _, r := range rows {
+		if r.RequestTime.Format("2006-01-02") != today {
+			continue
+		}
+		input += r.InputTokens
+		output += r.CompletionTokens
+		cached += r.CachedTokens
+		total += r.TotalTokens
+		reqs += r.RequestCount
+	}
+	setIntMetric(snap, "today_input_tokens", input, "tokens", "today")
+	setIntMetric(snap, "today_output_tokens", output, "tokens", "today")
+	setIntMetric(snap, "today_cached_tokens", cached, "tokens", "today")
+	setIntMetric(snap, "today_tokens", total, "tokens", "today")
+	setIntMetric(snap, "today_requests", reqs, "requests", "today")
+}
+
+func setIntMetric(snap *core.UsageSnapshot, key string, v int, unit, window string) {
+	val := float64(v)
+	snap.Metrics[key] = core.Metric{Used: core.Float64Ptr(val), Unit: unit, Window: window}
+}
+
+func dailyPoints(m map[string]float64) []core.TimePoint {
+	pts := make([]core.TimePoint, 0, len(m))
+	for day, val := range m {
+		pts = append(pts, core.TimePoint{Date: day, Value: val})
+	}
+	for i := 1; i < len(pts); i++ {
+		for j := i; j > 0 && pts[j].Date < pts[j-1].Date; j-- {
+			pts[j], pts[j-1] = pts[j-1], pts[j]
+		}
+	}
+	return pts
+}
+
+// jwtPayloadEmail best-effort decodes the (unverified) body of a JWT to
+// extract the email so it can be surfaced as account metadata. Returns ""
+// on any failure — never an error.
+func jwtPayloadEmail(token string) string {
+	if token == "" {
+		return ""
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		SubInfo struct {
+			Email string `json:"email"`
+		} `json:"sub_info"`
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	if claims.SubInfo.Email != "" {
+		return claims.SubInfo.Email
+	}
+	return claims.Email
+}

--- a/internal/providers/makora/provider.go
+++ b/internal/providers/makora/provider.go
@@ -1,0 +1,38 @@
+// Package makora implements the Makora billing/usage provider.
+//
+// Makora's billing endpoints are gated behind a dashboard *session JWT*
+// (not the Inference+Optimize API key — that returns 403 on credits/usage).
+// This provider resolves a session token in precedence order:
+//
+//  1. MAKORA_SESSION_TOKEN env var (manually pasted JWT)
+//  2. ~/.config/makora-usage/state.json token cache (read-only sibling of the
+//     shared makora-usage helper; may be refreshed when this flow logs in)
+//  3. MAKORA_EMAIL + MAKORA_PASSWORD env vars → password login
+//
+// Data endpoints (base https://app.makora.com, "Authorization: Bearer <jwt>"):
+//
+//	GET /api/v1/credits/status                 → live balance
+//	GET /api/v1/credits/user                   → monthly spend limit / auto-recharge
+//	GET /api/v1/usage/my-usage/between/{start}/{end}?paygo=true → per-model daily usage
+//	GET /api/v1/credits/default-rates          → public per-1M-token rate card
+//
+// cached_tokens is a SUBSET of input_tokens; non-cached input is
+// input_tokens − cached_tokens. Cost per model-day row uses the public rate
+// card: (input−cached)·prompt + completion·completion + cached·cache_read.
+package makora
+
+import (
+	"github.com/janekbaraniewski/openusage/internal/providers/providerbase"
+)
+
+// Provider implements core.UsageProvider for Makora.
+type Provider struct {
+	providerbase.Base
+}
+
+// New returns the provider with its fully-populated spec and widgets.
+func New() *Provider {
+	return &Provider{
+		Base: providerbase.New(spec()),
+	}
+}

--- a/internal/providers/makora/provider_test.go
+++ b/internal/providers/makora/provider_test.go
@@ -1,0 +1,430 @@
+package makora
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+const ratesBody = `{"updated_at":"2026-08-22T15:13:11Z","models":[
+	{"model":"deepseek-ai/DeepSeek-V4-Flash","pricing":{"prompt":"0.09","completion":"0.195","input_cache_read":"0.0196"}},
+	{"model":"anon/model-x","pricing":{"prompt":"0.10","completion":"0.34","input_cache_read":"0.02"}}
+]}`
+
+const statusBody = `{"balance":13.32,"currency":"Credits","has_payment_method":true}`
+
+const userBody = `{"pay_as_you_go_enabled":true,"spending_warning_notification":{"is_enabled":true,"amount":250.0},
+	"monthly_prepaid_notification":{"is_enabled":true,"amount":400.0}}`
+
+// usageBody: two models, one row with cached (input includes cached), one row
+// without. Cached must be treated as a subset of input — not added on top.
+const usageBody = `{"interval":"day","usage":[
+	{"request_time":"2026-08-22T12:00:00Z","model":"deepseek-ai/DeepSeek-V4-Flash","request_count":10,
+	 "input_tokens":1000000,"completion_tokens":200000,"total_tokens":1200000,"cached_tokens":400000},
+	{"request_time":"2026-08-21T12:00:00Z","model":"anon/model-x","request_count":5,
+	 "input_tokens":500000,"completion_tokens":100000,"total_tokens":600000,"cached_tokens":0}
+]}`
+
+// makoraTestServer fakes the app.makora.com data endpoints plus the
+// be.prod.makora.com auth endpoints. authFails controls whether bearer
+// requests return 401 until refreshLogin is called.
+type makoraTestServer struct {
+	server       *httptest.Server
+	authFails    bool
+	loginCalls   int
+	refreshCalls int
+	lastAuth     string
+}
+
+func newMakoraServer(t *testing.T, authFails bool) *makoraTestServer {
+	ms := &makoraTestServer{authFails: authFails}
+	ms.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == loginPath || r.URL.Path == "/v1/login/access-token":
+			ms.loginCalls++
+			ms.respondJSON(w, `{"access_token":"jwt-login","refresh_token":"rt-login"}`)
+		case r.URL.Path == refreshPath:
+			ms.refreshCalls++
+			ms.respondJSON(w, `{"access_token":"jwt-refresh","refresh_token":"rt-refresh"}`)
+		case r.URL.Path == ratesPath:
+			ms.respondJSON(w, ratesBody)
+		default:
+			// Any authed data endpoint.
+			if ms.authFails {
+				if r.Header.Get("Authorization") != "Bearer jwt-refresh" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+			}
+			ms.lastAuth = r.Header.Get("Authorization")
+			switch r.URL.Path {
+			case statusPath:
+				ms.respondJSON(w, statusBody)
+			case userPath:
+				ms.respondJSON(w, userBody)
+			default:
+				ms.respondJSON(w, usageBody)
+			}
+		}
+	}))
+	t.Cleanup(ms.server.Close)
+	return ms
+}
+
+func (ms *makoraTestServer) respondJSON(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, body)
+}
+
+func (ms *makoraTestServer) acct() core.AccountConfig {
+	return core.AccountConfig{
+		ID:       "makora",
+		Provider: "makora",
+		BaseURL:  ms.server.URL,
+	}
+}
+
+// loginAcct returns an account whose data AND login endpoints both target the
+// fake server (the real login host, be.prod.makora.com, is separate).
+func (ms *makoraTestServer) loginAcct() core.AccountConfig {
+	acct := ms.acct()
+	acct.SetHint("login_base_url", ms.server.URL)
+	return acct
+}
+
+func providerForTest() *Provider { return New() }
+
+func TestMakoraFetch_HappyPath_TokenCache(t *testing.T) {
+	ms := newMakoraServer(t, false)
+	p := providerForTest()
+
+	dir := t.TempDir()
+	state := filepath.Join(dir, "state.json")
+	writeTestState(t, state, "jwt-cache", "rt-cache")
+
+	t.Setenv("MAKORA_SESSION_TOKEN", "")
+	t.Setenv("MAKORA_EMAIL", "")
+	t.Setenv("MAKORA_PASSWORD", "")
+
+	acct := ms.acct()
+	acct.SetPath("state_file", state)
+
+	snap, err := p.Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err)
+	}
+	if snap.Status != core.StatusOK {
+		t.Errorf("Status = %q, want OK (%s)", snap.Status, snap.Message)
+	}
+	if snap.Attributes["auth_type"] != "token_cache" {
+		t.Errorf("auth_type = %q, want token_cache", snap.Attributes["auth_type"])
+	}
+
+	bal, ok := snap.Metrics["credit_balance"]
+	if !ok {
+		t.Fatal("missing credit_balance metric")
+	}
+	if bal.Remaining == nil || *bal.Remaining != 13.32 {
+		t.Errorf("credit_balance.Remaining = %v, want 13.32", bal.Remaining)
+	}
+	lim, ok := snap.Metrics["spend_limit"]
+	if !ok || lim.Limit == nil || *lim.Limit != 400 {
+		t.Errorf("spend_limit = %+v, want limit 400", lim)
+	}
+	// Gauge reference should be wired into the balance metric.
+	if bal.Limit == nil || *bal.Limit != 400 {
+		t.Errorf("credit_balance.Limit = %v, want 400 (spend-limit reference)", bal.Limit)
+	}
+
+	// Per-model rows.
+	if len(snap.ModelUsage) != 2 {
+		t.Fatalf("ModelUsage len = %d, want 2", len(snap.ModelUsage))
+	}
+
+	// Cached-as-subset arithmetic: non-cached input = input - cached.
+	deepseek := findModel(t, snap, "deepseek-ai/DeepSeek-V4-Flash")
+	// nonCached = 1,000,000 - 400,000 = 600,000
+	// cost = 0.6*0.09 + 0.2*0.195 + 0.4*0.0196 = 0.054 + 0.039 + 0.00784 = 0.10084
+	wantCost := 0.6*0.09 + 0.2*0.195 + 0.4*0.0196
+	if diff := *deepseek.TotalTokens; diff != 1200000 {
+		t.Errorf("deepseek total tokens = %v, want 1200000", diff)
+	}
+	if v := *deepseek.CachedTokens; v != 400000 {
+		t.Errorf("deepseek cached = %v, want 400000", v)
+	}
+	if v := *deepseek.CostUSD; abs(v-wantCost) > 1e-9 {
+		t.Errorf("deepseek cost = %v, want %v (cached NOT double-counted)", v, wantCost)
+	}
+	if v := *deepseek.InputTokens; v != 1000000 {
+		t.Errorf("deepseek input = %v, want 1000000 (cached kept as subset)", v)
+	}
+
+	// Daily series present.
+	if _, ok := snap.DailySeries["cost"]; !ok {
+		t.Error("missing DailySeries['cost']")
+	}
+	if _, ok := snap.DailySeries["tokens"]; !ok {
+		t.Error("missing DailySeries['tokens']")
+	}
+	if snap.Metrics["monthly_spend"].Used == nil {
+		t.Error("missing monthly_spend.Used")
+	}
+}
+
+func TestMakoraFetch_NoCredential_StatusAuth(t *testing.T) {
+	ms := newMakoraServer(t, false)
+	p := providerForTest()
+
+	t.Setenv("MAKORA_SESSION_TOKEN", "")
+	t.Setenv("MAKORA_EMAIL", "")
+	t.Setenv("MAKORA_PASSWORD", "")
+	// Point the state path at a nonexistent file.
+	acct := ms.acct()
+	acct.SetPath("state_file", filepath.Join(t.TempDir(), "nope.json"))
+
+	snap, err := p.Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err)
+	}
+	if snap.Status != core.StatusAuth {
+		t.Errorf("Status = %q, want AUTH_REQUIRED", snap.Status)
+	}
+	if snap.AccountID != "makora" || snap.ProviderID != "makora" {
+		t.Errorf("unexpected snapshot ids: acct=%s prov=%s", snap.AccountID, snap.ProviderID)
+	}
+}
+
+func TestMakoraFetch_401ThenRefresh_SingleRetry(t *testing.T) {
+	ms := newMakoraServer(t, true) // 401 until Bearer jwt-refresh issued
+	p := providerForTest()
+
+	dir := t.TempDir()
+	state := filepath.Join(dir, "state.json")
+	writeTestState(t, state, "jwt-expired", "rt-expired")
+	acct := ms.loginAcct()
+	acct.SetPath("state_file", state)
+
+	t.Setenv("MAKORA_SESSION_TOKEN", "")
+	t.Setenv("MAKORA_EMAIL", "")
+	t.Setenv("MAKORA_PASSWORD", "")
+
+	snap, err := p.Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err)
+	}
+	if snap.Status != core.StatusOK {
+		t.Errorf("Status = %q, want OK (%s)", snap.Status, snap.Message)
+	}
+	if ms.refreshCalls != 1 {
+		t.Errorf("refreshCalls = %d, want 1 (re-auth once, then retry)", ms.refreshCalls)
+	}
+	if ms.lastAuth != "Bearer jwt-refresh" {
+		t.Errorf("final auth header = %q, want Bearer jwt-refresh", ms.lastAuth)
+	}
+}
+
+func TestMakoraFetch_PasswordLoginFallback(t *testing.T) {
+	ms := newMakoraServer(t, false)
+	p := providerForTest()
+
+	t.Setenv("MAKORA_SESSION_TOKEN", "")
+	t.Setenv("MAKORA_EMAIL", "user@example.com")
+	t.Setenv("MAKORA_PASSWORD", "sekret")
+
+	// No state file and no session token => password login path.
+	acct := ms.loginAcct()
+	acct.SetPath("state_file", filepath.Join(t.TempDir(), "missing.json"))
+
+	snap, err := p.Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err)
+	}
+	if snap.Status != core.StatusOK {
+		t.Errorf("Status = %q, want OK (%s)", snap.Status, snap.Message)
+	}
+	if ms.loginCalls != 1 {
+		t.Errorf("loginCalls = %d, want 1", ms.loginCalls)
+	}
+	if snap.Attributes["auth_type"] != "password" {
+		t.Errorf("auth_type = %q, want password", snap.Attributes["auth_type"])
+	}
+	if ms.lastAuth != "Bearer jwt-login" {
+		t.Errorf("final auth header = %q, want Bearer jwt-login", ms.lastAuth)
+	}
+}
+
+func TestMakoraFetch_EnvSessionToken(t *testing.T) {
+	ms := newMakoraServer(t, false)
+	p := providerForTest()
+
+	t.Setenv("MAKORA_SESSION_TOKEN", "jwt-env")
+	t.Setenv("MAKORA_EMAIL", "")
+	t.Setenv("MAKORA_PASSWORD", "")
+	acct := ms.acct()
+	acct.SetPath("state_file", filepath.Join(t.TempDir(), "missing.json"))
+
+	snap, err := p.Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err)
+	}
+	if snap.Status != core.StatusOK {
+		t.Errorf("Status = %q, want OK (%s)", snap.Status, snap.Message)
+	}
+	if snap.Attributes["auth_type"] != "env_session" {
+		t.Errorf("auth_type = %q, want env_session", snap.Attributes["auth_type"])
+	}
+}
+
+func TestMakoraFetch_MissingTokenFile_IsNotHazard(t *testing.T) {
+	// A nonexistent state file should simply fall through to auth-required
+	// (or another credential path) rather than erroring.
+	ms := newMakoraServer(t, false)
+	p := providerForTest()
+
+	t.Setenv("MAKORA_SESSION_TOKEN", "")
+	t.Setenv("MAKORA_EMAIL", "")
+	t.Setenv("MAKORA_PASSWORD", "")
+	acct := ms.acct()
+	acct.SetPath("state_file", filepath.Join(t.TempDir(), "definitely-missing.json"))
+
+	snap, err := p.Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err) // no credential path should NOT be a hard error
+	}
+	if snap.Status != core.StatusAuth {
+		t.Errorf("Status = %q, want AUTH_REQUIRED", snap.Status)
+	}
+}
+
+func TestMakoraParseUsage_CachedIsSubset_NoDoubleCount(t *testing.T) {
+	rc, err := parseRateCard([]byte(ratesBody))
+	if err != nil {
+		t.Fatalf("parseRateCard: %v", err)
+	}
+	snap := core.NewUsageSnapshot("makora", "makora")
+
+	if err := parseUsage(&snap, []byte(usageBody), "", rc); err != nil {
+		t.Fatalf("parseUsage: %v", err)
+	}
+
+	deepseek := findModel(t, snap, "deepseek-ai/DeepSeek-V4-Flash")
+	modelX := findModel(t, snap, "anon/model-x")
+
+	// deepseek: input 1e6, cached 400k => nonCached 600k
+	// cost = 0.6*0.09 + 0.2*0.195 + 0.4*0.0196
+	wantDS := 0.6*0.09 + 0.2*0.195 + 0.4*0.0196
+	if v := *deepseek.CostUSD; abs(v-wantDS) > 1e-9 {
+		t.Errorf("deepseek cost = %v, want %v", v, wantDS)
+	}
+	if v := *deepseek.InputTokens; v != 1000000 {
+		t.Errorf("deepseek input = %v, want 1000000 (cached is subset, not additive)", v)
+	}
+
+	// modelX: input 500k, cached 0 => cost = 0.5*0.10 + 0.1*0.34
+	wantMX := 0.5*0.10 + 0.1*0.34
+	if v := *modelX.CostUSD; abs(v-wantMX) > 1e-9 {
+		t.Errorf("modelX cost = %v, want %v", v, wantMX)
+	}
+
+	// Total month spend = sum of both.
+	total := *snap.Metrics["monthly_spend"].Used
+	wantTotal := wantDS + wantMX
+	if abs(total-wantTotal) > 1e-9 {
+		t.Errorf("monthly_spend = %v, want %v", total, wantTotal)
+	}
+
+	// Daily series has two distinct days.
+	costSeries := snap.DailySeries["cost"]
+	if len(costSeries) != 2 {
+		t.Errorf("DailySeries['cost'] len = %d, want 2", len(costSeries))
+	}
+	if costSeries[0].Date > costSeries[1].Date {
+		t.Errorf("daily series not sorted: %s then %s", costSeries[0].Date, costSeries[1].Date)
+	}
+}
+
+func TestMakoraParseUsage_UnknownModel_ConservZero(t *testing.T) {
+	// A model missing from the rate card must not blow up; cost stays 0.
+	rc, _ := parseRateCard([]byte(ratesBody))
+	snap := core.NewUsageSnapshot("makora", "makora")
+	body := `{"interval":"day","usage":[{"request_time":"2026-08-22T12:00:00Z","model":"totally/unknown",
+		"request_count":1,"input_tokens":100,"completion_tokens":100,"total_tokens":200,"cached_tokens":0}]}`
+	if err := parseUsage(&snap, []byte(body), "", rc); err != nil {
+		t.Fatalf("parseUsage: %v", err)
+	}
+	rec := findModel(t, snap, "totally/unknown")
+	if *rec.CostUSD != 0 {
+		t.Errorf("unknown model cost = %v, want 0", *rec.CostUSD)
+	}
+}
+
+func TestMakoraJWTPayloadEmail(t *testing.T) {
+	// Real-format JWT header.payload.signature (payload only is read).
+	header := base64URL("{\"alg\":\"HS256\"}")
+	payload := base64URL(`{"sub":"abc","sub_info":{"email":"illusivejosiah@gmail.com","roles":[]},"aud":"a2labs:auth"}`)
+	tok := header + "." + payload + ".sig"
+	if got := jwtPayloadEmail(tok); got != "illusivejosiah@gmail.com" {
+		t.Errorf("jwtPayloadEmail = %q", got)
+	}
+	if got := jwtPayloadEmail("not-a-jwt"); got != "" {
+		t.Errorf("jwtPayloadEmail(malformed) = %q, want empty", got)
+	}
+	if got := jwtPayloadEmail(""); got != "" {
+		t.Errorf("jwtPayloadEmail(empty) = %q, want empty", got)
+	}
+}
+
+// --- helpers ---
+
+func writeTestState(t *testing.T, path, access, refresh string) {
+	t.Helper()
+	payload, _ := json.Marshal(map[string]any{
+		"access_token":  access,
+		"refresh_token": refresh,
+		"exp":           time.Now().Add(24 * time.Hour).Unix(),
+	})
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func findModel(t *testing.T, snap core.UsageSnapshot, id string) *core.ModelUsageRecord {
+	t.Helper()
+	for i := range snap.ModelUsage {
+		if snap.ModelUsage[i].RawModelID == id {
+			return &snap.ModelUsage[i]
+		}
+	}
+	t.Fatalf("model %q not found in ModelUsage", id)
+	return nil
+}
+
+func abs(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func base64URL(s string) string {
+	e := base64.StdEncoding.EncodeToString([]byte(s))
+	e = strings.TrimRight(e, "=")
+	e = strings.ReplaceAll(e, "+", "-")
+	e = strings.ReplaceAll(e, "/", "_")
+	return e
+}

--- a/internal/providers/makora/spec.go
+++ b/internal/providers/makora/spec.go
@@ -1,0 +1,52 @@
+package makora
+
+import (
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+const (
+	// defaultBaseURL hosts all bearer-JWT data endpoints.
+	defaultBaseURL = "https://app.makora.com"
+	// baseLoginURL hosts the password/refresh auth endpoints.
+	baseLoginURL = "https://be.prod.makora.com"
+
+	statusPath  = "/api/v1/credits/status"
+	userPath    = "/api/v1/credits/user"
+	ratesPath   = "/api/v1/credits/default-rates"
+	usagePrefix = "/api/v1/usage/my-usage/between/"
+	loginPath   = "/api/v1/login/access-token"
+	refreshPath = "/api/v1/login/refresh"
+	deviceName  = "openusage"
+)
+
+// spec returns the canonical ProviderSpec for the makora provider.
+func spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		ID: "makora",
+		Info: core.ProviderInfo{
+			Name:         "Makora",
+			Capabilities: []string{"balance_endpoint", "usage_endpoint", "per_model_breakdown", "daily_series"},
+			DocURL:       "https://app.makora.com",
+		},
+		Auth: core.ProviderAuthSpec{
+			Type:             core.ProviderAuthTypeToken,
+			DefaultAccountID: "makora",
+		},
+		Setup: core.ProviderSetupSpec{
+			DocsURL: "https://app.makora.com",
+			Quickstart: []string{
+				"Set MAKORA_SESSION_TOKEN to a dashboard session JWT (simplest),",
+				"or set MAKORA_EMAIL + MAKORA_PASSWORD for password login,",
+				"or let openusage reuse the token cache at ~/.config/makora-usage/state.json.",
+				"Note: MAKORA_API_KEY (Inference+Optimize) is NOT accepted by the billing endpoints (HTTP 403).",
+			},
+		},
+		Dashboard: dashboardWidget(),
+		Detail:    detailWidget(),
+		CreditMetrics: map[string]core.BalanceSemantics{
+			"credit_balance": core.BalancePoint,
+			"monthly_spend":  core.BalanceCumulative,
+			"spend_limit":    core.BalanceLimit,
+		},
+	}
+}

--- a/internal/providers/makora/widgets.go
+++ b/internal/providers/makora/widgets.go
@@ -1,0 +1,89 @@
+package makora
+
+import (
+	"github.com/janekbaraniewski/openusage/internal/core"
+	"github.com/janekbaraniewski/openusage/internal/providers/providerbase"
+)
+
+// dashboardWidget defines the tile layout for the Makora provider.
+//
+// Balance is the primary metric; its gauge uses the monthly spend limit as
+// the reference (Limit) so the user sees remaining credits against the
+// monthly budget. monthly_spend is the actual credits consumed in the window
+// (spend vs limit), and spend_limit is the fixed monthly cap.
+func dashboardWidget() core.DashboardWidget {
+	cfg := providerbase.DefaultDashboard(
+		providerbase.WithColorRole(core.DashboardColorRoleSapphire),
+		providerbase.WithGaugeMaxLines(2),
+		providerbase.WithGaugePriority(
+			"credit_balance", "monthly_spend", "spend_limit",
+		),
+		providerbase.WithCompactRows(
+			core.DashboardCompactRow{Label: "Credits", Keys: []string{"credit_balance", "monthly_spend", "spend_limit"}, MaxSegments: 4},
+			core.DashboardCompactRow{Label: "Tokens", Keys: []string{"today_input_tokens", "today_output_tokens", "today_cached_tokens", "today_tokens"}, MaxSegments: 4},
+			core.DashboardCompactRow{Label: "Activity", Keys: []string{"today_requests", "30d_requests", "30d_models"}, MaxSegments: 4},
+		),
+		providerbase.WithSectionOrder(
+			core.DashboardSectionHeader,
+			core.DashboardSectionTopUsageProgress,
+			core.DashboardSectionModelBurn,
+			core.DashboardSectionClientBurn,
+			core.DashboardSectionToolUsage,
+			core.DashboardSectionLanguageBurn,
+			core.DashboardSectionDailyUsage,
+			core.DashboardSectionOtherData,
+		),
+		providerbase.WithHideMetricPrefixes(
+			"model_", "today_", "30d_",
+		),
+		providerbase.WithSuppressZeroMetricKeys(
+			"today_input_tokens", "today_output_tokens", "today_cached_tokens", "today_tokens", "today_requests",
+		),
+		providerbase.WithRawGroups(
+			core.DashboardRawGroup{Label: "Account", Keys: []string{"account_email", "auth_type", "currency", "has_payment_method"}},
+			core.DashboardRawGroup{Label: "Plan", Keys: []string{"pay_as_you_go_enabled", "spend_limit"}},
+			core.DashboardRawGroup{Label: "Usage", Keys: []string{"usage_interval", "usage_range", "30d_requests", "30d_models", "request_count_total"}},
+			core.DashboardRawGroup{Label: "Rate Card", Keys: []string{"rate_card_updated_at", "models_priced"}},
+		),
+		providerbase.WithMetricLabels(map[string]string{
+			"credit_balance":      "Balance",
+			"monthly_spend":       "Month spend",
+			"spend_limit":         "Monthly limit",
+			"today_input_tokens":  "Input tokens",
+			"today_output_tokens": "Output tokens",
+			"today_cached_tokens": "Cached tokens",
+			"today_tokens":        "Total tokens",
+			"today_requests":      "Requests today",
+			"30d_requests":        "30d requests",
+			"30d_models":          "Models (30d)",
+			"request_count_total": "Total requests",
+			"models_priced":       "Models priced",
+		}),
+		providerbase.WithCompactLabels(map[string]string{
+			"credit_balance": "bal",
+			"monthly_spend":  "spent",
+			"spend_limit":    "limit",
+			"today_tokens":   "tok",
+			"30d_models":     "models",
+		}),
+	)
+
+	cfg.DisplayStyle = core.DashboardDisplayStyleDetailedCredits
+	return cfg
+}
+
+// detailWidget defines the right-hand detail panel sections. Models and
+// Trends are driven by the snapshot's ModelUsage records and DailySeries, so
+// per-model tables and daily spend charts work automatically.
+func detailWidget() core.DetailWidget {
+	return core.DetailWidget{
+		Sections: []core.DetailSection{
+			{Name: "Usage", Order: 1, Style: core.DetailSectionStyleUsage},
+			{Name: "Models", Order: 2, Style: core.DetailSectionStyleModels},
+			{Name: "Spending", Order: 3, Style: core.DetailSectionStyleSpending},
+			{Name: "Tokens", Order: 4, Style: core.DetailSectionStyleTokens},
+			{Name: "Trends", Order: 5, Style: core.DetailSectionStyleTrends},
+			{Name: "Activity", Order: 6, Style: core.DetailSectionStyleActivity},
+		},
+	}
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -24,6 +24,7 @@ import (
 	"github.com/janekbaraniewski/openusage/internal/providers/kilocode"
 	"github.com/janekbaraniewski/openusage/internal/providers/kimi_cli"
 	"github.com/janekbaraniewski/openusage/internal/providers/kiro"
+	"github.com/janekbaraniewski/openusage/internal/providers/makora"
 	"github.com/janekbaraniewski/openusage/internal/providers/mistral"
 	"github.com/janekbaraniewski/openusage/internal/providers/moonshot"
 	"github.com/janekbaraniewski/openusage/internal/providers/mux"
@@ -54,6 +55,7 @@ func AllProviders() []core.UsageProvider {
 		mistral.New(),
 		moonshot.New(),
 		deepseek.New(),
+		makora.New(),
 		xai.New(),
 		zai.New(),
 		opencode.New(),


### PR DESCRIPTION
Adds a Makora inference provider (provider #36): live credit balance, 30-day spend + per-model usage/cost from the private credits/usage API, plus a shared-token-auth path.

- Auth: MAKORA_SESSION_TOKEN env → shared ~/.config/makora-usage/state.json cache → MAKORA_EMAIL+MAKORA_PASSWORD password login (be.prod.makora.com), 401→re-auth retry
- Data: /api/v1/credits/status, /api/v1/credits/user (spend limit), /api/v1/usage/my-usage/between (30d), public /api/v1/credits/default-rates price card
- Cost: cached tokens treated as a subset of input (avoids double-count); reconciles to billing ledger
- Tests: 14 (9 provider + 5 detect), httptest only, no network