### PR TITLE
fix(integrations): treat OpenCode plugin auto-discovery as configured

### DIFF
--- a/docs/TELEMETRY_INTEGRATIONS.md
+++ b/docs/TELEMETRY_INTEGRATIONS.md
@@ -48,7 +48,7 @@ The daemon also prints a hint at startup when it detects tools with missing inte
 ### OpenCode (Plugin)
 
 - `~/.config/opencode/plugins/openusage-telemetry.ts`
-- plugin entry in `~/.config/opencode/opencode.json`
+- no config entry: OpenCode auto-discovers plugins in `~/.config/opencode/plugins/`
 
 ### Codex (Notify Hook)
 

--- a/docs/site/docs/daemon/integrations.md
+++ b/docs/site/docs/daemon/integrations.md
@@ -13,7 +13,7 @@ OpenUsage ships three official integrations.
 |---|---|---|---|---|
 | `claude_code` | Claude Code | `~/.config/openusage/hooks/claude-hook.sh` | `~/.claude/settings.json` | JSON |
 | `codex` | Codex | `~/.config/openusage/hooks/codex-notify.sh` | `~/.codex/config.toml` | TOML |
-| `opencode` | OpenCode | `~/.config/opencode/plugins/openusage-telemetry.ts` | `~/.config/opencode/opencode.json` | JSON |
+| `opencode` | OpenCode | `~/.config/opencode/plugins/openusage-telemetry.ts` | none (plugin-directory auto-discovery) | JSON / JSONC |
 
 ## Listing integrations
 
@@ -138,7 +138,6 @@ Override the Codex config directory with `CODEX_CONFIG_DIR`.
 
 ```
 ~/.config/opencode/plugins/openusage-telemetry.ts   (mode 0644)
-~/.config/opencode/opencode.json                    (patched, mode 0600)
 ```
 
 **Install.**
@@ -147,7 +146,18 @@ Override the Codex config directory with `CODEX_CONFIG_DIR`.
 openusage integrations install opencode
 ```
 
-**Example patched config.**
+**No config file is touched.** OpenCode loads every local file in its global
+plugin directory automatically, so the plugin is active as soon as it is
+written and needs no `plugin` entry. Install therefore leaves your OpenCode
+config exactly as it is, and does not create one if you have none.
+
+This matters if you keep an `opencode.jsonc`: re-serializing it as strict JSON
+would strip the comments that make it a `.jsonc`. OpenUsage reads both
+`opencode.json` and `opencode.jsonc` (comments and trailing commas included),
+and prefers an existing `.jsonc` rather than creating a competing `.json`
+beside it.
+
+Versions before 0.24.5 wrote an explicit registration:
 
 ```json
 {
@@ -156,7 +166,8 @@ openusage integrations install opencode
 }
 ```
 
-The patcher writes the singular `plugin` key as a flat array of `file://` URLs; existing entries are preserved.
+That entry is still recognized, and `openusage integrations uninstall opencode`
+still removes it, so upgrading needs no manual cleanup.
 
 The plugin uses `OPENUSAGE_BIN` and `OPENUSAGE_TELEMETRY_SOCKET` if set; otherwise it falls back to the embedded defaults captured at install time.
 

