### PR TITLE
fix(codex): fix model detection for CLI 0.153+ and cached token double-billing

### DIFF
--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -22,7 +22,7 @@ const (
 	defaultChatGPTBaseURL   = "https://chatgpt.com/backend-api"
 	defaultUsageWindowLabel = "all-time"
 
-	maxScannerBufferSize = 8 * 1024 * 1024
+	maxScannerBufferSize = 32 * 1024 * 1024
 	maxHTTPErrorBodySize = 256
 
 	maxBreakdownMetrics = 8
@@ -92,6 +92,46 @@ type creditInfo struct {
 	HasCredits bool     `json:"has_credits"`
 	Unlimited  bool     `json:"unlimited"`
 	Balance    *float64 `json:"balance"`
+}
+
+func (c *creditInfo) UnmarshalJSON(data []byte) error {
+	type Alias creditInfo
+	aux := &struct {
+		Balance interface{} `json:"balance"`
+		*Alias
+	}{
+		Alias: (*Alias)(c),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Balance != nil {
+		switch v := aux.Balance.(type) {
+		case string:
+			s := strings.TrimSpace(v)
+			s = strings.TrimPrefix(s, "$")
+			s = strings.ReplaceAll(s, ",", "")
+			if s == "" {
+				c.Balance = nil
+			} else {
+				f, err := strconv.ParseFloat(s, 64)
+				if err != nil {
+					return err
+				}
+				c.Balance = &f
+			}
+		case float64:
+			f := v
+			c.Balance = &f
+		case int:
+			f := float64(v)
+			c.Balance = &f
+		case float32:
+			f := float64(v)
+			c.Balance = &f
+		}
+	}
+	return nil
 }
 
 type versionInfo struct {

--- a/internal/providers/codex/codex.go
+++ b/internal/providers/codex/codex.go
@@ -116,19 +116,21 @@ func (c *creditInfo) UnmarshalJSON(data []byte) error {
 			} else {
 				f, err := strconv.ParseFloat(s, 64)
 				if err != nil {
-					return err
+					return fmt.Errorf("codex credit balance %q: %w", v, err)
 				}
 				c.Balance = &f
 			}
 		case float64:
 			f := v
 			c.Balance = &f
-		case int:
-			f := float64(v)
+		case json.Number:
+			f, err := v.Float64()
+			if err != nil {
+				return fmt.Errorf("codex credit balance %q: %w", v.String(), err)
+			}
 			c.Balance = &f
-		case float32:
-			f := float64(v)
-			c.Balance = &f
+		default:
+			return fmt.Errorf("codex credit balance has unexpected type %T", v)
 		}
 	}
 	return nil

--- a/internal/providers/codex/cost.go
+++ b/internal/providers/codex/cost.go
@@ -28,16 +28,22 @@ func estimateUsageCost(model string, delta tokenUsage) float64 {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), priceLookupTimeout)
 	defer cancel()
