### PR TITLE
fix(telemetry): stop retention blanking the limit_snapshot the dashboard reads

### DIFF
--- a/docs/site/docs/daemon/storage.md
+++ b/docs/site/docs/daemon/storage.md
@@ -125,7 +125,15 @@ The daemon runs, in order each cycle:
    you lose the per-turn timeline beyond the hot window, not the totals or
    breakdowns.
 3. **Payload pruning** — `PruneRawEventPayloads` clears the heavy payload blob
-   from old raw rows.
+   from old raw rows, one hour after ingest. Everything the dashboard needs from
+   a usage event has already been extracted into `usage_events` columns by then,
+   so the blob is only replay/debug detail.
+
+   One exception: the newest `limit_snapshot` per provider/account keeps its
+   payload permanently. That payload *is* the provider's quota state — it is
+   what the daemon reads back to rebuild a tile's metrics, and no column in
+   `usage_events` can substitute for it. Superseded snapshots are still cleared,
+   and they are the bulk of the volume.
 
 ```json
 {

--- a/internal/telemetry/balance_observations.go
+++ b/internal/telemetry/balance_observations.go
@@ -266,12 +266,19 @@ func (s *Store) PruneBalanceObservations(ctx context.Context, retentionDays int)
 		retentionDays = minRetentionDays
 	}
 
+	// observed_at is RFC3339Nano, so the horizons are rendered in Go rather
+	// than with datetime('now', ...) — see Store.retentionCutoff for why the
+	// two forms do not compare correctly within the same day.
+	horizon := s.retentionCutoff(time.Duration(retentionDays) * 24 * time.Hour)
+	sevenDays := s.retentionCutoff(7 * 24 * time.Hour)
+	fortyEightHours := s.retentionCutoff(48 * time.Hour)
+
 	var total int64
 	// 1. Hard delete beyond the retention horizon.
 	if res, err := s.db.ExecContext(ctx, `
 		DELETE FROM balance_observations