--- a/docs/site/docs/guides/headless-servers.md
+++ b/docs/site/docs/guides/headless-servers.md
@@ -89,7 +89,7 @@ openusage integrations install codex
 openusage integrations install opencode
 ```
 
-Each tool's config file is patched (Claude `~/.claude/settings.json`, Codex `~/.codex/config.toml`, OpenCode `~/.config/opencode/opencode.json`). The hook scripts shell out to `openusage telemetry hook <source>` and post events to the daemon.
+Claude and Codex have their config files patched (`~/.claude/settings.json`, `~/.codex/config.toml`). OpenCode needs no config change — it auto-discovers plugins in `~/.config/opencode/plugins/`. The hook scripts shell out to `openusage telemetry hook <source>` and post events to the daemon.
 
 If the daemon is briefly unavailable, hooks spool to `~/.local/state/openusage/telemetry-spool/` and are drained when it comes back.
 

--- a/docs/site/docs/reference/paths.md
+++ b/docs/site/docs/reference/paths.md
@@ -40,7 +40,7 @@ These belong to the third-party tools OpenUsage hooks into.
 |---|---|---|---|
 | `~/.claude/settings.json` | Claude Code | Hook registration. | `CLAUDE_SETTINGS_FILE` |
 | `~/.codex/config.toml` | Codex | `notify` registration. | `CODEX_CONFIG_DIR` |
-| `~/.config/opencode/opencode.json` | OpenCode | Plugin registration. | — |
+| `~/.config/opencode/opencode.json` or `opencode.jsonc` | OpenCode | Read only. Plugin registration is not required — OpenCode auto-discovers the plugin directory. Legacy entries written by openusage < 0.24.5 are still honored and removed on uninstall. | — |
 | `~/.config/opencode/plugins/openusage-telemetry.ts` | OpenCode | Plugin source installed by `integrations install opencode`. | — |
 | `~/.local/share/opencode/auth.json` | OpenCode | API keys adopted by auto-detection (OpenCode's data dir). | `XDG_DATA_HOME` |
 

--- a/internal/integrations/definitions.go
+++ b/internal/integrations/definitions.go
@@ -305,6 +305,21 @@ func patchOpenCodeConfig(configData []byte, targetFile string, install bool) ([]
 		// reformat a config we have no edit to make to.
 		return nil, nil
 	}
+	// Re-serializing through encoding/json would drop every comment in a
+	// .jsonc, so when the file carries any, excise just our array entries
+	// textually and leave the rest of the bytes alone. A plain .json has
+	// nothing to preserve, so it takes the simpler marshal path.
+	if configCarriesComments(configData) {
+		trimmed, ok := removeOpenCodePluginLines(configData, pluginURL)
+		if ok {
+			return trimmed, nil
+		}
+		// Entries were not on their own lines, so a line-wise edit can't be
+		// done safely. Marshalling is still correct JSON and still removes
+		// the stale entry; comments are lost, which beats leaving a
+		// registration pointing at a file we just deleted.
+	}
+
 	cfg["plugin"] = remaining
 
 	payload, err := json.MarshalIndent(cfg, "", "  ")
@@ -312,6 +327,76 @@ func patchOpenCodeConfig(configData []byte, targetFile string, install bool) ([]
 		return nil, fmt.Errorf("serialize opencode config: %w", err)
 	}
 	return append(payload, '\n'), nil
+}
+
+// configCarriesComments reports whether stripping JSONC syntax would actually
+// change the file, i.e. whether there is anything worth preserving.
+func configCarriesComments(configData []byte) bool {
+	return !bytes.Equal(bytes.TrimSpace(configData), bytes.TrimSpace(stripJSONC(configData)))
+}
+
+// removeOpenCodePluginLines deletes the lines of the `plugin` array that hold
+// our registration, preserving the rest of the file verbatim. Reports false
+// when any of our entries is not alone on its line, in which case a line-wise
+// edit could corrupt the file and the caller must fall back.
+func removeOpenCodePluginLines(configData []byte, pluginURL string) ([]byte, bool) {
+	isOurs := func(line string) bool {
+		return strings.Contains(line, "openusage-telemetry.ts") || strings.Contains(line, pluginURL)
+	}
+
+	lines := strings.Split(string(configData), "\n")
+	kept := make([]string, 0, len(lines))
+	removed := 0
+
+	for _, line := range lines {
+		if !isOurs(line) {
+			kept = append(kept, line)
+			continue
+		}
+		// The entry must be the only value on the line: a bare quoted string
+		// with an optional trailing comma, and nothing else.
+		bare := strings.TrimSpace(line)
+		bare = strings.TrimSuffix(bare, ",")
+		if !strings.HasPrefix(bare, `"`) || !strings.HasSuffix(bare, `"`) || strings.Count(bare, `"`) != 2 {
+			return nil, false
+		}
+		removed++
+	}
+	if removed == 0 {
+		return nil, false
+	}
+
+	out := strings.Join(kept, "\n")
+
+	// Removing the last element can leave the preceding one with a trailing
+	// comma. JSONC tolerates that, but normalize it so the file stays valid
+	// strict JSON too.
+	out = dropDanglingCommaBeforeClose(out)
+	return []byte(out), true
+}
+
+// dropDanglingCommaBeforeClose removes a comma that now sits immediately before
+// a closing bracket or brace, ignoring whitespace and comment-only lines.
+func dropDanglingCommaBeforeClose(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasSuffix(trimmed, ",") {
+			continue
+		}
+		for j := i + 1; j < len(lines); j++ {
+			next := strings.TrimSpace(lines[j])
+			if next == "" || strings.HasPrefix(next, "//") || strings.HasPrefix(next, "/*") {
+				continue
+			}
+			if strings.HasPrefix(next, "]") || strings.HasPrefix(next, "}") {
+				idx := strings.LastIndex(line, ",")
+				lines[i] = line[:idx] + line[idx+1:]
+			}
+			break
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // --- Detectors ---

--- a/internal/integrations/definitions.go
+++ b/internal/integrations/definitions.go
@@ -114,12 +114,10 @@ func opencodeDef() Definition {
 		TargetFileFunc: func(dirs Dirs) string {
 			return filepath.Join(dirs.ConfigRoot, "opencode", "plugins", "openusage-telemetry.ts")
 		},
-		ConfigFileFunc: func(dirs Dirs) string {
-			return filepath.Join(dirs.ConfigRoot, "opencode", "opencode.json")
-		},
-		ConfigFormat:  ConfigJSON,
-		ConfigPatcher: patchOpenCodeConfig,
-		Detector:      detectOpenCodeStatus,
+		ConfigFileFunc: openCodeConfigFile,
+		ConfigFormat:   ConfigJSON,
+		ConfigPatcher:  patchOpenCodeConfig,
+		Detector:       detectOpenCodeStatus,
 
 		MatchProviderIDs:  []string{"opencode"},
 		MatchToolNameHint: "",
@@ -246,37 +244,68 @@ func patchCodexConfig(configData []byte, targetFile string, install bool) ([]byt
 	return []byte(out), nil
 }
 
-func patchOpenCodeConfig(configData []byte, targetFile string, install bool) ([]byte, error) {
-	cfg := map[string]any{
-		"$schema": "https://opencode.ai/config.json",
+// openCodeConfigFile resolves the config file to inspect or edit. OpenCode
+// accepts both opencode.json and opencode.jsonc; when the user keeps an
+// authoritative .jsonc we must read and edit that one rather than create a
+// competing strict-JSON file alongside it.
+func openCodeConfigFile(dirs Dirs) string {
+	root := filepath.Join(dirs.ConfigRoot, "opencode")
+	jsonc := filepath.Join(root, "opencode.jsonc")
+	if _, err := os.Stat(jsonc); err == nil {
+		return jsonc
 	}
-	if len(bytes.TrimSpace(configData)) > 0 {
-		if err := json.Unmarshal(configData, &cfg); err != nil {
-			return nil, fmt.Errorf("parse opencode config: %w", err)
-		}
+	return filepath.Join(root, "opencode.json")
+}
+
+// patchOpenCodeConfig unregisters the plugin on uninstall and leaves the config
+// untouched on install.
+//
+// The plugin is written into OpenCode's global plugin directory, and OpenCode
+// loads every local file there automatically
+// (https://opencode.ai/docs/plugins/#from-local-files). An explicit `plugin`
+// entry is therefore redundant on install, and writing one costs real things:
+// it would create an opencode.json for users who have none, and re-serializing
+// a .jsonc through encoding/json would silently strip the comments that make it
+// a .jsonc in the first place.
+//
+// Uninstall still has to run, because earlier openusage versions did write an
+// explicit registration and a stale entry would point at a deleted file.
+// Returning nil means "no config change required" — see Definition.ConfigPatcher.
+func patchOpenCodeConfig(configData []byte, targetFile string, install bool) ([]byte, error) {
+	if install {
+		return nil, nil
+	}
+	if len(bytes.TrimSpace(configData)) == 0 {
+		return nil, nil
+	}
+
+	cfg := map[string]any{}
+	if err := decodeJSONC(configData, &cfg); err != nil {
+		return nil, fmt.Errorf("parse opencode config: %w", err)
+	}
+
+	raw, ok := cfg["plugin"].([]any)
+	if !ok {
+		return nil, nil
 	}
 
 	plugins := []string{}
-	if raw, ok := cfg["plugin"].([]any); ok {
-		for _, item := range raw {
-			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
-				plugins = append(plugins, text)
-			}
+	for _, item := range raw {
+		if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
+			plugins = append(plugins, text)
 		}
 	}
 
 	pluginURL := "file://" + targetFile
-
-	if install {
-		if !slices.Contains(plugins, pluginURL) {
-			plugins = append(plugins, pluginURL)
-		}
-	} else {
-		plugins = slices.DeleteFunc(plugins, func(s string) bool {
-			return s == pluginURL || strings.Contains(s, "openusage-telemetry.ts")
-		})
+	remaining := slices.DeleteFunc(slices.Clone(plugins), func(s string) bool {
+		return s == pluginURL || strings.Contains(s, "openusage-telemetry.ts")
+	})
+	if len(remaining) == len(plugins) {
+		// Nothing of ours in there — leave the file alone rather than
+		// reformat a config we have no edit to make to.
+		return nil, nil
 	}
-	cfg["plugin"] = plugins
+	cfg["plugin"] = remaining
 
 	payload, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
@@ -370,20 +399,28 @@ func detectOpenCodeStatus(dirs Dirs) Status {
 	st.Installed = pluginErr == nil
 	st.InstalledVersion = parseIntegrationVersion(pluginData)
 
-	configured := false
-	configFile := def.ConfigFileFunc(dirs)
-	if configData, err := os.ReadFile(configFile); err == nil {
-		var cfg map[string]any
-		if json.Unmarshal(configData, &cfg) == nil {
-			if list, ok := cfg["plugin"].([]any); ok {
-				for _, item := range list {
-					text, ok := item.(string)
-					if !ok {
-						continue
-					}
-					if text == "file://"+pluginFile || strings.Contains(text, "openusage-telemetry.ts") {
-						configured = true
-						break
+	// A versioned plugin sitting in OpenCode's global plugin directory is
+	// already active: OpenCode loads every local file there automatically
+	// (https://opencode.ai/docs/plugins/#from-local-files). Requiring an
+	// explicit `plugin` entry on top of that reported a working install as
+	// PARTIAL. An explicit registration still counts, so configs written by
+	// older openusage versions keep reporting READY.
+	configured := st.Installed && st.InstalledVersion != ""
+	if !configured {
+		configFile := def.ConfigFileFunc(dirs)
+		if configData, err := os.ReadFile(configFile); err == nil {
+			var cfg map[string]any
+			if decodeJSONC(configData, &cfg) == nil {
+				if list, ok := cfg["plugin"].([]any); ok {
+					for _, item := range list {
+						text, ok := item.(string)
+						if !ok {
+							continue
+						}
+						if text == "file://"+pluginFile || strings.Contains(text, "openusage-telemetry.ts") {
+							configured = true
+							break
+						}
 					}
 				}
 			}

--- a/internal/integrations/installer.go
+++ b/internal/integrations/installer.go
@@ -41,9 +41,6 @@ func Install(def Definition, dirs Dirs) (InstallResult, error) {
 			return InstallResult{}, fmt.Errorf("integrations: create target dir: %w", err)
 		}
 	}
-	if err := os.MkdirAll(filepath.Dir(configFile), 0o755); err != nil {
-		return InstallResult{}, fmt.Errorf("integrations: create config dir: %w", err)
-	}
 
 	// Render template with version and binary placeholders.
 	content := strings.ReplaceAll(def.Template, "__OPENUSAGE_INTEGRATION_VERSION__", IntegrationVersion)
@@ -55,9 +52,6 @@ func Install(def Definition, dirs Dirs) (InstallResult, error) {
 			return InstallResult{}, fmt.Errorf("integrations: backup target: %w", err)
 		}
 	}
-	if err := backupIfExists(configFile); err != nil {
-		return InstallResult{}, fmt.Errorf("integrations: backup config: %w", err)
-	}
 
 	// Write rendered template.
 	if writesArtifact {
@@ -66,7 +60,8 @@ func Install(def Definition, dirs Dirs) (InstallResult, error) {
 		}
 	}
 
-	// Read config, patch it, write it back.
+	// Read config, patch it, write it back. A nil patch means the tool needs
+	// no registration entry, so the config file is left untouched.
 	configData, err := os.ReadFile(configFile)
 	if err != nil && !os.IsNotExist(err) {
 		return InstallResult{}, fmt.Errorf("integrations: read config: %w", err)
@@ -75,8 +70,16 @@ func Install(def Definition, dirs Dirs) (InstallResult, error) {
 	if err != nil {
 		return InstallResult{}, fmt.Errorf("integrations: patch config: %w", err)
 	}
-	if err := os.WriteFile(configFile, patched, 0o600); err != nil {
-		return InstallResult{}, fmt.Errorf("integrations: write config: %w", err)
+	if patched != nil {
+		if err := os.MkdirAll(filepath.Dir(configFile), 0o755); err != nil {
+			return InstallResult{}, fmt.Errorf("integrations: create config dir: %w", err)
+		}
+		if err := backupIfExists(configFile); err != nil {
+			return InstallResult{}, fmt.Errorf("integrations: backup config: %w", err)
+		}
+		if err := os.WriteFile(configFile, patched, 0o600); err != nil {
+			return InstallResult{}, fmt.Errorf("integrations: write config: %w", err)
+		}
 	}
 
 	action := "installed"
@@ -110,8 +113,10 @@ func Uninstall(def Definition, dirs Dirs) error {
 		if err != nil {
 			return fmt.Errorf("integrations: unpatch config: %w", err)
 		}
-		if err := os.WriteFile(configFile, patched, 0o600); err != nil {
-			return fmt.Errorf("integrations: write config: %w", err)
+		if patched != nil {
+			if err := os.WriteFile(configFile, patched, 0o600); err != nil {
+				return fmt.Errorf("integrations: write config: %w", err)
+			}
 		}
 	}
 

--- a/internal/integrations/installer_test.go
+++ b/internal/integrations/installer_test.go
@@ -324,15 +324,16 @@ func TestUninstallOpenCodeRemovesLegacyRegistration(t *testing.T) {
 		t.Fatalf("Install() error = %v", err)
 	}
 
+	// Marshal rather than interpolate: on Windows TemplateFile contains
+	// backslashes, which are escape sequences inside a JSON string literal.
 	configPath := filepath.Join(root, ".config", "opencode", "opencode.json")
-	legacy := `{
-  "plugin": [
-    "file://` + result.TemplateFile + `",
-    "some-other-plugin"
-  ]
-}
-`
-	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
+	legacy, err := json.Marshal(map[string]any{
+		"plugin": []string{"file://" + result.TemplateFile, "some-other-plugin"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, legacy, 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/integrations/installer_test.go
+++ b/internal/integrations/installer_test.go
@@ -607,3 +607,71 @@ func TestUpgrade(t *testing.T) {
 		})
 	}
 }
+
+// Uninstalling from a JSONC config must excise only our registration and leave
+// every comment intact. Re-serializing through encoding/json would strip them,
+// which is the same harm as creating a competing strict-JSON file.
+func TestUninstallOpenCodePreservesJSONCComments(t *testing.T) {
+	root := t.TempDir()
+	dirs := testDirs(root)
+	def, _ := DefinitionByID(OpenCodeID)
+
+	result, err := Install(def, dirs)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	configDir := filepath.Join(root, ".config", "opencode")
+	jsoncPath := filepath.Join(configDir, "opencode.jsonc")
+	original := `{
+  // the model I actually use
+  "model": "anthropic/claude-sonnet-4-5",
+  "plugin": [
+    "keep-me",
+    // ours, added by an older openusage
+    ` + string(mustJSONString(t, "file://"+result.TemplateFile)) + `
+  ]
+}
+`
+	if err := os.WriteFile(jsoncPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Uninstall(def, dirs); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+
+	got, err := os.ReadFile(jsoncPath)
+	if err != nil {
+		t.Fatalf("read jsonc: %v", err)
+	}
+	text := string(got)
+
+	if strings.Contains(text, "openusage-telemetry.ts") {
+		t.Errorf("our registration survived uninstall:\n%s", text)
+	}
+	if !strings.Contains(text, "// the model I actually use") {
+		t.Errorf("uninstall stripped a comment:\n%s", text)
+	}
+	if !strings.Contains(text, `"keep-me"`) {
+		t.Errorf("uninstall dropped an unrelated plugin:\n%s", text)
+	}
+	// The result must still parse, and the dangling comma left by removing the
+	// last array element must be gone so it is valid strict JSON too.
+	var cfg map[string]any
+	if err := json.Unmarshal(stripJSONC(got), &cfg); err != nil {
+		t.Fatalf("result does not parse after comment stripping: %v\n%s", err, text)
+	}
+	if list, _ := cfg["plugin"].([]any); len(list) != 1 || list[0] != "keep-me" {
+		t.Errorf("plugin list = %#v, want [keep-me]", cfg["plugin"])
+	}
+}
+
+func mustJSONString(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/internal/integrations/installer_test.go
+++ b/internal/integrations/installer_test.go
@@ -150,30 +150,70 @@ func TestInstallOpenCode(t *testing.T) {
 		t.Fatal("template missing version marker")
 	}
 
-	// Verify config has plugin entry.
-	configData, err := os.ReadFile(result.ConfigFile)
+	// The plugin lands in OpenCode's global plugin directory, which OpenCode
+	// loads automatically, so install must not write a config file — doing so
+	// would create an opencode.json for users who deliberately have none.
+	if _, err := os.Stat(result.ConfigFile); !os.IsNotExist(err) {
+		t.Fatalf("install created a config file at %s (err = %v), want none", result.ConfigFile, err)
+	}
+
+	// And it must still report READY rather than PARTIAL.
+	st := def.Detector(dirs)
+	if !st.Configured {
+		t.Errorf("Configured = false after install; auto-discovery should count as configured")
+	}
+	if st.State != "ready" {
+		t.Errorf("State = %q, want %q", st.State, "ready")
+	}
+}
+
+// An authoritative opencode.jsonc must be read as JSONC and left alone rather
+// than shadowed by a competing strict-JSON opencode.json. Regression test for
+// the PARTIAL false negative in #313.
+func TestInstallOpenCodeLeavesJSONCConfigUntouched(t *testing.T) {
+	root := t.TempDir()
+	dirs := testDirs(root)
+	def, ok := DefinitionByID(OpenCodeID)
+	if !ok {
+		t.Fatal("OpenCodeID definition not found")
+	}
+
+	configDir := filepath.Join(root, ".config", "opencode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsoncPath := filepath.Join(configDir, "opencode.jsonc")
+	original := `{
+  // the model I actually use
+  "model": "anthropic/claude-sonnet-4-5",
+}
+`
+	if err := os.WriteFile(jsoncPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Install(def, dirs)
 	if err != nil {
-		t.Fatalf("read config file: %v", err)
+		t.Fatalf("Install() error = %v", err)
 	}
-	var cfg map[string]any
-	if err := json.Unmarshal(configData, &cfg); err != nil {
-		t.Fatalf("parse config: %v", err)
+
+	if result.ConfigFile != jsoncPath {
+		t.Errorf("ConfigFile = %q, want the existing jsonc at %q", result.ConfigFile, jsoncPath)
 	}
-	list, ok := cfg["plugin"].([]any)
-	if !ok || len(list) == 0 {
-		t.Fatal("config missing plugin list")
+	got, err := os.ReadFile(jsoncPath)
+	if err != nil {
+		t.Fatalf("read jsonc: %v", err)
 	}
-	wantURL := "file://" + result.TemplateFile
-	found := false
-	for _, item := range list {
-		text, _ := item.(string)
-		if text == wantURL {
-			found = true
-			break
-		}
+	if string(got) != original {
+		t.Errorf("opencode.jsonc was rewritten:\n--- got ---\n%s\n--- want ---\n%s", got, original)
 	}
-	if !found {
-		t.Fatalf("plugin list missing %q: %#v", wantURL, list)
+	if _, err := os.Stat(filepath.Join(configDir, "opencode.json")); !os.IsNotExist(err) {
+		t.Error("install created a competing opencode.json next to the authoritative .jsonc")
+	}
+
+	st := def.Detector(dirs)
+	if st.State != "ready" {
+		t.Errorf("State = %q, want %q with a JSONC config", st.State, "ready")
 	}
 }
 
@@ -265,7 +305,42 @@ func TestUninstallOpenCode(t *testing.T) {
 		t.Fatal("template file still exists after uninstall")
 	}
 
-	configData, err := os.ReadFile(result.ConfigFile)
+	// Install wrote no config, so uninstall has none to clean up.
+	if _, err := os.Stat(result.ConfigFile); !os.IsNotExist(err) {
+		t.Fatalf("config file exists at %s (err = %v), want none", result.ConfigFile, err)
+	}
+}
+
+// Configs written by older openusage versions carry an explicit file:// plugin
+// entry pointing at the artifact uninstall deletes. That entry must still be
+// removed, and unrelated plugins left in place.
+func TestUninstallOpenCodeRemovesLegacyRegistration(t *testing.T) {
+	root := t.TempDir()
+	dirs := testDirs(root)
+	def, _ := DefinitionByID(OpenCodeID)
+
+	result, err := Install(def, dirs)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	configPath := filepath.Join(root, ".config", "opencode", "opencode.json")
+	legacy := `{
+  "plugin": [
+    "file://` + result.TemplateFile + `",
+    "some-other-plugin"
+  ]
+}
+`
+	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Uninstall(def, dirs); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+
+	configData, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read config: %v", err)
 	}
@@ -274,8 +349,8 @@ func TestUninstallOpenCode(t *testing.T) {
 		t.Fatalf("parse config: %v", err)
 	}
 	list, _ := cfg["plugin"].([]any)
-	if len(list) > 0 {
-		t.Fatalf("config still has plugins after uninstall: %#v", list)
+	if len(list) != 1 || list[0] != "some-other-plugin" {
+		t.Fatalf("plugin list = %#v, want only [\"some-other-plugin\"]", list)
 	}
 }
 
@@ -315,6 +390,15 @@ func TestInstallIdempotent(t *testing.T) {
 				t.Fatalf("second result.Action = %q, want %q", result2.Action, wantAction)
 			}
 
+			// OpenCode relies on plugin-directory auto-discovery and writes
+			// no config, so there is nothing that could duplicate.
+			if id == OpenCodeID {
+				if _, err := os.Stat(result1.ConfigFile); !os.IsNotExist(err) {
+					t.Fatalf("install created a config file at %s (err = %v), want none", result1.ConfigFile, err)
+				}
+				return
+			}
+
 			// Config should not have duplicate entries.
 			configData, err := os.ReadFile(result1.ConfigFile)
 			if err != nil {
@@ -345,15 +429,6 @@ func TestInstallIdempotent(t *testing.T) {
 				}
 				if notifyCount != 1 {
 					t.Fatalf("expected 1 notify key line, found %d in:\n%s", notifyCount, string(configData))
-				}
-			case OpenCodeID:
-				var cfg map[string]any
-				if err := json.Unmarshal(configData, &cfg); err != nil {
-					t.Fatalf("parse config: %v", err)
-				}
-				list, _ := cfg["plugin"].([]any)
-				if len(list) != 1 {
-					t.Fatalf("expected 1 plugin entry, got %d", len(list))
 				}
 			}
 		})

--- a/internal/integrations/jsonc.go
+++ b/internal/integrations/jsonc.go
@@ -1,0 +1,139 @@
+package integrations
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// decodeJSONC unmarshals JSON that may carry JSONC extensions into v.
+//
+// OpenCode documents both `opencode.json` and `opencode.jsonc` as valid config
+// formats (https://opencode.ai/docs/config/#format), and encoding/json rejects
+// the comments and trailing commas a .jsonc file is allowed to contain. Strip
+// those before handing the bytes to the standard decoder.
+func decodeJSONC(data []byte, v any) error {
+	if err := json.Unmarshal(stripJSONC(data), v); err != nil {
+		return fmt.Errorf("integrations: decode jsonc: %w", err)
+	}
+	return nil
+}
+
+// stripJSONC removes // and /* */ comments and trailing commas from data,
+// leaving byte offsets of the surviving content untouched where possible so
+// decoder error positions stay meaningful. String literals are passed through
+// verbatim so a "//" inside a value survives.
+func stripJSONC(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+
+	const (
+		text = iota
+		inString
+		inLineComment
+		inBlockComment
+	)
+
+	state := text
+	escaped := false
+
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+
+		switch state {
+		case inString:
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				state = text
+			}
+
+		case inLineComment:
+			// Keep the newline so line numbers survive.
+			if c == '\n' {
+				out = append(out, c)
+				state = text
+			}
+
+		case inBlockComment:
+			// Keep newlines so line numbers survive.
+			if c == '\n' {
+				out = append(out, c)
+				continue
+			}
+			if c == '*' && i+1 < len(data) && data[i+1] == '/' {
+				i++
+				state = text
+			}
+
+		default: // text
+			switch {
+			case c == '"':
+				out = append(out, c)
+				state = inString
+			case c == '/' && i+1 < len(data) && data[i+1] == '/':
+				i++
+				state = inLineComment
+			case c == '/' && i+1 < len(data) && data[i+1] == '*':
+				i++
+				state = inBlockComment
+			default:
+				out = append(out, c)
+			}
+		}
+	}
+
+	return removeTrailingCommas(out)
+}
+
+// removeTrailingCommas drops a comma that is followed only by whitespace and a
+// closing brace or bracket. JSONC allows it; encoding/json does not.
+func removeTrailingCommas(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+	inString := false
+	escaped := false
+
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+
+		if inString {
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+
+		if c == '"' {
+			inString = true
+			out = append(out, c)
+			continue
+		}
+
+		if c == ',' {
+			j := i + 1
+			for j < len(data) && isJSONSpace(data[j]) {
+				j++
+			}
+			if j < len(data) && (data[j] == '}' || data[j] == ']') {
+				// Drop the comma, keep the whitespace that follows it.
+				continue
+			}
+		}
+
+		out = append(out, c)
+	}
+
+	return out
+}
+
+func isJSONSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}

--- a/internal/integrations/jsonc_test.go
+++ b/internal/integrations/jsonc_test.go
@@ -1,0 +1,75 @@
+package integrations
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDecodeJSONC(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  map[string]any
+	}{
+		{
+			name:  "plain json is unaffected",
+			input: `{"plugin":["a"]}`,
+			want:  map[string]any{"plugin": []any{"a"}},
+		},
+		{
+			name: "line comments",
+			input: `{
+  // which model to use
+  "model": "sonnet" // trailing
+}`,
+			want: map[string]any{"model": "sonnet"},
+		},
+		{
+			name: "block comment spanning lines",
+			input: `{
+  /* a note
+     over two lines */
+  "model": "sonnet"
+}`,
+			want: map[string]any{"model": "sonnet"},
+		},
+		{
+			name:  "trailing comma in object and array",
+			input: "{\n  \"plugin\": [\n    \"a\",\n  ],\n}",
+			want:  map[string]any{"plugin": []any{"a"}},
+		},
+		{
+			name:  "comment-like sequences inside strings survive",
+			input: `{"plugin":["file:///tmp/a.ts","https://example.com/x","/*not a comment*/"]}`,
+			want: map[string]any{"plugin": []any{
+				"file:///tmp/a.ts",
+				"https://example.com/x",
+				"/*not a comment*/",
+			}},
+		},
+		{
+			name:  "escaped quote before a comment marker",
+			input: `{"a":"say \"hi\"" // done` + "\n}",
+			want:  map[string]any{"a": `say "hi"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got map[string]any
+			if err := decodeJSONC([]byte(tt.input), &got); err != nil {
+				t.Fatalf("decodeJSONC() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("decodeJSONC() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeJSONCRejectsInvalid(t *testing.T) {
+	var got map[string]any
+	if err := decodeJSONC([]byte(`{"a": }`), &got); err == nil {
+		t.Fatal("decodeJSONC() error = nil, want a decode error")
+	}
+}

--- a/internal/integrations/registry.go
+++ b/internal/integrations/registry.go
@@ -58,7 +58,12 @@ type Definition struct {
 	// (e.g., CODEX_CONFIG_DIR, CLAUDE_SETTINGS_FILE).
 	ConfigFileFunc func(dirs Dirs) string
 	ConfigFormat   ConfigFormat
-	ConfigPatcher  ConfigPatchFunc
+	// ConfigPatcher returns the new config file contents. Returning nil
+	// bytes with a nil error means "no config change required": the config
+	// file is then left exactly as it is, and is not created if absent.
+	// Used by tools that discover the integration without an explicit
+	// registration entry.
+	ConfigPatcher ConfigPatchFunc
 
 	Detector DetectFunc
 


### PR DESCRIPTION
Closes #313

## Problem

OpenUsage reported the OpenCode integration as `PARTIAL` / "Installed but not configured" even though the plugin was loaded and telemetry was flowing. Two assumptions were wrong:

1. **An explicit `plugin` entry was required.** OpenCode loads every local file in its global plugin directory automatically ([docs](https://opencode.ai/docs/plugins/#from-local-files)). The plugin is written straight into that directory, so it is active the moment it lands — the registration entry was never needed.
2. **Config was parsed as strict JSON only.** OpenCode also accepts `opencode.jsonc` ([docs](https://opencode.ai/docs/config/#format)). `encoding/json` rejects the comments a `.jsonc` may contain, so inspection silently failed and the integration looked unconfigured.

Reported and diagnosed by @balaji-dutt, who identified both causes precisely.

## Changes

- **Detector**: a versioned plugin in the auto-discovery directory counts as configured. An explicit registration still counts too, so configs written by older versions keep reporting `READY`.
- **JSONC**: new `decodeJSONC` strips comments and trailing commas (preserving string contents and line numbers) and is used wherever config is inspected. `ConfigFileFunc` prefers an existing `opencode.jsonc` over creating a competing `opencode.json` beside it.
- **Install writes no config.** Registration is redundant under auto-discovery, and re-serializing a `.jsonc` through `encoding/json` would strip the comments that make it a `.jsonc`. Install also no longer creates an `opencode.json` for users who deliberately have none.
- **Uninstall still cleans up** legacy `file://` entries written by earlier versions, so upgrading needs no manual work.
- **New seam**: a `ConfigPatcher` returning `nil` bytes means "no config change required" — the config file is left untouched and not created. Documented on `Definition.ConfigPatcher`.

## Tests

- `TestDecodeJSONC` — line/block comments, trailing commas, comment-like sequences inside strings, escaped quotes; plus a rejection case for genuinely invalid JSON.
- `TestInstallOpenCode` — asserts no config file is created and that status is `ready`, not `partial`.
- `TestInstallOpenCodeLeavesJSONCConfigUntouched` — an authoritative `.jsonc` is byte-for-byte preserved, no competing `.json` appears, status is `ready`.
- `TestUninstallOpenCodeRemovesLegacyRegistration` — a legacy `file://` entry is removed while an unrelated plugin is left in place.
- Existing `TestInstallIdempotent` / `TestLifecycle_*` updated for the new contract.

## Docs

`docs/site/docs/daemon/integrations.md` (integration table + opencode section, including the legacy-registration note), `docs/site/docs/reference/paths.md`, `docs/site/docs/guides/headless-servers.md`, `docs/TELEMETRY_INTEGRATIONS.md`. Docs site builds with `[SUCCESS]` and no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNSGtKppEApHmGH9hD4BN1