### PR TITLE
feat(tui): make Analytics a standard screen, retiring the experimental flag

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -48,7 +48,6 @@ func main() {
 	model := tui.NewModel(
 		0.20,
 		0.05,
-		false,
 		// Hide sections a provider has no data for (e.g. an API router has no
 		// tool/language/MCP telemetry) so the demo never shows empty
 		// "No X data for this time range" placeholders.

--- a/cmd/openusage/dashboard.go
+++ b/cmd/openusage/dashboard.go
@@ -39,7 +39,6 @@ func runDashboard(cfg config.Config) {
 	model := tui.NewModel(
 		cfg.UI.WarnThreshold,
 		cfg.UI.CritThreshold,
-		cfg.Experimental.Analytics,
 		cfg.Dashboard,
 		cachedAccounts,
 		timeWindow,

--- a/cmd/openusage/hub.go
+++ b/cmd/openusage/hub.go
@@ -185,7 +185,6 @@ func runHub(cfg config.Config, allowPublic bool) {
 	model := tui.NewModel(
 		cfg.UI.WarnThreshold,
 		cfg.UI.CritThreshold,
-		cfg.Experimental.Analytics,
 		cfg.Dashboard,
 		nil,
 		timeWindow,

--- a/cmd/openusage/hub_view.go
+++ b/cmd/openusage/hub_view.go
@@ -89,7 +89,6 @@ func runHubView(cfg config.Config, hubURL, token string) {
 	model := tui.NewModel(
 		cfg.UI.WarnThreshold,
 		cfg.UI.CritThreshold,
-		cfg.Experimental.Analytics,
 		cfg.Dashboard,
 		nil,
 		timeWindow,

--- a/configs/example_settings.json
+++ b/configs/example_settings.json
@@ -9,9 +9,6 @@
     "time_window": "7d",
     "retention_days": 30
   },
-  "experimental": {
-    "analytics": false
-  },
   "model_normalization": {
     "enabled": true,
     "group_by": "lineage",

--- a/docs/site/docs/getting-started/first-run.md
+++ b/docs/site/docs/getting-started/first-run.md
@@ -69,14 +69,6 @@ Use <kbd>j</kbd>/<kbd>k</kbd> to scroll, <kbd>Tab</kbd>/<kbd>Shift+Tab</kbd> to 
 
 Press <kbd>Tab</kbd> (or <kbd>Shift+Tab</kbd>) to switch to the **Analytics** screen.
 
-:::note Opt-in
-Analytics is gated behind `experimental.analytics` in your settings. If <kbd>Tab</kbd> doesn't seem to do anything, enable it:
-
-```json
-{ "experimental": { "analytics": true } }
-```
-:::
-
 Analytics aggregates across providers:
 
 - **Metric strip** — window spend, token volume, spend/active day, spend trend

--- a/docs/site/docs/guides/headless-servers.md
+++ b/docs/site/docs/guides/headless-servers.md
@@ -67,18 +67,6 @@ tmux attach -t usage
 
 The TUI keeps rendering whether anyone is attached or not.
 
-## Disabling Analytics on small servers
-
-The Analytics screen is opt-in (`cfg.Experimental.Analytics`). On a server you may want to leave it off to keep the rendering loop tight:
-
-```json
-{
-  "experimental": { "analytics": false }
-}
-```
-
-The Tab cycle then just bounces between dashboard views.
-
 ## Integrations on a server
 
 If the server itself runs Claude Code, Codex, or OpenCode jobs, install the hooks the same way as on a workstation:

--- a/docs/site/docs/reference/configuration.md
+++ b/docs/site/docs/reference/configuration.md
@@ -22,7 +22,6 @@ The TUI reads the file on startup and writes it back when you change settings in
 | [`data`](#data) | object | Time window default and retention. |
 | [`telemetry`](#telemetry) | object | Daemon-related settings. |
 | [`dashboard`](#dashboard) | object | Provider list, view, and widget sections. |
-| [`experimental`](#experimental) | object | Opt-in screens. |
 | [`model_normalization`](#model_normalization) | object | Group raw model ids by canonical lineage. |
 | [`integrations`](#integrations) | object | Install state for tool hooks. |
 | [`export`](#export) | object | Daemon push to a remote hub (multi-machine aggregation). |
@@ -186,20 +185,6 @@ Same shape as `widget_sections`, but applied to the detail (full-page) view rath
 |---|---|---|
 | `id` | string | Section ID (provider-defined). |
 | `enabled` | bool | Render or hide on the detail view. |
-
-## `experimental`
-
-```json
-{
-  "experimental": {
-    "analytics": true
-  }
-}
-```
-
-| Field | Type | Default | Purpose |
-|---|---|---|---|
-| `analytics` | bool | `false` | Enables the Analytics screen (<kbd>Tab</kbd> from dashboard). |
 
 ## `model_normalization`
 
@@ -391,9 +376,6 @@ Read-only mirror of accounts the detector found at startup. Format is identical 
       "google": "gemini_api",
       "github-copilot": "copilot"
     }
-  },
-  "experimental": {
-    "analytics": false
   },
   "model_normalization": {
     "enabled": true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,10 +19,6 @@ type UIConfig struct {
 	CritThreshold          float64 `json:"crit_threshold"`
 }
 
-type ExperimentalConfig struct {
-	Analytics bool `json:"analytics"`
-}
-
 type TelemetryConfig struct {
 	// ProviderLinks maps source telemetry provider IDs to configured provider IDs.
 	// Example: {"anthropic":"claude_code"}.
@@ -204,7 +200,6 @@ type Config struct {
 	UI                   UIConfig                      `json:"ui"`
 	Theme                string                        `json:"theme"`
 	Data                 DataConfig                    `json:"data"`
-	Experimental         ExperimentalConfig            `json:"experimental"`
 	Telemetry            TelemetryConfig               `json:"telemetry"`
 	Dashboard            DashboardConfig               `json:"dashboard"`
 	ModelNormalization   core.ModelNormalizationConfig `json:"model_normalization"`
@@ -247,7 +242,6 @@ func DefaultConfig() Config {
 			CritThreshold:          0.05,
 		},
 		Data:               DataConfig{TimeWindow: "30d", RetentionDays: defaultRetentionDays},
-		Experimental:       ExperimentalConfig{Analytics: false},
 		Telemetry:          TelemetryConfig{ProviderLinks: map[string]string{}},
 		Dashboard:          DashboardConfig{View: DashboardViewGrid},
 		ModelNormalization: core.DefaultModelNormalizationConfig(),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,9 +26,6 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Theme != "Gruvbox" {
 		t.Errorf("default theme = %q, want 'Gruvbox'", cfg.Theme)
 	}
-	if cfg.Experimental.Analytics {
-		t.Error("expected experimental analytics to be false by default")
-	}
 	if cfg.Dashboard.View != DashboardViewGrid {
 		t.Errorf("default dashboard.view = %q, want %q", cfg.Dashboard.View, DashboardViewGrid)
 	}
@@ -106,9 +103,6 @@ func TestLoadFrom_ValidFile(t *testing.T) {
 	}
 	if cfg.Theme != "Nord" {
 		t.Errorf("theme = %q, want 'Nord'", cfg.Theme)
-	}
-	if !cfg.Experimental.Analytics {
-		t.Error("expected analytics=true")
 	}
 	if cfg.AutoDetect {
 		t.Error("expected auto_detect=false")
@@ -283,7 +277,7 @@ func TestSaveTo_CreatesFileAndDir(t *testing.T) {
 
 	cfg := DefaultConfig()
 	cfg.Theme = "Dracula"
-	cfg.Experimental.Analytics = true
+	cfg.Data.RetentionDays = 45
 
 	if err := SaveTo(path, cfg); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -296,8 +290,8 @@ func TestSaveTo_CreatesFileAndDir(t *testing.T) {
 	if loaded.Theme != "Dracula" {
 		t.Errorf("expected 'Dracula', got %q", loaded.Theme)
 	}
-	if !loaded.Experimental.Analytics {
-		t.Error("expected analytics=true after round-trip")
+	if loaded.Data.RetentionDays != 45 {
+		t.Errorf("retention_days = %d, want 45 after round-trip", loaded.Data.RetentionDays)
 	}
 }
 
@@ -447,7 +441,7 @@ func TestSaveAndLoad_RoundTrip(t *testing.T) {
 
 	original := DefaultConfig()
 	original.Theme = "Synthwave '84"
-	original.Experimental.Analytics = false
+	original.Data.RetentionDays = 45
 
 	if err := SaveTo(path, original); err != nil {
 		t.Fatalf("save error: %v", err)
@@ -461,8 +455,8 @@ func TestSaveAndLoad_RoundTrip(t *testing.T) {
 	if loaded.Theme != original.Theme {
 		t.Errorf("theme mismatch: got %q, want %q", loaded.Theme, original.Theme)
 	}
-	if loaded.Experimental.Analytics != original.Experimental.Analytics {
-		t.Errorf("analytics mismatch: got %v, want %v", loaded.Experimental.Analytics, original.Experimental.Analytics)
+	if loaded.Data.RetentionDays != original.Data.RetentionDays {
+		t.Errorf("retention_days mismatch: got %v, want %v", loaded.Data.RetentionDays, original.Data.RetentionDays)
 	}
 }
 
@@ -471,7 +465,7 @@ func TestSaveThemeTo(t *testing.T) {
 
 	// Start with a config
 	cfg := DefaultConfig()
-	cfg.Experimental.Analytics = true
+	cfg.Data.RetentionDays = 45
 	if err := SaveTo(path, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -489,8 +483,8 @@ func TestSaveThemeTo(t *testing.T) {
 	if loaded.Theme != "Nord" {
 		t.Errorf("theme = %q, want 'Nord'", loaded.Theme)
 	}
-	if !loaded.Experimental.Analytics {
-		t.Error("analytics should be preserved after SaveThemeTo")
+	if loaded.Data.RetentionDays != 45 {
+		t.Errorf("retention_days = %d, want 45 preserved after SaveThemeTo", loaded.Data.RetentionDays)
 	}
 }
 
@@ -1366,5 +1360,29 @@ func TestExportTargetPreservedAcrossModifyConfig(t *testing.T) {
 	}
 	if cfg.Export.MachineName != "mybox" {
 		t.Errorf("export.machine_name = %q after SaveAutoDetected, want mybox", cfg.Export.MachineName)
+	}
+}
+
+// The Analytics screen used to be gated behind experimental.analytics. The key
+// is retired, but plenty of configs still carry it, so loading one must not
+// fail -- the key is simply ignored. encoding/json drops unknown fields, and
+// nothing here sets DisallowUnknownFields; this test pins that.
+func TestLoadFrom_RetiredExperimentalKeyIsIgnored(t *testing.T) {
+	for _, body := range []string{
+		`{"theme":"Nord","experimental":{"analytics":false}}`,
+		`{"theme":"Nord","experimental":{"analytics":true}}`,
+		`{"theme":"Nord","experimental":{}}`,
+	} {
+		path := filepath.Join(t.TempDir(), "settings.json")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadFrom(path)
+		if err != nil {
+			t.Fatalf("LoadFrom(%s) error = %v", body, err)
+		}
+		if cfg.Theme != "Nord" {
+			t.Errorf("LoadFrom(%s) theme = %q, want Nord -- the rest of the config must still apply", body, cfg.Theme)
+		}
 	}
 }

--- a/internal/tui/analytics_available_test.go
+++ b/internal/tui/analytics_available_test.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/config"
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+func newAnalyticsModel(t *testing.T) Model {
+	t.Helper()
+	m := NewModel(0.20, 0.05, config.DashboardConfig{View: config.DashboardViewGrid}, nil, core.TimeWindow("30d"))
+	m.width, m.height = 140, 44
+	// hasData true with no snapshots is the real first-run case: the daemon is
+	// reachable but nothing has been collected yet. With hasData false View()
+	// returns the splash and never reaches the analytics renderer.
+	m.hasData = true
+	return m
+}
+
+// Analytics is no longer gated, so Tab must always reach it.
+func TestAnalyticsAlwaysAvailable(t *testing.T) {
+	m := newAnalyticsModel(t)
+
+	screens := m.availableScreens()
+	if len(screens) != 2 || screens[0] != screenDashboard || screens[1] != screenAnalytics {
+		t.Fatalf("availableScreens() = %v, want [dashboard analytics]", screens)
+	}
+
+	if got := m.nextScreen(1); got != screenAnalytics {
+		t.Errorf("nextScreen(1) from dashboard = %v, want analytics", got)
+	}
+	m.screen = screenAnalytics
+	if got := m.nextScreen(1); got != screenDashboard {
+		t.Errorf("nextScreen(1) from analytics = %v, want to wrap to dashboard", got)
+	}
+}
+
+// The screen is reachable before any data exists, so the empty state has to
+// render rather than panic or come back blank.
+func TestAnalyticsScreenRendersWithNoData(t *testing.T) {
+	m := newAnalyticsModel(t)
+	m.screen = screenAnalytics
+
+	out := m.View()
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("analytics view rendered empty with no snapshots")
+	}
+}
+
+// A first-run terminal can be narrow, and the screen is reachable immediately.
+func TestAnalyticsScreenRendersAcrossWidths(t *testing.T) {
+	for _, size := range [][2]int{{60, 20}, {80, 24}, {140, 44}, {200, 60}} {
+		m := newAnalyticsModel(t)
+		m.width, m.height = size[0], size[1]
+		m.screen = screenAnalytics
+		m.analyticsCache = analyticsRenderCacheEntry{}
+		if strings.TrimSpace(m.View()) == "" {
+			t.Errorf("analytics view empty at %dx%d", size[0], size[1])
+		}
+	}
+}
+
+// Analytics costs nothing while another screen is active: the render path is
+// behind the screen switch. This pins that the dashboard render never builds
+// the analytics aggregate, which is why no opt-out is needed.
+func TestDashboardRenderDoesNotBuildAnalyticsCache(t *testing.T) {
+	m := newAnalyticsModel(t)
+	m.screen = screenDashboard
+	m.analyticsCache = analyticsRenderCacheEntry{}
+
+	_ = m.View()
+
+	if m.analyticsCache.key != "" {
+		t.Errorf("dashboard render populated the analytics cache (key=%q); analytics work should be lazy", m.analyticsCache.key)
+	}
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -135,13 +135,11 @@ func (m Model) renderHelpOverlay(screenW, screenH int) string {
 		{"Space / Enter", "Apply setting in modal"},
 		{"Shift+J/K", "Reorder providers (order tab)"},
 	}
-	if m.experimentalAnalytics {
-		actionKeys = append(actionKeys,
-			struct{ key, desc string }{"s", "Cycle sort (analytics)"},
-			struct{ key, desc string }{"1-4", "Jump to analytics tab"},
-			struct{ key, desc string }{"Enter/Space", "Expand model (Models tab)"},
-		)
-	}
+	actionKeys = append(actionKeys,
+		struct{ key, desc string }{"s", "Cycle sort (analytics)"},
+		struct{ key, desc string }{"1-4", "Jump to analytics tab"},
+		struct{ key, desc string }{"Enter/Space", "Expand model (Models tab)"},
+	)
 	actionKeys = append(actionKeys,
 		struct{ key, desc string }{"r", "Refresh"},
 		struct{ key, desc string }{"t", "Cycle theme"},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -227,8 +227,6 @@ type Model struct {
 	// future render-cache work a stable cache key, and keeps View() pure).
 	referenceTime time.Time
 
-	experimentalAnalytics bool // when false, only the Dashboard screen is available
-
 	daemon daemonState
 
 	providerOrder    []string
@@ -259,7 +257,6 @@ type Model struct {
 
 func NewModel(
 	warnThresh, critThresh float64,
-	experimentalAnalytics bool,
 	dashboardCfg config.DashboardConfig,
 	accounts []core.AccountConfig,
 	timeWindow core.TimeWindow,
@@ -268,7 +265,6 @@ func NewModel(
 		snapshots:             make(map[string]core.UsageSnapshot),
 		warnThreshold:         warnThresh,
 		critThreshold:         critThresh,
-		experimentalAnalytics: experimentalAnalytics,
 		providerEnabled:       make(map[string]bool),
 		accountProviders:      make(map[string]string),
 		expandedModelMixTiles: make(map[string]bool),

--- a/internal/tui/model_display_test.go
+++ b/internal/tui/model_display_test.go
@@ -273,7 +273,7 @@ func TestComputeDisplayInfo_IndividualSpendClampedToZero(t *testing.T) {
 }
 
 func TestUpdate_SnapshotsMsgMarksModelReadyOnFirstFrame(t *testing.T) {
-	m := NewModel(0.2, 0.1, false, config.DashboardConfig{}, nil, core.TimeWindow30d)
+	m := NewModel(0.2, 0.1, config.DashboardConfig{}, nil, core.TimeWindow30d)
 	if m.hasData {
 		t.Fatal("expected hasData=false on fresh model")
 	}
@@ -303,7 +303,7 @@ func TestUpdate_SnapshotsMsgMarksModelReadyOnFirstFrame(t *testing.T) {
 }
 
 func TestUpdate_SnapshotsMsgIgnoresStaleTimeWindowResponse(t *testing.T) {
-	m := NewModel(0.2, 0.1, false, config.DashboardConfig{}, nil, core.TimeWindow1d)
+	m := NewModel(0.2, 0.1, config.DashboardConfig{}, nil, core.TimeWindow1d)
 	currentUsed := 1.0
 	m.snapshots = map[string]core.UsageSnapshot{
 		"openrouter": {
@@ -340,7 +340,7 @@ func TestUpdate_SnapshotsMsgIgnoresStaleTimeWindowResponse(t *testing.T) {
 }
 
 func TestUpdate_SnapshotsMsgIgnoresOlderCurrentWindowResponse(t *testing.T) {
-	m := NewModel(0.2, 0.1, false, config.DashboardConfig{}, nil, core.TimeWindow7d)
+	m := NewModel(0.2, 0.1, config.DashboardConfig{}, nil, core.TimeWindow7d)
 	m.hasData = true
 
 	newUsed := 7.0
@@ -384,7 +384,7 @@ func TestUpdate_SnapshotsMsgIgnoresOlderCurrentWindowResponse(t *testing.T) {
 }
 
 func TestUpdate_AppUpdateMsgStoresNotice(t *testing.T) {
-	m := NewModel(0.2, 0.1, false, config.DashboardConfig{}, nil, core.TimeWindow30d)
+	m := NewModel(0.2, 0.1, config.DashboardConfig{}, nil, core.TimeWindow30d)
 
 	updated, _ := m.Update(AppUpdateMsg{
 		CurrentVersion: "v0.4.0",
@@ -407,7 +407,7 @@ func TestUpdate_AppUpdateMsgStoresNotice(t *testing.T) {
 }
 
 func TestRenderFooterStatusLine_ShowsAppUpdateWhenIdle(t *testing.T) {
-	m := NewModel(0.2, 0.1, false, config.DashboardConfig{}, nil, core.TimeWindow30d)
+	m := NewModel(0.2, 0.1, config.DashboardConfig{}, nil, core.TimeWindow30d)
 	m.daemon.appUpdateCurrent = "v0.4.0"
 	m.daemon.appUpdateLatest = "v0.5.0"
 	m.daemon.appUpdateHint = "go install github.com/janekbaraniewski/openusage/cmd/openusage@latest"

--- a/internal/tui/model_input.go
+++ b/internal/tui/model_input.go
@@ -592,10 +592,11 @@ func (m Model) handleAnalyticsFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// availableScreens lists the screens Tab cycles through. Analytics is always
+// present: it is rendered only while it is the active screen (see the screen
+// switch in renderDashboard), so an unused Analytics screen costs nothing and
+// there is nothing for a toggle to save.
 func (m Model) availableScreens() []screenTab {
-	if !m.experimentalAnalytics {
-		return []screenTab{screenDashboard}
-	}
 	return []screenTab{screenDashboard, screenAnalytics}
 }
 

--- a/internal/tui/model_install_test.go
+++ b/internal/tui/model_install_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDaemonInstallResultSuccess(t *testing.T) {
-	m := NewModel(0.2, 0.1, false, config.DashboardConfig{}, nil, core.TimeWindow30d)
+	m := NewModel(0.2, 0.1, config.DashboardConfig{}, nil, core.TimeWindow30d)
 	m.daemon.status = DaemonNotInstalled
 	m.daemon.installing = true
 
@@ -31,7 +31,7 @@ func TestDaemonInstallResultSuccess(t *testing.T) {
 }
 
 func TestDaemonInstallResultFailure(t *testing.T) {
-	m := NewModel(0.2, 0.1, false, config.DashboardConfig{}, nil, core.TimeWindow30d)
+	m := NewModel(0.2, 0.1, config.DashboardConfig{}, nil, core.TimeWindow30d)
 	m.daemon.status = DaemonNotInstalled
 	m.daemon.installing = true
 

--- a/internal/tui/model_mouse_test.go
+++ b/internal/tui/model_mouse_test.go
@@ -147,7 +147,7 @@ func TestMouseWheelScrollsSettingsWidgetPreview(t *testing.T) {
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{{ID: "claude-preview", Provider: "claude_code"}},
 		core.TimeWindow7d,
@@ -169,7 +169,7 @@ func TestMouseWheelUpClampsSettingsWidgetPreviewOffsetAtZero(t *testing.T) {
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{{ID: "claude-preview", Provider: "claude_code"}},
 		core.TimeWindow7d,
@@ -192,7 +192,7 @@ func TestMouseWheelDoesNotScrollSettingsPreviewOutsideWidgetSectionsTab(t *testi
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{{ID: "claude-preview", Provider: "claude_code"}},
 		core.TimeWindow7d,

--- a/internal/tui/model_refresh_test.go
+++ b/internal/tui/model_refresh_test.go
@@ -83,12 +83,11 @@ func TestBeginTimeWindowRefreshRequestsSelectedWindow(t *testing.T) {
 
 func TestHandleKey_DetailTabNavigatesSectionsInsteadOfSwitchingScreen(t *testing.T) {
 	m := Model{
-		screen:                screenDashboard,
-		mode:                  modeDetail,
-		experimentalAnalytics: true,
-		width:                 120,
-		height:                40,
-		sortedIDs:             []string{"codex-cli"},
+		screen:    screenDashboard,
+		mode:      modeDetail,
+		width:     120,
+		height:    40,
+		sortedIDs: []string{"codex-cli"},
 		snapshots: map[string]core.UsageSnapshot{
 			"codex-cli": {
 				ProviderID: "codex",

--- a/internal/tui/provider_widget_test.go
+++ b/internal/tui/provider_widget_test.go
@@ -76,7 +76,7 @@ func TestNewModel_AppliesWidgetSectionOverridesFromConfig(t *testing.T) {
 	_ = NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{
 			WidgetSections: []config.DashboardWidgetSection{
 				{

--- a/internal/tui/settings_widget_sections_test.go
+++ b/internal/tui/settings_widget_sections_test.go
@@ -95,7 +95,7 @@ func TestHandleSettingsModalKey_WidgetSectionsReorderAffectsRenderedWidget(t *te
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{
 			{ID: "openai", Provider: "openai"},
@@ -129,7 +129,7 @@ func TestRenderSettingsWidgetSectionsBody_RendersListOnly(t *testing.T) {
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{{ID: "claude-preview", Provider: "claude_code"}},
 		core.TimeWindow7d,
@@ -155,7 +155,7 @@ func TestRenderSettingsModalOverlay_WidgetSectionsIncludesSeparatePreviewPanel(t
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{{ID: "claude-preview", Provider: "claude_code"}},
 		core.TimeWindow7d,
@@ -183,7 +183,7 @@ func TestHandleSettingsModalKey_WidgetSectionsPreviewScroll(t *testing.T) {
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{{ID: "claude-preview", Provider: "claude_code"}},
 		core.TimeWindow7d,
@@ -244,7 +244,7 @@ func TestRenderSettingsWidgetSectionsPreview_ReflectsSectionVisibility(t *testin
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{{ID: "claude-preview", Provider: "claude_code"}},
 		core.TimeWindow7d,
@@ -275,7 +275,7 @@ func TestSettingsWidgetPreviewBodyHeight_SideBySideShrinksToContent(t *testing.T
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{{ID: "claude-preview", Provider: "claude_code"}},
 		core.TimeWindow7d,
@@ -309,7 +309,7 @@ func TestRenderSettingsDetailSectionsPreview_ShowsTrendCharts(t *testing.T) {
 	m := NewModel(
 		0.2,
 		0.05,
-		false,
+
 		config.DashboardConfig{},
 		[]core.AccountConfig{{ID: "claude-preview", Provider: "claude_code"}},
 		core.TimeWindow30d,


### PR DESCRIPTION
Analytics was gated behind `experimental.analytics`, which defaults to `false` — so a default install pressed <kbd>Tab</kbd> and nothing happened.

My first pass just flipped the default. @janekbaraniewski asked whether the flag should go entirely, which was the better call, so this now retires it.

## The flag wasn't buying anything

That's the whole argument, so it's worth showing rather than asserting. The analytics render path is behind the screen switch in `renderDashboard`:

```go
switch m.screen {
case screenAnalytics:
    content = m.renderAnalyticsContent(w, contentH)   // extractCostData lives under here
default:
    content = m.renderDashboardContent(w, contentH)
}
```

`extractCostData` runs inside `cachedAnalyticsPageContent`, reached only from `renderAnalyticsContent`, and behind a render cache. So while you're on the Dashboard, an available-but-unused Analytics screen costs **zero** — no eager aggregation, no background work. The toggle's only effect was removing one stop from the Tab cycle.

`TestDashboardRenderDoesNotBuildAnalyticsCache` pins this, so a future change that makes analytics work eager fails loudly instead of quietly reintroducing a cost the flag no longer exists to mitigate.

**Our docs were wrong about this.** `headless-servers.md` advised disabling Analytics "to keep the rendering loop tight" — which saved nothing unless you were actively looking at the screen. That whole section is removed rather than reworded.

## Changes

- Removed `ExperimentalConfig` and `Config.Experimental` entirely
- Removed `Model.experimentalAnalytics`, the `NewModel` parameter, and all four call sites (`dashboard.go`, `hub.go`, `hub_view.go`, `cmd/demo`)
- `availableScreens()` always returns both screens; the help overlay always lists the analytics keys
- Docs: removed the `experimental` reference section, the first-run opt-in note, the false headless advice, and the key from `configs/example_settings.json`

`cmd/demo` passed `false`, so the demo used for **screenshots has never shown the Analytics screen**. That's fixed as a side effect.

## Existing configs keep working

This is the one way the change could have hurt people, so it's tested. Nothing in the codebase sets `DisallowUnknownFields`, so `encoding/json` silently ignores unknown keys — a config still carrying `experimental.analytics` loads cleanly and the key is inert.

`TestLoadFrom_RetiredExperimentalKeyIsIgnored` covers `{"analytics":false}`, `{"analytics":true}`, and `{}`, asserting the *rest* of the config still applies (so a stale key can't silently discard someone's theme).

Several config tests had been using `Experimental.Analytics` as an arbitrary "some other field" to prove save/load round-tripping and `SaveThemeTo` preservation. Those assertions were kept and repointed at `Data.RetentionDays` rather than deleted — the intent was worth preserving.

## Trade-off, stated plainly

Anyone who genuinely wants one fewer Tab stop loses that ability. The only documented reason to want it was the false performance claim above, so no real need is being dropped — but it is a removed capability, not a pure win.

## Testing

- `TestAnalyticsAlwaysAvailable` — both screens present; Tab goes dashboard → analytics → wraps back
- `TestAnalyticsScreenRendersWithNoData` — `hasData: true` with zero snapshots (the real "daemon up, nothing collected yet" state). Note `hasData: false` returns the splash and never reaches the analytics renderer, so that flag matters for the test to mean anything
- `TestAnalyticsScreenRendersAcrossWidths` — 60×20 through 200×60
- `TestDashboardRenderDoesNotBuildAnalyticsCache` — the laziness claim above

**Live check.** Built the binary and drove it in a sized pty against a real config with `experimental.analytics` explicitly set to `false`. The retired key is ignored and the screen renders with real data:

```
⚡ OpenUsage  1:Dashboard  2:Analytics  12◉
    Analytics
  Window Today · 12 providers · 12 active · 1 active days
  Window Spend $468.13   Token Volume 77.7M in 71.6M · out 6.1M   Spend / Active Day $468.13
  TOTAL COST OVER TIME
```

`go test -race ./...` passes, `golangci-lint run ./...` reports 0 issues, docs build `[SUCCESS]` with no broken links.

## Sequencing

#341 and #339 both landed first, so this sits on top of the daemon read/write fixes rather than promoting a screen built on the buggy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNSGtKppEApHmGH9hD4BN1