### PR TITLE
perf(telemetry): skip the dedup enrich UPDATE when the merge changes nothing

### DIFF
--- a/internal/telemetry/dedup_write_test.go
+++ b/internal/telemetry/dedup_write_test.go
@@ -1,0 +1,229 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+// totalChanges reports SQLite's cumulative row-modification counter for the
+// connection. On a dedup hit the enrich UPDATE is the only statement that can
+// move it, which makes it a precise probe for "did we write anything?".
+func totalChanges(t *testing.T, db *sql.DB) int64 {
+	t.Helper()
+	var n int64
+	if err := db.QueryRow(`SELECT total_changes()`).Scan(&n); err != nil {
+		t.Fatalf("total_changes(): %v", err)
+	}
+	return n
+}
+
+func usageEventRequest() IngestRequest {
+	input := int64(120)
+	output := int64(40)
+	total := int64(160)
+	return IngestRequest{
+		SourceSystem:  SourceSystem("claude_code"),
+		SourceChannel: SourceChannelHook,
+		OccurredAt:    time.Date(2026, time.August, 20, 9, 0, 0, 0, time.UTC),
+		ProviderID:    "claude_code",
+		AccountID:     "claude-code",
+		AgentName:     "claude_code",
+		EventType:     EventTypeMessageUsage,
+		SessionID:     "sess-1",
+		MessageID:     "msg-1",
+		ModelRaw:      "claude-opus-4-6",
+		TokenUsage: core.TokenUsage{
+			InputTokens:  &input,
+			OutputTokens: &output,
+			TotalTokens:  &total,
+			Requests:     int64Ptr(1),
+		},
+	}
+}
+
+// Local-file sources re-import their recent history every collection cycle, so
+// the same event is ingested over and over. Rewriting twenty columns for a
+// merge that changes nothing dirtied the row page and every index covering it
+// on every cycle, and all of it landed in the WAL — the write amplification
+// reported in #318. A no-op merge must not write.
+func TestIngest_DuplicateWithIdenticalFieldsPerformsNoWrite(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "telemetry.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	req := usageEventRequest()
+
+	first, err := store.Ingest(ctx, req)
+	if err != nil {
+		t.Fatalf("first Ingest: %v", err)
+	}
+	if first.Deduped {
+		t.Fatal("first ingest reported Deduped = true")
+	}
+
+	before := totalChanges(t, store.db)
+
+	for i := 0; i < 3; i++ {
+		again, err := store.Ingest(ctx, req)
+		if err != nil {
+			t.Fatalf("re-Ingest %d: %v", i, err)
+		}
+		if !again.Deduped {
+			t.Fatalf("re-Ingest %d reported Deduped = false", i)
+		}
+		if again.EventID != first.EventID {
+			t.Fatalf("re-Ingest %d event id = %q, want %q", i, again.EventID, first.EventID)
+		}
+	}
+
+	if after := totalChanges(t, store.db); after != before {
+		t.Errorf("re-ingesting an identical event wrote %d row change(s), want 0", after-before)
+	}
+}
+
+// The skip must not swallow a genuine enrichment: a later event carrying a
+// field the stored row lacks still has to be merged in.
+func TestIngest_DuplicateWithNewFieldStillWrites(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "telemetry.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+
+	sparse := usageEventRequest()
+	sparse.ModelRaw = ""
+	sparse.CostUSD = nil
+	if _, err := store.Ingest(ctx, sparse); err != nil {
+		t.Fatalf("first Ingest: %v", err)
+	}
+
+	before := totalChanges(t, store.db)
+
+	enriched := usageEventRequest()
+	cost := 0.42
+	enriched.CostUSD = &cost
+	res, err := store.Ingest(ctx, enriched)
+	if err != nil {
+		t.Fatalf("enriching Ingest: %v", err)
+	}
+	if !res.Deduped {
+		t.Fatal("enriching ingest reported Deduped = false")
+	}
+	if after := totalChanges(t, store.db); after == before {
+		t.Fatal("enriching ingest wrote nothing; the merge was skipped")
+	}
+
+	var (
+		model sql.NullString
+		got   sql.NullFloat64
+	)
+	if err := store.db.QueryRow(
+		`SELECT model_raw, cost_usd FROM usage_events WHERE event_id = ?`, res.EventID,
+	).Scan(&model, &got); err != nil {
+		t.Fatalf("read back event: %v", err)
+	}
+	if model.String != "claude-opus-4-6" {
+		t.Errorf("model_raw = %q, want %q", model.String, "claude-opus-4-6")
+	}
+	if !got.Valid || got.Float64 != cost {
+		t.Errorf("cost_usd = %#v, want %v", got, cost)
+	}
+
+	// And a second pass over the now-complete row writes nothing again.
+	settled := totalChanges(t, store.db)
+	if _, err := store.Ingest(ctx, enriched); err != nil {
+		t.Fatalf("settled Ingest: %v", err)
+	}
+	if after := totalChanges(t, store.db); after != settled {
+		t.Errorf("re-ingest after enrichment wrote %d row change(s), want 0", after-settled)
+	}
+}
+
+func TestCanonicalEventDiffers(t *testing.T) {
+	base := storedCanonicalEvent{
+		EventID:     "e1",
+		ProviderID:  sql.NullString{String: "codex", Valid: true},
+		InputTokens: sql.NullInt64{Int64: 10, Valid: true},
+		CostUSD:     sql.NullFloat64{Float64: 1.5, Valid: true},
+		Status:      "ok",
+	}
+	matching := canonicalEventFields{
+		providerID:  "codex",
+		inputTokens: int64Ptr(10),
+		costUSD:     float64Ptr(1.5),
+		status:      EventStatus("ok"),
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*canonicalEventFields)
+		want   bool
+	}{
+		{name: "identical merge", mutate: func(*canonicalEventFields) {}, want: false},
+		{
+			name:   "blank string matches a NULL column",
+			mutate: func(f *canonicalEventFields) { f.sessionID = "   " },
+			want:   false,
+		},
+		{
+			name:   "nil pointer matches a NULL column",
+			mutate: func(f *canonicalEventFields) { f.requests = nil },
+			want:   false,
+		},
+		{
+			name:   "changed string",
+			mutate: func(f *canonicalEventFields) { f.providerID = "claude_code" },
+			want:   true,
+		},
+		{
+			name:   "string cleared to NULL",
+			mutate: func(f *canonicalEventFields) { f.providerID = "" },
+			want:   true,
+		},
+		{
+			name:   "new value for a NULL column",
+			mutate: func(f *canonicalEventFields) { f.sessionID = "sess-9" },
+			want:   true,
+		},
+		{
+			name:   "changed int",
+			mutate: func(f *canonicalEventFields) { f.inputTokens = int64Ptr(11) },
+			want:   true,
+		},
+		{
+			name:   "int cleared to NULL",
+			mutate: func(f *canonicalEventFields) { f.inputTokens = nil },
+			want:   true,
+		},
+		{
+			name:   "changed float",
+			mutate: func(f *canonicalEventFields) { f.costUSD = float64Ptr(1.6) },
+			want:   true,
+		},
+		{
+			name:   "changed status",
+			mutate: func(f *canonicalEventFields) { f.status = EventStatus("error") },
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged := matching
+			tt.mutate(&merged)
+			if got := canonicalEventDiffers(base, merged); got != tt.want {
+				t.Fatalf("canonicalEventDiffers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/telemetry/store.go
+++ b/internal/telemetry/store.go
@@ -672,6 +672,38 @@ func enrichEventByDedupKey(ctx context.Context, tx *sql.Tx, dedupKey string, nor
 	requests := chooseInt64(current.Requests, norm.Requests, override)
 	status := chooseStatus(current.Status, norm.Status, override)
 
+	// A re-ingested event usually merges to exactly what is already stored:
+	// local-file sources re-import their recent history every collection
+	// cycle, and a hook event often arrives again from the session file. The
+	// UPDATE below rewrites twenty columns, dirtying the row's page and every
+	// index covering them, and all of it lands in the WAL. Issuing it for a
+	// merge that changes nothing turned steady-state ingest into sustained
+	// write amplification (#318), so compare first and skip the no-op.
+	if !canonicalEventDiffers(current, canonicalEventFields{
+		providerID:       providerID,
+		accountID:        accountID,
+		workspaceID:      workspaceID,
+		sessionID:        sessionID,
+		turnID:           turnID,
+		messageID:        messageID,
+		toolCallID:       toolCallID,
+		modelRaw:         modelRaw,
+		modelCanonical:   modelCanonical,
+		modelLineage:     modelLineage,
+		toolName:         toolName,
+		inputTokens:      inputTokens,
+		outputTokens:     outputTokens,
+		reasoningTokens:  reasoningTokens,
+		cacheReadTokens:  cacheReadTokens,
+		cacheWriteTokens: cacheWriteTokens,
+		totalTokens:      totalTokens,
+		costUSD:          costUSD,
+		requests:         requests,
+		status:           status,
+	}) {
+		return nil
+	}
+
 	_, err = tx.ExecContext(ctx, `
 		UPDATE usage_events
 		SET
@@ -720,6 +752,113 @@ func enrichEventByDedupKey(ctx context.Context, tx *sql.Tx, dedupKey string, nor
 		current.EventID,
 	)
 	return err
+}
+
+// canonicalEventFields is the merged result enrichEventByDedupKey is about to
+// write, in the same nullable-or-zero form the UPDATE binds.
+type canonicalEventFields struct {
+	providerID       string
+	accountID        string
+	workspaceID      string
+	sessionID        string
+	turnID           string
+	messageID        string
+	toolCallID       string
+	modelRaw         string
+	modelCanonical   string
+	modelLineage     string
+	toolName         string
+	inputTokens      *int64
+	outputTokens     *int64
+	reasoningTokens  *int64
+	cacheReadTokens  *int64
+	cacheWriteTokens *int64
+	totalTokens      *int64
+	costUSD          *float64
+	requests         *int64
+	status           EventStatus
+}
+
+// canonicalEventDiffers reports whether writing merged would change the stored
+// row. Each comparison mirrors the binder the UPDATE uses for that column, so
+// a value the binder would store as NULL compares equal to a NULL column:
+// nullable() nulls a blank string, and nullableInt64/nullableFloat64 null a nil
+// pointer. Getting that mapping wrong would either skip a real update or never
+// skip at all, so the binders are the reference, not the Go zero value.
+func canonicalEventDiffers(current storedCanonicalEvent, merged canonicalEventFields) bool {
+	strFields := []struct {
+		stored sql.NullString
+		next   string
+	}{
+		{current.ProviderID, merged.providerID},
+		{current.AccountID, merged.accountID},
+		{current.WorkspaceID, merged.workspaceID},
+		{current.SessionID, merged.sessionID},
+		{current.TurnID, merged.turnID},
+		{current.MessageID, merged.messageID},
+		{current.ToolCallID, merged.toolCallID},
+		{current.ModelRaw, merged.modelRaw},
+		{current.ModelCanonical, merged.modelCanonical},
+		{current.ModelLineageID, merged.modelLineage},
+		{current.ToolName, merged.toolName},
+	}
+	for _, f := range strFields {
+		if nullStringDiffers(f.stored, f.next) {
+			return true
+		}
+	}
+
+	intFields := []struct {
+		stored sql.NullInt64
+		next   *int64
+	}{
+		{current.InputTokens, merged.inputTokens},
+		{current.OutputTokens, merged.outputTokens},
+		{current.Reasoning, merged.reasoningTokens},
+		{current.CacheRead, merged.cacheReadTokens},
+		{current.CacheWrite, merged.cacheWriteTokens},
+		{current.TotalTokens, merged.totalTokens},
+		{current.Requests, merged.requests},
+	}
+	for _, f := range intFields {
+		if nullInt64Differs(f.stored, f.next) {
+			return true
+		}
+	}
+
+	if nullFloat64Differs(current.CostUSD, merged.costUSD) {
+		return true
+	}
+
+	// status is bound as a plain string, never NULL.
+	return current.Status != string(merged.status)
+}
+
+// nullStringDiffers compares a stored column against what nullable(next) would
+// write: NULL for a blank string, otherwise next verbatim.
+func nullStringDiffers(stored sql.NullString, next string) bool {
+	if strings.TrimSpace(next) == "" {
+		return stored.Valid
+	}
+	return !stored.Valid || stored.String != next
+}
+
+// nullInt64Differs compares a stored column against what nullableInt64(next)
+// would write: NULL for a nil pointer, otherwise *next.
+func nullInt64Differs(stored sql.NullInt64, next *int64) bool {
+	if next == nil {
+		return stored.Valid
+	}
+	return !stored.Valid || stored.Int64 != *next
+}
+
+// nullFloat64Differs compares a stored column against what
+// nullableFloat64(next) would write: NULL for a nil pointer, otherwise *next.
+func nullFloat64Differs(stored sql.NullFloat64, next *float64) bool {
+	if next == nil {
+		return stored.Valid
+	}
+	return !stored.Valid || stored.Float64 != *next
 }
 
 func sourceChannelPriority(channel SourceChannel) int {


### PR DESCRIPTION
Refs #318

## Problem

`enrichEventByDedupKey` ran an unconditional twenty-column `UPDATE usage_events` on **every** dedup hit — including the overwhelmingly common case where every merged value already equalled what was stored.

Each of those UPDATEs dirties the row's page plus every index covering the updated columns (`provider_id`, `account_id`, `session_id`, `model_*`, `status`, …), and all of it lands in the WAL.

That interacts badly with a deliberate design choice documented at `internal/daemon/server_collect.go:101`:

> No ingest-time age filter: local-file sources re-import the last ~90d of history each cycle

So a steady-state daemon replayed that UPDATE across its entire hot window every 20–30 seconds. On @backcho's system that produced **~235GB of writes against a 66MB database** (≈12MB per genuinely-new event) with 10–17 fsyncs/sec, pushing an HDD-backed WSL2 VHDX to ~92% utilization.

## Fix

Compare the merged fields against the stored row and return early when writing them would change nothing.

The comparison deliberately mirrors each column's binder rather than using Go zero values: `nullable()` stores a blank string as `NULL`, and `nullableInt64`/`nullableFloat64` store a nil pointer as `NULL`. So a value that *would* be written as `NULL` compares equal to an existing `NULL` column. Getting that mapping wrong would either skip a real update or never skip at all, which is why the binders are the reference — noted in the code.

Genuine enrichment is untouched: a later event carrying a field the stored row lacks still merges. Only the settled re-ingest is skipped.

## Verification

`TestIngest_DuplicateWithIdenticalFieldsPerformsNoWrite` probes SQLite's `total_changes()`, which on a dedup hit can only be moved by this UPDATE. I confirmed the test is not vacuous by disabling the early return:

```
--- FAIL: TestIngest_DuplicateWithIdenticalFieldsPerformsNoWrite
    dedup_write_test.go:88: re-ingesting an identical event wrote 3 row change(s), want 0
```

With the fix: 0 writes for 3 duplicate ingests.

Also added:
- `TestIngest_DuplicateWithNewFieldStillWrites` — a sparse row is genuinely enriched (model + cost merged in and read back), and the *following* re-ingest of the now-complete row writes nothing.
- `TestCanonicalEventDiffers` — table-driven over identical merges, blank-string/nil-pointer vs `NULL`, and each mutation class (string changed/cleared, int changed/cleared, float, status).

`go test -race ./...` passes; `golangci-lint` reports 0 issues.

## Scope note

This is one of several contributors to daemon I/O in that area. It is independent of #269 (which stops the redundant *reparse* for unchanged files) and complementary: this one removes the redundant *write* that remains whenever an event legitimately arrives twice — a hook event that also appears in the session file, or a changed file replayed in full. I have not closed #318, since the reporter should confirm the improvement against their workload before we call it done.

## Docs

No user-facing docs change: this is an internal write-path optimization with no change to behavior, config, or output. Storage docs already describe dedup without promising a write per duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNSGtKppEApHmGH9hD4BN1