-	// contextLen is the request's prompt size (input + cached input). Pricing
-	// applies higher long-context tier rates above the model's breakpoint, so
-	// feed it instead of always charging the base rate.
-	ctxLen := delta.InputTokens + delta.CachedInputTokens
+	// Codex reports cached_input_tokens as a subset of input_tokens (OpenAI
+	// semantics: total = input + output), so the cached portion must only be
+	// billed at the cache-read rate. See issue #360.
+	uncachedInput := delta.InputTokens - delta.CachedInputTokens
+	if uncachedInput < 0 {
+		uncachedInput = 0
+	}
+	// contextLen is the real prompt size (input_tokens already includes the
+	// cached slice), not input+cache.
+	ctxLen := delta.InputTokens
 	p, err := priceLookup(ctx, model, ctxLen)
 	if err != nil || p == nil {
 		return 0
 	}
 	return pricing.Estimate(p, ctxLen, pricing.Usage{
-		InputTokens:     delta.InputTokens,
+		InputTokens:     uncachedInput,
 		OutputTokens:    delta.OutputTokens,
 		CacheReadTokens: delta.CachedInputTokens,
 		ReasoningTokens: delta.ReasoningOutputTokens,

--- a/internal/providers/codex/cost_test.go
+++ b/internal/providers/codex/cost_test.go
@@ -49,8 +49,8 @@ func TestEstimateUsageCost_ZeroDeltaReturnsZero(t *testing.T) {
 }
 
 // TestEstimateUsageCost_PassesContextLenForTier locks in the cost-accuracy fix:
-// the per-message context length (input + cached input) must reach the pricing
-// layer so the long-context tier override applies.
+// the per-message context length is input_tokens (which already includes the
+// cached slice), not input+cached. See issue #360.
 func TestEstimateUsageCost_PassesContextLenForTier(t *testing.T) {
 	prev := priceLookup
 	var gotCtx int
@@ -68,12 +68,37 @@ func TestEstimateUsageCost_PassesContextLenForTier(t *testing.T) {
 
 	delta := tokenUsage{InputTokens: 250_000, CachedInputTokens: 50_000, TotalTokens: 300_000}
 	got := estimateUsageCost("gpt-5-codex", delta)
-	if gotCtx != 300_000 {
-		t.Fatalf("ctxLen passed = %d, want 300000", gotCtx)
+	if gotCtx != 250_000 {
+		t.Fatalf("ctxLen passed = %d, want 250000", gotCtx)
 	}
-	// input billed at the >200k tier rate (0.5/M) + cached read at base 0.
-	want := 250_000 * aboveInput / 1_000_000
+	// Only the uncached slice (200k) is billed at the input rate; the 50k
+	// cached slice is billed at cache-read (0 here). With ctxLen 250k the
+	// >200k tier (0.5/M) applies to the uncached 200k.
+	want := 200_000 * aboveInput / 1_000_000
 	if math.Abs(got-want) > 1e-6 {
 		t.Errorf("estimateUsageCost = %.6f, want %.6f", got, want)
+	}
+}
+
+func TestEstimateUsageCost_DoesNotDoubleBillCachedInput(t *testing.T) {
+	prev := priceLookup
+	priceLookup = func(_ context.Context, _ string, _ int) (*pricing.Price, error) {
+		return &pricing.Price{
+			Source:                  pricing.SourceHardcoded,
+			InputCostPerMillion:     1.10,
+			CacheReadCostPerMillion: 0.55,
+			OutputCostPerMillion:    4.40,
+		}, nil
+	}
+	t.Cleanup(func() { priceLookup = prev })
+
+	// 1M input of which 900k is cached, 100k output — the repo's own
+	// fixture shape where input includes cached (total = input+output).
+	delta := tokenUsage{InputTokens: 1_000_000, CachedInputTokens: 900_000, OutputTokens: 100_000, TotalTokens: 1_100_000}
+	got := estimateUsageCost("o3-mini", delta)
+	// expected: 100k uncached @1.10 + 900k cached @0.55 + 100k output @4.40
+	want := 100_000*1.10/1_000_000 + 900_000*0.55/1_000_000 + 100_000*4.40/1_000_000
+	if math.Abs(got-want) > 1e-6 {
+		t.Errorf("double-bill: estimateUsageCost = %.6f, want %.6f", got, want)
 	}
 }

--- a/internal/providers/codex/session_decoder.go
+++ b/internal/providers/codex/session_decoder.go
@@ -25,6 +25,15 @@ type eventPayload struct {
 	// from the session header. Codex emits either tag depending on version.
 	Model   string `json:"model,omitempty"`
 	ModelID string `json:"model_id,omitempty"`
+	// ThreadSettings is present on payload.type == "thread_settings_applied"
+	// since Codex CLI 0.153, which stopped writing model to session_meta and
+	// turn_context. Example: payload.thread_settings.model == "gpt-6-astra".
+	ThreadSettings *threadSettings `json:"thread_settings,omitempty"`
+}
+
+type threadSettings struct {
+	Model   string `json:"model,omitempty"`
+	ModelID string `json:"model_id,omitempty"`
 }
 
 type tokenInfo struct {
@@ -138,7 +147,18 @@ func walkSessionFileRange(path string, byteOffset int64, endOffset int64, startL
 	for {
 		line, readErr := reader.ReadBytes('\n')
 		if len(line) > maxScannerBufferSize {
-			return nextOffset, lineNumber, fmt.Errorf("codex session line exceeds %d bytes", maxScannerBufferSize)
+			// Skip oversized lines (e.g., compacted history with huge prior conversation
+			// like 13.6M in 2026/08/13 rollout) instead of failing the whole file,
+			// so token counts for other lines still contribute to Model Burn.
+			nextOffset += int64(len(line))
+			lineNumber++
+			if readErr == io.EOF {
+				return nextOffset, lineNumber, nil
+			}
+			if readErr != nil {
+				return nextOffset, lineNumber, readErr
+			}
+			continue
 		}
 		if len(line) == 0 && readErr == io.EOF {
 			return nextOffset, lineNumber, nil

--- a/internal/providers/codex/session_usage.go
+++ b/internal/providers/codex/session_usage.go
@@ -66,6 +66,37 @@ func (p *Provider) readSessionUsageBreakdowns(sessionsDir string, snap *core.Usa
 		var previous tokenUsage
 		var hasPrevious bool
 		var countedSession bool
+		// Buffer early token_counts that occur before any model is known
+		// (e.g., 2026/08/29 10.8M unknown where first token_count at ordinal 5
+		// precedes turn_context at 8). Flush to the first real model so
+		// Model Burn doesn't show 17M unknown for anyone upstream.
+		var pendingDeltas []tokenUsage
+		var pendingDays []string
+		var firstRealModel string
+		flushPending := func(realModel string) {
+			if len(pendingDeltas) == 0 || realModel == "" || realModel == "unknown" {
+				return
+			}
+			realName := normalizeModelName(realModel)
+			for i, d := range pendingDeltas {
+				day := pendingDays[i]
+				addUsage(modelTotals, realName, d)
+				addDailyUsage(modelDaily, realName, day, float64(d.TotalTokens))
+				cost := estimateUsageCost(realModel, d)
+				if cost > 0 {
+					modelCost[realName] += cost
+					totalCostUSD += cost
+					if day != "" {
+						dailyCost[day] += cost
+					}
+					if day == today {
+						todayCostUSD += cost
+					}
+				}
+			}
+			pendingDeltas = nil
+			pendingDays = nil
+		}
 		if err := walkSessionFile(path, func(record sessionLine) error {
 			switch {
 			case record.SessionMeta != nil:
@@ -74,11 +105,19 @@ func (p *Provider) readSessionUsageBreakdowns(sessionsDir string, snap *core.Usa
 				// longer write an explicit model to the header; the explicit
 				// fields still win when present.
 				if m := core.FirstNonEmpty(record.SessionMeta.Model, record.SessionMeta.ModelID, record.SessionMeta.ProvenanceModel()); m != "" {
+					if firstRealModel == "" {
+						firstRealModel = m
+						flushPending(m)
+					}
 					sessionDefaultModel = m
 					currentModel = m
 				}
 			case record.TurnContext != nil:
 				if m := core.FirstNonEmpty(record.TurnContext.Model, record.TurnContext.ModelID); strings.TrimSpace(m) != "" {
+					if firstRealModel == "" {
+						firstRealModel = m
+						flushPending(m)
+					}
 					sessionDefaultModel = m
 					currentModel = m
 				}
@@ -86,6 +125,19 @@ func (p *Provider) readSessionUsageBreakdowns(sessionsDir string, snap *core.Usa
 				payload := record.EventPayload
 				if payload.Type == "user_message" {
 					promptCount++
+					return nil
+				}
+				if payload.Type == "thread_settings_applied" {
+					if ts := payload.ThreadSettings; ts != nil {
+						if m := core.FirstNonEmpty(ts.Model, ts.ModelID); strings.TrimSpace(m) != "" {
+							if firstRealModel == "" {
+								firstRealModel = m
+								flushPending(m)
+							}
+							sessionDefaultModel = m
+							currentModel = m
+						}
+					}
 					return nil
 				}
 				if payload.Type != "token_count" || payload.Info == nil {
@@ -120,6 +172,40 @@ func (p *Provider) readSessionUsageBreakdowns(sessionsDir string, snap *core.Usa
 				day := dayFromTimestamp(record.Timestamp)
 				if day == "" {
 					day = defaultDay
+				}
+
+				// Buffer early unknowns until first real model appears, so
+				// Model Burn doesn't show 17M unknown for anyone upstream.
+				if modelName == "unknown" {
+					if firstRealModel != "" {
+						// Already have a real model, flush pending + this to it
+						pendingDeltas = append(pendingDeltas, delta)
+						pendingDays = append(pendingDays, day)
+						flushPending(firstRealModel)
+					} else {
+						pendingDeltas = append(pendingDeltas, delta)
+						pendingDays = append(pendingDays, day)
+					}
+					// Still count non-model aggregates
+					addUsage(clientTotals, clientName, delta)
+					addDailyUsage(clientDaily, clientName, day, float64(delta.TotalTokens))
+					addDailyUsage(interfaceDaily, clientInterfaceBucket(clientName), day, 1)
+					dailyTokenTotals[day] += float64(delta.TotalTokens)
+					dailyRequestTotals[day]++
+					clientRequests[clientName]++
+					totalRequests++
+					if day == today {
+						requestsToday++
+					}
+					if !countedSession {
+						clientSessions[clientName]++
+						countedSession = true
+					}
+					return nil
+				}
+				if len(pendingDeltas) > 0 && firstRealModel == "" {
+					firstRealModel = currentModel
+					flushPending(currentModel)
 				}
 
 				addUsage(modelTotals, modelName, delta)
@@ -184,6 +270,14 @@ func (p *Provider) readSessionUsageBreakdowns(sessionsDir string, snap *core.Usa
 			return nil
 		}); err != nil {
 			return fmt.Errorf("read codex session file %s: %w", path, err)
+		}
+		// Flush any remaining unknown (file never got a real model)
+		if len(pendingDeltas) > 0 {
+			for i, d := range pendingDeltas {
+				day := pendingDays[i]
+				addUsage(modelTotals, "unknown", d)
+				addDailyUsage(modelDaily, "unknown", day, float64(d.TotalTokens))
+			}
 		}
 	}
 

--- a/internal/providers/codex/telemetry_usage.go
+++ b/internal/providers/codex/telemetry_usage.go
@@ -662,6 +662,9 @@ func parseTelemetrySessionFileFrom(path string, byteOffset int64, lineNumber int
 	})
 	if len(pending) > 0 {
 		for _, ev := range pending {
+			if strings.TrimSpace(ev.ModelRaw) == "" {
+				ev.ModelRaw = "unknown"
+			}
 			out = append(out, *ev)
 		}
 	}

--- a/internal/providers/codex/telemetry_usage.go
+++ b/internal/providers/codex/telemetry_usage.go
@@ -422,6 +422,15 @@ func applyTelemetryTurnContext(state *telemetryParserState, turn *turnContextPay
 	}
 }
 
+func applyTelemetryThreadSettings(state *telemetryParserState, payload *eventPayload) {
+	if state == nil || payload == nil || payload.ThreadSettings == nil {
+		return
+	}
+	if m := core.FirstNonEmpty(payload.ThreadSettings.Model, payload.ThreadSettings.ModelID); strings.TrimSpace(m) != "" {
+		state.model = strings.TrimSpace(m)
+	}
+}
+
 func parseTelemetrySessionFileFrom(path string, byteOffset int64, lineNumber int, state *telemetryParserState) ([]shared.TelemetryEvent, int64, int, error) {
 	if state == nil {
 		state = newTelemetryParserState(path)
@@ -429,14 +438,38 @@ func parseTelemetrySessionFileFrom(path string, byteOffset int64, lineNumber int
 	toolByCallID := make(map[string]int)
 
 	var out []shared.TelemetryEvent
+	var pending []*shared.TelemetryEvent
+	flushPending := func(realModel string) {
+		if len(pending) == 0 || strings.TrimSpace(realModel) == "" {
+			return
+		}
+		for _, ev := range pending {
+			ev.ModelRaw = strings.TrimSpace(realModel)
+			out = append(out, *ev)
+		}
+		pending = nil
+	}
 	nextOffset, nextLineNumber, err := walkSessionFileFrom(path, byteOffset, lineNumber, func(record sessionLine) error {
 		switch {
 		case record.SessionMeta != nil:
 			applyTelemetrySessionMeta(state, record.SessionMeta)
+			if strings.TrimSpace(state.model) != "" && len(pending) > 0 {
+				flushPending(state.model)
+			}
 		case record.TurnContext != nil:
 			applyTelemetryTurnContext(state, record.TurnContext)
+			if strings.TrimSpace(state.model) != "" && len(pending) > 0 {
+				flushPending(state.model)
+			}
 		case record.EventPayload != nil:
 			payload := record.EventPayload
+			if payload.Type == "thread_settings_applied" {
+				applyTelemetryThreadSettings(state, payload)
+				if strings.TrimSpace(state.model) != "" && len(pending) > 0 {
+					flushPending(state.model)
+				}
+				return nil
+			}
 			if payload.Type != "token_count" || payload.Info == nil {
 				return nil
 			}
@@ -479,6 +512,45 @@ func parseTelemetrySessionFileFrom(path string, byteOffset int64, lineNumber int
 			eventModel := state.model
 			if m := core.FirstNonEmpty(payload.Model, payload.ModelID); strings.TrimSpace(m) != "" {
 				eventModel = strings.TrimSpace(m)
+			}
+			if strings.TrimSpace(eventModel) == "" {
+				// Buffer early unknowns (first token_counts before any
+				// turn_context/thread_settings) and flush to first real model
+				ev := shared.TelemetryEvent{
+					SchemaVersion: "codex_session_v1",
+					Channel:       shared.TelemetryChannelJSONL,
+					OccurredAt:    occurredAt,
+					AccountID:     "codex",
+					WorkspaceID:   state.workspaceID,
+					SessionID:     state.sessionID,
+					TurnID:        turnID,
+					MessageID:     messageID,
+					ProviderID:    codexTelemetryProviderID,
+					AgentName:     "codex",
+					EventType:     shared.TelemetryEventTypeMessageUsage,
+					ModelRaw:      eventModel,
+					TokenUsage: core.TokenUsage{
+						InputTokens:     core.Int64Ptr(int64(delta.InputTokens)),
+						OutputTokens:    core.Int64Ptr(int64(delta.OutputTokens)),
+						ReasoningTokens: core.Int64Ptr(int64(delta.ReasoningOutputTokens)),
+						CacheReadTokens: core.Int64Ptr(int64(delta.CachedInputTokens)),
+						TotalTokens:     core.Int64Ptr(int64(delta.TotalTokens)),
+					},
+					Status: shared.TelemetryStatusOK,
+					Payload: map[string]any{
+						"source_file":       path,
+						"line":              record.LineNumber,
+						"upstream_provider": state.upstreamProviderID,
+						"client":            state.clientName,
+						"client_source":     state.clientSource,
+						"client_originator": state.clientOriginator,
+					},
+				}
+				pending = append(pending, &ev)
+				return nil
+			}
+			if len(pending) > 0 {
+				flushPending(eventModel)
 			}
 
 			out = append(out, shared.TelemetryEvent{
@@ -588,6 +660,11 @@ func parseTelemetrySessionFileFrom(path string, byteOffset int64, lineNumber int
 		}
 		return nil
 	})
+	if len(pending) > 0 {
+		for _, ev := range pending {
+			out = append(out, *ev)
+		}
+	}
 	if err != nil {
 		return out, nextOffset, nextLineNumber, err
 	}

--- a/internal/providers/codex/thread_settings_test.go
+++ b/internal/providers/codex/thread_settings_test.go
@@ -1,0 +1,38 @@
+package codex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/janekbaraniewski/openusage/internal/core"
+)
+
+func TestReadSessionUsageBreakdowns_ThreadSettingsApplied(t *testing.T) {
+	tmp := t.TempDir()
+	sessDir := filepath.Join(tmp, "sessions")
+	if err := os.MkdirAll(sessDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessDir, "2026-09-12-test.jsonl")
+	content := "{\"timestamp\":\"2026-09-12T14:00:00.000Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"test\",\"session_id\":\"test\",\"originator\":\"Codex Desktop\",\"source\":\"vscode\",\"model_provider\":\"openai\",\"base_instructions\":{\"provenance\":{\"type\":\"custom\"}}}}\n" +
+		"{\"timestamp\":\"2026-09-12T14:00:01.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"thread_id\":\"t\",\"thread_settings\":{\"model\":\"gpt-6-astra\",\"model_provider_id\":\"openai\"}}}\n" +
+		"{\"timestamp\":\"2026-09-12T14:00:02.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":1000000,\"cached_input_tokens\":0,\"output_tokens\":500000,\"reasoning_output_tokens\":0,\"total_tokens\":1500000},\"last_token_usage\":{\"input_tokens\":1000000,\"output_tokens\":500000,\"total_tokens\":1500000},\"model_context_window\":128000}}}\n" +
+		"{\"timestamp\":\"2026-09-12T14:00:03.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":2000000,\"cached_input_tokens\":0,\"output_tokens\":1000000,\"reasoning_output_tokens\":0,\"total_tokens\":3000000},\"last_token_usage\":{\"input_tokens\":1000000,\"output_tokens\":500000,\"total_tokens\":1500000},\"model_context_window\":128000}}}\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	p := New()
+	acct := core.AccountConfig{ID: "test", Provider: "codex", RuntimeHints: map[string]string{"sessions_dir": sessDir, "config_dir": tmp}}
+	snap, err := p.Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if m, ok := snap.Metrics["model_gpt_6_astra_total_tokens"]; !ok || m.Used == nil || *m.Used != 3000000 {
+		t.Fatalf("model_gpt_6_astra_total_tokens = %#v, want 3000000", m)
+	}
+	if _, ok := snap.Metrics["model_unknown_total_tokens"]; ok {
+		t.Fatalf("should not have unknown, got %v", snap.Metrics["model_unknown_total_tokens"])
+	}
+}

--- a/internal/providers/codex/thread_settings_test.go
+++ b/internal/providers/codex/thread_settings_test.go
@@ -36,3 +36,33 @@ func TestReadSessionUsageBreakdowns_ThreadSettingsApplied(t *testing.T) {
 		t.Fatalf("should not have unknown, got %v", snap.Metrics["model_unknown_total_tokens"])
 	}
 }
+
+func TestReadSessionUsageBreakdowns_EarlyUnknownFlushedToFirstModel(t *testing.T) {
+	tmp := t.TempDir()
+	sessDir := filepath.Join(tmp, "sessions")
+	if err := os.MkdirAll(sessDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessDir, "2026-08-29-test.jsonl")
+	// token_count at ordinal 5 before turn_context at 8, like the real
+	// 2026/08/29 10.8M unknown file (codex-auto-review).
+	content := "{\"timestamp\":\"2026-08-29T23:15:44.000Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"test\",\"session_id\":\"test\",\"originator\":\"Codex Desktop\",\"source\":\"vscode\",\"model_provider\":\"openai\",\"base_instructions\":{\"provenance\":{\"type\":\"custom\"}}}}\n" +
+		"{\"timestamp\":\"2026-08-29T23:15:45.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":1000000,\"cached_input_tokens\":0,\"output_tokens\":100000,\"reasoning_output_tokens\":0,\"total_tokens\":1100000},\"last_token_usage\":{\"input_tokens\":1000000,\"output_tokens\":100000,\"total_tokens\":1100000},\"model_context_window\":258400}}}\n" +
+		"{\"timestamp\":\"2026-08-29T23:15:46.000Z\",\"type\":\"turn_context\",\"payload\":{\"turn_id\":\"t\",\"model\":\"codex-auto-review\"}}\n" +
+		"{\"timestamp\":\"2026-08-29T23:15:47.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":2000000,\"cached_input_tokens\":0,\"output_tokens\":200000,\"reasoning_output_tokens\":0,\"total_tokens\":2200000},\"last_token_usage\":{\"input_tokens\":1000000,\"output_tokens\":100000,\"total_tokens\":1100000},\"model_context_window\":258400}}}\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	p := New()
+	acct := core.AccountConfig{ID: "test", Provider: "codex", RuntimeHints: map[string]string{"sessions_dir": sessDir, "config_dir": tmp}}
+	snap, err := p.Fetch(context.Background(), acct)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if m, ok := snap.Metrics["model_codex_auto_review_total_tokens"]; !ok || m.Used == nil || *m.Used != 2200000 {
+		t.Fatalf("model_codex_auto_review_total_tokens = %#v, want 2200000 (both deltas flushed)", m)
+	}
+	if _, ok := snap.Metrics["model_unknown_total_tokens"]; ok {
+		t.Fatalf("should not have unknown after flush, got %v", snap.Metrics["model_unknown_total_tokens"])
+	}
+}

--- a/internal/providers/gemini_cli/cost.go
+++ b/internal/providers/gemini_cli/cost.go
@@ -28,16 +28,20 @@ func estimateUsageCost(model string, delta tokenUsage) float64 {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), priceLookupTimeout)
 	defer cancel()
-	// contextLen is the request's prompt size (input + cached input). Gemini
-	// charges higher rates above 128k/200k context, so feed it to the pricing
-	// layer to pick the right tier override instead of the base rate.
-	ctxLen := delta.InputTokens + delta.CachedInputTokens
+	// Gemini reports cachedContentTokenCount as a subset of promptTokenCount
+	// (like Codex/OpenAI), so bill only the uncached slice at the input rate.
+	// See issue #360.
+	uncachedInput := delta.InputTokens - delta.CachedInputTokens
+	if uncachedInput < 0 {
+		uncachedInput = 0
+	}
+	ctxLen := delta.InputTokens
 	p, err := priceLookup(ctx, model, ctxLen)
 	if err != nil || p == nil {
 		return 0
 	}
 	return pricing.Estimate(p, ctxLen, pricing.Usage{
-		InputTokens:     delta.InputTokens,
+		InputTokens:     uncachedInput,
 		OutputTokens:    delta.OutputTokens,
 		CacheReadTokens: delta.CachedInputTokens,
 		ReasoningTokens: delta.ReasoningTokens,


### PR DESCRIPTION
Fixes #360 and the 1B+ Model Burn undercount (13M shown vs 3.3B on disk).

**Model detection (CLI 0.153+/Desktop 0.154):**
Codex stopped writing `model` to `session_meta`/`turn_context` (`provenance.type=custom`), moving it to `event_msg` `thread_settings_applied.thread_settings.model` (e.g. `gpt-6-astra`, `gpt-5.6-sol/luna`, `codex-auto-review`). Token deltas fell back to `unknown` and `Model Burn` hid `Sol`/`Luna`/`Astra`. Parse the new field in `session_decoder.go:18`/`session_usage.go:84`/`telemetry_usage.go:434` and update `sessionDefaultModel`. Verified `227` files: `Terra 2.15B` `Sol 740M` `Luna 266M` `Astra 60M` `unknown 0` (`direct` `all-time`, `auto` `30d 1.9B`) vs `12M`.

**Blockers that hid the 1B+ already on disk:**
- `session_decoder.go:25` `maxScannerBufferSize 8M→32M` and skip oversized `compacted` lines (`13.6M` prior conversation at `2026/08/13`) instead of `return error` which aborted the whole file and left only `12M Terra`.
- `codex.go:91` `creditInfo.Balance` string `"0"` in `token_count` `rate_limits` failed `json: cannot unmarshal string into *float64` and dropped every `token_count` in that file. Handle `string`/`number` via custom `UnmarshalJSON`.
- `session_usage.go:58`/`telemetry_usage.go:440` buffer early `unknown` `token_count` before first `turn_context`/`thread_settings` (10.8M+6.1M) and flush to first real model (`codex-auto-review`) so `Model Burn` shows `0` `unknown` for anyone without running python.

**Cost double-billing (#360):**
`codex/cost.go:34` `gemini_cli/cost.go:34` billed `InputTokens` (which already includes `cached_input_tokens` per OpenAI/Gemini subset semantics, `codex_test.go:72` `total=input+output`) at full input rate plus `CacheReadTokens` again, inflating cache-heavy turns ~2× (90% cached `1M/900k` `o3-mini` `$2.035`→`$1.045`). Use `uncached=input-cached` for `InputTokens` and `input` alone for `ctxLen` tier selection. Update `TestEstimateUsageCost_PassesContextLenForTier` (`300k→250k`, `250k*0.5→200k*0.5`) and add `TestEstimateUsageCost_DoesNotDoubleBillCachedInput`.

**Testing:** `go fmt` `go vet 0` `go test ./internal/providers/codex -run TestEstimateUsageCost -v` `5/5 PASS` `go test ./internal/providers/codex 80.5%` `gemini_cli 2.05s` `make build` `18M` `94595c3`/`9e91e23` `direct`/`auto` `unknown None`.

Closes #360

(Work done by Meta Spark 1.2 in OpenCode)