-		WHERE observed_at < datetime('now', ?)
-	`, fmt.Sprintf("-%d day", retentionDays)); err == nil {
+		WHERE observed_at < ?
+	`, horizon); err == nil {
 		n, _ := res.RowsAffected()
 		total += n
 	} else {
@@ -281,13 +288,13 @@ func (s *Store) PruneBalanceObservations(ctx context.Context, retentionDays int)
 	// 2. Thin 7d..horizon to one row per metric per day (keep the earliest).
 	if res, err := s.db.ExecContext(ctx, `
 		DELETE FROM balance_observations
-		WHERE observed_at < datetime('now', '-7 day')
+		WHERE observed_at < ?
 		  AND rowid NOT IN (
 			SELECT MIN(rowid) FROM balance_observations
-			WHERE observed_at < datetime('now', '-7 day')
+			WHERE observed_at < ?
 			GROUP BY provider_id, account_id, metric_key, date(observed_at)
 		  )
-	`); err == nil {
+	`, sevenDays, sevenDays); err == nil {
 		n, _ := res.RowsAffected()
 		total += n
 	} else {
@@ -297,15 +304,15 @@ func (s *Store) PruneBalanceObservations(ctx context.Context, retentionDays int)
 	// 3. Thin 48h..7d to one row per metric per hour (keep the earliest).
 	if res, err := s.db.ExecContext(ctx, `
 		DELETE FROM balance_observations
-		WHERE observed_at < datetime('now', '-48 hours')
-		  AND observed_at >= datetime('now', '-7 day')
+		WHERE observed_at < ?
+		  AND observed_at >= ?
 		  AND rowid NOT IN (
 			SELECT MIN(rowid) FROM balance_observations
-			WHERE observed_at < datetime('now', '-48 hours')
-			  AND observed_at >= datetime('now', '-7 day')
+			WHERE observed_at < ?
+			  AND observed_at >= ?
 			GROUP BY provider_id, account_id, metric_key, strftime('%Y-%m-%dT%H', observed_at)
 		  )
-	`); err == nil {
+	`, fortyEightHours, sevenDays, fortyEightHours, sevenDays); err == nil {
 		n, _ := res.RowsAffected()
 		total += n
 	} else {

--- a/internal/telemetry/limit_snapshot_retention_test.go
+++ b/internal/telemetry/limit_snapshot_retention_test.go
@@ -1,0 +1,176 @@
+package telemetry
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+func ingestLimitSnapshot(t *testing.T, store *Store, providerID, accountID string, remaining float64, at time.Time) {
+	t.Helper()
+	limit := 20.0
+	snaps := map[string]core.UsageSnapshot{
+		accountID: {
+			ProviderID: providerID,
+			AccountID:  accountID,
+			Timestamp:  at,
+			Status:     core.StatusOK,
+			Metrics: map[string]core.Metric{
+				"plan_spend": {
+					Limit:     &limit,
+					Remaining: &remaining,
+					Unit:      "USD",
+					Window:    "month",
+				},
+			},
+		},
+	}
+	if err := NewQuotaSnapshotIngestor(store).Ingest(context.Background(), snaps); err != nil {
+		t.Fatalf("ingest limit snapshot: %v", err)
+	}
+}
+
+func rawPayloadFor(t *testing.T, store *Store, providerID, accountID string) string {
+	t.Helper()
+	payload, _, found, err := queryLatestLimitSnapshotPayload(context.Background(), store.db, providerID, accountID)
+	if err != nil {
+		t.Fatalf("query latest limit snapshot: %v", err)
+	}
+	if !found {
+		t.Fatal("no limit_snapshot row found")
+	}
+	return payload
+}
+
+// Retention blanked source_payload for every raw event older than an hour,
+// limit_snapshot included. That payload is the read model's only source for a
+// provider's quota metrics, so blanking it left the dashboard hydrating from an
+// empty envelope — a confident UNKNOWN with no metrics that survived a daemon
+// restart because the damage was in the database (#293).
+func TestPruneRawEventPayloads_KeepsLatestLimitSnapshot(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "telemetry.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	ingestLimitSnapshot(t, store, "cursor", "cursor-ide", 12.5, time.Date(2026, 8, 1, 15, 30, 0, 0, time.UTC))
+
+	// retentionHours = 0 makes every row eligible, which is what an old
+	// snapshot looks like once the daemon has been up for a while.
+	if _, err := store.PruneRawEventPayloads(ctx, 0, 1000); err != nil {
+		t.Fatalf("PruneRawEventPayloads: %v", err)
+	}
+
+	if got := rawPayloadFor(t, store, "cursor", "cursor-ide"); got == "{}" {
+		t.Fatal("latest limit_snapshot payload was blanked by retention")
+	}
+
+	// And it still hydrates a real snapshot rather than an UNKNOWN shell.
+	base := map[string]core.UsageSnapshot{
+		"cursor-ide": {ProviderID: "cursor", AccountID: "cursor-ide"},
+	}
+	got, err := applyCanonicalTelemetryViewForTest(ctx, dbPath, base)
+	if err != nil {
+		t.Fatalf("apply canonical telemetry view: %v", err)
+	}
+	snap := got["cursor-ide"]
+	if snap.Status != core.StatusOK {
+		t.Errorf("status = %q, want %q", snap.Status, core.StatusOK)
+	}
+	if m, ok := snap.Metrics["plan_spend"]; !ok || m.Remaining == nil || *m.Remaining != 12.5 {
+		t.Errorf("plan_spend = %+v, want remaining 12.5", snap.Metrics["plan_spend"])
+	}
+}
+
+// Only the newest snapshot per provider/account is protected; the historical
+// ones are never read back and are the bulk of the volume, so they must still
+// be reclaimed.
+func TestPruneRawEventPayloads_StillPrunesSupersededLimitSnapshots(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "telemetry.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	ingestLimitSnapshot(t, store, "cursor", "cursor-ide", 5.0, time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC))
+	ingestLimitSnapshot(t, store, "cursor", "cursor-ide", 7.0, time.Date(2026, 8, 1, 11, 0, 0, 0, time.UTC))
+	ingestLimitSnapshot(t, store, "cursor", "cursor-ide", 9.0, time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC))
+
+	pruned, err := store.PruneRawEventPayloads(ctx, 0, 1000)
+	if err != nil {
+		t.Fatalf("PruneRawEventPayloads: %v", err)
+	}
+	if pruned != 2 {
+		t.Errorf("pruned = %d, want 2 (the two superseded snapshots)", pruned)
+	}
+
+	// The survivor is the newest one.
+	if got := rawPayloadFor(t, store, "cursor", "cursor-ide"); got == "{}" {
+		t.Fatal("newest limit_snapshot payload was blanked")
+	}
+	var blanked int
+	if err := store.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM usage_raw_events WHERE source_payload = '{}'`,
+	).Scan(&blanked); err != nil {
+		t.Fatalf("count blanked: %v", err)
+	}
+	if blanked != 2 {
+		t.Errorf("blanked rows = %d, want 2", blanked)
+	}
+}
+
+// A payload that was already blanked by an older build must not hydrate. This
+// is the half of the fix that repairs existing databases, where the damage is
+// already on disk and no code change can un-blank it.
+func TestDecodeStoredLimitSnapshot_RejectsBlankedPayload(t *testing.T) {
+	for _, payload := range []string{"{}", `{"snapshot":{}}`, `{"snapshot":{"provider_id":"cursor","account_id":"cursor-ide"}}`} {
+		if _, ok := decodeStoredLimitSnapshot("cursor", "cursor-ide", payload, "2026-08-01T15:30:08Z"); ok {
+			t.Errorf("decodeStoredLimitSnapshot(%q) = ok, want rejected as empty", payload)
+		}
+	}
+
+	usable := `{"snapshot":{"status":"OK","metrics":{"plan_spend":{"remaining":3}}}}`
+	if _, ok := decodeStoredLimitSnapshot("cursor", "cursor-ide", usable, "2026-08-01T15:30:08Z"); !ok {
+		t.Error("decodeStoredLimitSnapshot rejected a payload carrying real metrics")
+	}
+}
+
+// The timestamp columns hold time.RFC3339Nano while the retention horizons were
+// built with datetime('now', ...), which renders a space separator. The two
+// forms only sort consistently when the dates differ: within the same day the
+// 'T' outranks the ' ', so a row ingested earlier today compared as newer than
+// the horizon and was never pruned. Retention silently meant "previous calendar
+// days" rather than "older than N hours".
+func TestPruneRawEventPayloads_PrunesWithinTheSameDay(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "telemetry.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	// Fix the clock at midday so "six hours ago" is unambiguously the same
+	// calendar day. With the old comparison this row survived a 1h horizon.
+	noon := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return noon.Add(-6 * time.Hour) }
+
+	ingestLimitSnapshot(t, store, "cursor", "cursor-ide", 5.0, noon.Add(-6*time.Hour))
+	ingestLimitSnapshot(t, store, "cursor", "cursor-ide", 7.0, noon.Add(-5*time.Hour))
+
+	store.now = func() time.Time { return noon }
+
+	pruned, err := store.PruneRawEventPayloads(ctx, 1, 1000)
+	if err != nil {
+		t.Fatalf("PruneRawEventPayloads: %v", err)
+	}
+	if pruned != 1 {
+		t.Fatalf("pruned = %d, want 1 — a six-hour-old row on the same calendar day must be past a 1h horizon", pruned)
+	}
+}

--- a/internal/telemetry/read_model.go
+++ b/internal/telemetry/read_model.go
@@ -27,6 +27,19 @@ type storedLimitSnapshot struct {
 	Diagnostics map[string]string            `json:"diagnostics"`
 }
 
+// isEmpty reports whether the envelope carried no snapshot data at all, which
+// is what a retention-blanked '{}' payload decodes to. Provider and account id
+// are ignored: the caller already knows both, and a payload carrying only
+// those is still telling us nothing about quota state.
+func (s storedLimitSnapshot) isEmpty() bool {
+	return strings.TrimSpace(s.Status) == "" &&
+		strings.TrimSpace(s.Message) == "" &&
+		len(s.Metrics) == 0 &&
+		len(s.Resets) == 0 &&
+		len(s.Attributes) == 0 &&
+		len(s.Diagnostics) == 0
+}
+
 type storedLimitMetric struct {
 	Limit     *float64 `json:"limit"`
 	Remaining *float64 `json:"remaining"`
@@ -306,6 +319,13 @@ func queryLatestLimitSnapshotPayload(
 func decodeStoredLimitSnapshot(providerID, accountID, payload, occurredAt string) (core.UsageSnapshot, bool) {
 	var envelope storedLimitEnvelope
 	if unmarshalErr := json.Unmarshal([]byte(payload), &envelope); unmarshalErr != nil {
+		return core.UsageSnapshot{}, false
+	}
+	// A payload blanked by retention ('{}') unmarshals cleanly into a zero
+	// envelope, so a successful decode is not proof of usable data. Merging
+	// that empty snapshot overwrote the live one with a confident UNKNOWN and
+	// no metrics (#293). Treat it as absent so hydration is skipped instead.
+	if envelope.Snapshot.isEmpty() {
 		return core.UsageSnapshot{}, false
 	}
 

--- a/internal/telemetry/store.go
+++ b/internal/telemetry/store.go
@@ -890,7 +890,7 @@ func (s *Store) PruneOldEvents(ctx context.Context, retentionDays int, rolledThr
 		// detail. Not an error; the next pass (after a rollup) will prune.
 		return 0, false, nil
 	}
-	cutoff := fmt.Sprintf("-%d day", retentionDays)
+	cutoff := s.retentionCutoff(time.Duration(retentionDays) * 24 * time.Hour)
 	for {
 		if ctx.Err() != nil {
 			return deleted, false, nil
@@ -903,7 +903,7 @@ func (s *Store) PruneOldEvents(ctx context.Context, retentionDays int, rolledThr
 			DELETE FROM usage_events
 			WHERE event_id IN (
 				SELECT event_id FROM usage_events
-				WHERE occurred_at < datetime('now', ?)
+				WHERE occurred_at < ?
 				  AND date(occurred_at) <= ?
 				ORDER BY occurred_at ASC
 				LIMIT ?
@@ -949,22 +949,69 @@ func (s *Store) PruneOrphanRawEvents(ctx context.Context, limit int) (int64, err
 	return n, nil
 }
 
+// retentionCutoff renders a horizon as an RFC3339Nano string comparable against
+// the timestamp columns.
+//
+// The columns store time.RFC3339Nano ("2026-08-31T08:57:12.211861Z"), so they
+// must not be compared against datetime('now', ...), which renders a space
+// separator ("2026-08-31 07:57:34"). Those forms only sort consistently when
+// the dates differ: on the same day the 'T' (0x54) outranks the ' ' (0x20), so
+// every row ingested earlier today compares as newer than the horizon and
+// escapes pruning. The horizon effectively became "previous calendar days"
+// instead of "older than N hours".
+//
+// Rendering the bound in Go keeps both sides in one format and, unlike wrapping
+// the column in datetime(), leaves the index on that column usable.
+func (s *Store) retentionCutoff(d time.Duration) string {
+	return s.now().UTC().Add(-d).Format(time.RFC3339Nano)
+}
+
 // PruneRawEventPayloads clears source_payload from old raw events to reclaim
-// disk space. All useful data has already been extracted into usage_events.
-// Keeps payloads for events newer than retentionHours.
+// disk space. For usage events all useful data has already been extracted into
+// usage_events columns, so the payload is redundant detail. Keeps payloads for
+// events newer than retentionHours.
+//
+// limit_snapshot is the exception: its payload IS the read model's source of
+// truth. hydrateRootsFromLimitSnapshots reads the newest one back per
+// provider/account to rebuild a provider's metrics, and nothing in
+// usage_events can substitute for it. Blanking it left the dashboard
+// hydrating from an empty envelope, which reads as a confident UNKNOWN with no
+// metrics and survives a daemon restart because the damage is in the database
+// (#293).
+//
+// Only the newest limit_snapshot per (provider_id, account_id) is protected.
+// The historical ones are never read back and are the bulk of the volume, so
+// they still get reclaimed.
 func (s *Store) PruneRawEventPayloads(ctx context.Context, retentionHours int, limit int) (int64, error) {
 	if s == nil || s.db == nil || retentionHours < 0 || limit <= 0 {
 		return 0, nil
 	}
-	cutoff := fmt.Sprintf("-%d hours", retentionHours)
+	cutoff := s.retentionCutoff(time.Duration(retentionHours) * time.Hour)
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE usage_raw_events
 		SET source_payload = '{}'
 		WHERE raw_event_id IN (
 			SELECT raw_event_id
 			FROM usage_raw_events
-			WHERE ingested_at < datetime('now', ?)
+			WHERE ingested_at < ?
 			  AND source_payload != '{}'
+			  AND raw_event_id NOT IN (
+				SELECT e.raw_event_id
+				FROM usage_events e
+				JOIN (
+					SELECT
+						COALESCE(provider_id, '') AS provider_id,
+						COALESCE(account_id, '') AS account_id,
+						MAX(occurred_at) AS occurred_at
+					FROM usage_events
+					WHERE event_type = 'limit_snapshot'
+					GROUP BY 1, 2
+				) latest
+				  ON COALESCE(e.provider_id, '') = latest.provider_id
+				 AND COALESCE(e.account_id, '') = latest.account_id
+				 AND e.occurred_at = latest.occurred_at
+				WHERE e.event_type = 'limit_snapshot'
+			  )
 			ORDER BY ingested_at ASC
 			LIMIT ?
 		)


### PR DESCRIPTION
Fixes #293

Traced from @djbclark's report: `openusage export` serves `cursor` as `UNKNOWN` with a stale timestamp, `--source direct` returns correct data, and **restarting the daemon changes nothing**. That last detail is the tell — the damage is in the database, not in process state. Three defects compound to produce it.

## 1. Retention horizons never fired within the same calendar day

`ingested_at`, `occurred_at` and `observed_at` all store `time.RFC3339Nano`:

```
2026-08-31T08:57:12.211861Z
```

Every horizon compared them against `datetime('now', ?)`, which renders a **space** separator:

```
2026-08-31 07:57:34
```

Those two forms only sort consistently when the dates differ. On the same day the comparison reaches the separator, where `'T'` (0x54) outranks `' '` (0x20) — so a row written earlier today always compares as *newer* than the horizon. Verified in SQLite:

| comparison | result | wanted |
|---|---|---|
| `datetime(...) < datetime('now','-1 hours')` | 1 | 1 |
| `'...T01:00:00.000Z' < datetime('now','-1 hours')` | **0** | 1 |
| `datetime('...T01:00:00.000Z') < datetime('now','-1 hours')` | 1 | 1 |

So `PruneRawEventPayloads(retentionHours: 1)` really meant "previous calendar days". Affected all three retention paths: raw payloads, `PruneOldEvents`, and the three `PruneBalanceObservations` horizons.

Fixed by rendering the bound in Go (`Store.retentionCutoff`) so both sides share one format. Deliberately *not* by wrapping the column in `datetime()` — every one of these columns is indexed, and wrapping the column would make the scans stop using them.

## 2. Retention blanked the payload the read model depends on

`PruneRawEventPayloads` sets `source_payload = '{}'` for every eligible raw event, with no exception for `limit_snapshot`. But `hydrateRootsFromLimitSnapshots` → `loadLatestLimitSnapshot` reads that payload back to rebuild a provider's quota metrics. Nothing in `usage_events` can substitute for it.

The doc comment justified the pruning as "all useful data has already been extracted into usage_events" — true for usage events, false for `limit_snapshot`, where the payload *is* the data.

Now the newest `limit_snapshot` per `(provider_id, account_id)` is protected. Superseded ones are never read back and are the bulk of the volume, so they still get reclaimed.

## 3. A blanked payload decoded as success

`'{}'` unmarshals **cleanly** into a zero `storedLimitEnvelope`, so `decodeStoredLimitSnapshot` returned `ok = true`. Hydration then merged that empty snapshot over the live one, yielding `status: UNKNOWN`, `message: null`, no metrics — exactly the reported output, and immune to a restart.

Now an envelope carrying no status, message, metrics, resets, attributes or diagnostics is treated as absent so hydration is skipped. **This is also the half that repairs already-damaged databases**, where the payload is gone and no code change can bring it back — those users get their live snapshot through instead of an UNKNOWN shell.

## Tests

Each test was confirmed to fail with its fix reverted:

| test | reverted-fix failure |
|---|---|
| `..._PrunesWithinTheSameDay` | `pruned = 0, want 1` |
| `..._KeepsLatestLimitSnapshot` | `latest limit_snapshot payload was blanked by retention` |
| `..._RejectsBlankedPayload` | `decodeStoredLimitSnapshot("{}") = ok, want rejected as empty` |

Plus `..._StillPrunesSupersededLimitSnapshots`, asserting the space reclamation is preserved (2 of 3 snapshots blanked, newest kept).

`go test -race ./...` passes; `golangci-lint` reports 0 issues.

## Note for @djbclark

Fix 3 should restore your `cursor` tile on upgrade even though the payload is already blanked. If it comes back as a *missing* tile rather than correct data, that is a separate question — whether cursor's poll is succeeding inside the daemon at all — and worth a follow-up issue with `OPENUSAGE_DEBUG=1` daemon logs.

## Docs

Updated `docs/site/docs/daemon/storage.md`: the payload-pruning step now documents the `limit_snapshot` exception and why it exists, and pins down the one-hour horizon the section previously left as just "old". Docs site builds with `[SUCCESS]` and no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNSGtKppEApHmGH9hD4BN1